### PR TITLE
Harden auth and logging in chat/download paths

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,10 @@ PORT=3001
 FRONTEND_URL=http://localhost:3000
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SECRET_KEY=your-supabase-service-role-key
+# Optional: dedicated HMAC key for signing /download/:token URLs. If unset
+# the backend falls back to SUPABASE_SECRET_KEY; if neither is set the
+# server refuses to mint download tokens. Use a long random string.
+# DOWNLOAD_SIGNING_SECRET=
 
 R2_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
 R2_ACCESS_KEY_ID=your-r2-access-key
@@ -12,3 +16,7 @@ GEMINI_API_KEY=your-gemini-key
 ANTHROPIC_API_KEY=your-anthropic-key
 OPENROUTER_API_KEY=your-openrouter-key
 RESEND_API_KEY=your-resend-key
+
+# Set to 1/true/yes/on to mirror raw Claude SSE events to
+# claude-raw-stream.log in the working directory. Leave unset in production.
+# DEBUG_RAW_LLM_STREAM=

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,9 @@ import { tabularRouter } from "./routes/tabular";
 import { workflowsRouter } from "./routes/workflows";
 import { userRouter } from "./routes/user";
 import { downloadsRouter } from "./routes/downloads";
+import { assertDownloadSigningConfigured } from "./lib/downloadTokens";
+
+assertDownloadSigningConfigured();
 
 const app = express();
 const PORT = process.env.PORT ?? 3001;

--- a/backend/src/lib/downloadTokens.ts
+++ b/backend/src/lib/downloadTokens.ts
@@ -7,14 +7,35 @@ import crypto from "crypto";
  * `/download/:token` validates the signature and streams the file. This
  * gives persistent links safe to store in chat history without signed-URL
  * expiry or R2 CORS headaches.
