### PR TITLE
Enhance chat creation endpoint to check project access using user email

### DIFF
--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -52,8 +52,16 @@ chatRouter.get("/", requireAuth, async (req, res) => {
 // POST /chat/create
 chatRouter.post("/create", requireAuth, async (req, res) => {
     const userId = res.locals.userId as string;
+    const userEmail = res.locals.userEmail as string | undefined;
     const projectId: string | null = req.body.project_id ?? null;
     const db = createServerSupabase();
+
+    if (projectId) {
+        const access = await checkProjectAccess(projectId, userId, userEmail, db);
+        if (!access.ok)
+            return void res.status(404).json({ detail: "Project not found" });
+    }
+
     const { data, error } = await db
         .from("chats")
         .insert({ user_id: userId, project_id: projectId ?? undefined })


### PR DESCRIPTION
Fix Issue #1 

Added an explicit authorisation check to POST /chat/create so chats can only be created against projects the caller can access.

In backend/src/routes/chat.ts, the route now reads userEmail from auth context and, when project_id is provided, calls checkProjectAccess(projectId, userId, userEmail, db) before insert.
If access is denied, the endpoint now returns 404 Project not found and does not write a chat row.
If access is allowed (owner or shared member), behaviour is unchanged and chat creation proceeds.
This closes the app-layer project spoofing vector where authenticated users could previously create chats under arbitrary existing project_id values.