+ *
+ * The signing secret comes from `DOWNLOAD_SIGNING_SECRET` (preferred) or
+ * falls back to `SUPABASE_SECRET_KEY`. If neither is set we throw rather
+ * than silently signing every link with a hardcoded literal — a forgeable
+ * default would let any caller mint download URLs for arbitrary keys.
  */
 
 function getSecret(): string {
-    return (
-        process.env.DOWNLOAD_SIGNING_SECRET ??
-        process.env.SUPABASE_SECRET_KEY ??
-        "dev-secret"
-    );
+    // Trim and ignore empty/whitespace values so a deploy with
+    // `DOWNLOAD_SIGNING_SECRET=` (e.g. an unfilled env template) still
+    // falls back to SUPABASE_SECRET_KEY instead of crashing every download.
+    const secret =
+        process.env.DOWNLOAD_SIGNING_SECRET?.trim() ||
+        process.env.SUPABASE_SECRET_KEY?.trim();
+    if (!secret) {
+        throw new Error(
+            "Download signing secret is not configured: set DOWNLOAD_SIGNING_SECRET (preferred) or SUPABASE_SECRET_KEY.",
+        );
+    }
+    return secret;
+}
+
+/**
+ * Call once at process start so a misconfigured deploy crashes fast at
+ * boot with a clear error, instead of returning 500 on every /download
+ * request once a user clicks a saved link.
+ */
+export function assertDownloadSigningConfigured(): void {
+    getSecret();
 }
 
 function b64urlEncode(buf: Buffer): string {

--- a/backend/src/lib/llm/claude.ts
+++ b/backend/src/lib/llm/claude.ts
@@ -10,6 +10,20 @@ import type {
 } from "./types";
 import { toClaudeTools } from "./tools";
 
+// Opt-in raw-stream debug logging. Set `DEBUG_RAW_LLM_STREAM` to one of
+// 1 / true / yes / on (case-insensitive) to mirror every Claude SSE event
+// to a file in cwd; otherwise we skip the write entirely so production
+// deployments don't accumulate an unbounded log. We parse explicitly so
+// "false" / "0" / "no" do not accidentally enable logging.
+//
+// WARNING: when enabled, the log captures whatever the model is processing
+// — for this app, that includes user-submitted legal documents. Treat the
+// log as sensitive: dev/staging only, restrictive file mode, rotate/purge
+// out of band.
+const RAW_STREAM_DEBUG = ["1", "true", "yes", "on"].includes(
+    (process.env.DEBUG_RAW_LLM_STREAM ?? "").trim().toLowerCase(),
+);
+const RAW_STREAM_LOG_MODE = 0o600;
 const RAW_STREAM_LOG_PATH = path.resolve(
     process.cwd(),
     "claude-raw-stream.log",
@@ -80,11 +94,18 @@ export async function streamClaude(
 
         let sawThinking = false;
 
-        stream.on("streamEvent", (event) => {
-            const line = JSON.stringify(event);
-            console.log("[claude raw stream]", line);
-            fs.appendFile(RAW_STREAM_LOG_PATH, line + "\n", () => {});
-        });
+        if (RAW_STREAM_DEBUG) {
+            stream.on("streamEvent", (event) => {
+                const line = JSON.stringify(event);
+                console.log("[claude raw stream]", line);
+                fs.appendFile(
+                    RAW_STREAM_LOG_PATH,
+                    line + "\n",
+                    { mode: RAW_STREAM_LOG_MODE },
+                    () => {},
+                );
+            });
+        }
 
         stream.on("text", (delta) => {
             callbacks.onContentDelta?.(delta);

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -52,8 +52,31 @@ chatRouter.get("/", requireAuth, async (req, res) => {
 // POST /chat/create
 chatRouter.post("/create", requireAuth, async (req, res) => {
     const userId = res.locals.userId as string;
-    const projectId: string | null = req.body.project_id ?? null;
+    const userEmail = res.locals.userEmail as string | undefined;
+    const rawProjectId: unknown = req.body.project_id;
+    let projectId: string | null = null;
+    if (rawProjectId !== null && rawProjectId !== undefined) {
+        if (typeof rawProjectId !== "string" || !rawProjectId.trim()) {
+            return void res
+                .status(400)
+                .json({ detail: "Invalid project_id" });
+        }
+        projectId = rawProjectId.trim();
+    }
     const db = createServerSupabase();
+
+    // Project chats require owner/shared access, matching POST /chat.
+    if (projectId) {
+        const access = await checkProjectAccess(
+            projectId,
+            userId,
+            userEmail,
+            db,
+        );
+        if (!access.ok)
+            return void res.status(404).json({ detail: "Project not found" });
+    }
+
     const { data, error } = await db
         .from("chats")
         .insert({ user_id: userId, project_id: projectId ?? undefined })


### PR DESCRIPTION
## Summary

Three small, themed security/operational fixes for the Express backend. All changes are surgical (one commit, +87/-11 across 5 files) and compile cleanly.

## What changed

### 1. `POST /chat/create` enforces `checkProjectAccess`
Without this, any authenticated caller can attach a chat row to any `project_id`, even one they cannot read. The streaming `POST /chat` already enforces the same rule, so `/chat/create` should as well. Also validates `project_id` is a non-empty string before the check, so a malformed body returns 400 instead of falling through to the insert and producing a 500.

(This bug was independently caught and patched in [`ryanmcdonough/mike`](https://github.com/ryanmcdonough/mike) — credit there for spotting it. Reproduced and shipped here against latest `main`.)

### 2. Gate Claude raw-stream disk logging behind `DEBUG_RAW_LLM_STREAM`
`backend/src/lib/llm/claude.ts` was unconditionally appending every Claude SSE event to `claude-raw-stream.log` in the working directory on every chat. In production this grows without bound and persists model output (which for this app includes user-submitted legal documents) to disk.

The mirror is now opt-in. The env var is parsed against an explicit truthy allowlist (`1` / `true` / `yes` / `on`, case-insensitive) so common "disabled" values like `false` or `0` don't accidentally enable it. When enabled, the log file is created with mode `0o600`, and a code-comment notes the PII risk.

### 3. Drop `"dev-secret"` fallback in `downloadTokens.ts`
`getSecret()` previously fell back to a hardcoded `"dev-secret"` literal if neither `DOWNLOAD_SIGNING_SECRET` nor `SUPABASE_SECRET_KEY` was set — letting any caller mint download URLs for arbitrary keys. Now throws if no secret is configured.

To avoid a misconfigured deploy turning every saved download link into a 500, `assertDownloadSigningConfigured()` is exported and called once from `backend/src/index.ts` so the server fails fast at boot with a clear error.

Empty-string env values (`DOWNLOAD_SIGNING_SECRET=`) are trimmed and ignored so an unfilled env template still falls back to `SUPABASE_SECRET_KEY` rather than failing.

## How to test

```bash
# 1. Build cleanly
npm run build --prefix backend

# 2. Boot guard fires when no signing secret is set
unset DOWNLOAD_SIGNING_SECRET SUPABASE_SECRET_KEY
npm run start --prefix backend
# → exits with: "Download signing secret is not configured: set DOWNLOAD_SIGNING_SECRET (preferred) or SUPABASE_SECRET_KEY."

# 3. Boot succeeds with a real secret set
export DOWNLOAD_SIGNING_SECRET="$(openssl rand -hex 32)"
# … start backend, exercise /chat/create with and without project_id, with and without project access

# 4. Raw-stream logging stays off by default and on common false-y values
DEBUG_RAW_LLM_STREAM=false npm run dev --prefix backend  # no log file written
DEBUG_RAW_LLM_STREAM=1     npm run dev --prefix backend  # log file appears with mode 0600
```

## Out of scope (deferred)

The following came up during review and are intentionally not in this PR — happy to do as follow-ups if useful:

- **TOCTOU race** between the project access check and the chat insert. Real but very low probability; properly addressed by Supabase RLS / a DB-side insert RPC rather than route code.
- **Requiring `DOWNLOAD_SIGNING_SECRET` explicitly in production** (i.e., disallowing the Supabase-key fallback when `NODE_ENV=production`). Useful but a maintainer call.
- **Backend test coverage.** The repo currently has no backend tests / test runner, and bootstrapping one as a side effect of a security fix felt like scope creep. Worth a dedicated PR.
- **Email case-sensitivity in `projects.ts`** sharing checks (separate bug, separate fix).
- **Express 5 / Multer 2 / Next.js patch bumps** — covered well by other forks (see `hreiten/mike`).

## Notes

- Diff is one commit, +87/-11. No dependency changes, no schema changes, no formatting churn (existing files were not prettier-clean and were left untouched outside the changed regions).
- License: AGPL-3.0-only (unchanged).