### PR TITLE
Fix three security issues: chat auth bypass, dev-secret fallback, plaintext stream log

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,12 @@ FRONTEND_URL=http://localhost:3000
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SECRET_KEY=your-supabase-service-role-key
 
+# HMAC key for signing /download/:token URLs. Use a randomly generated
+# value distinct from SUPABASE_SECRET_KEY (e.g. `openssl rand -hex 32`).
+# If unset, the backend falls back to SUPABASE_SECRET_KEY; if neither
+# is set, download signing throws at runtime rather than use a default.
+DOWNLOAD_SIGNING_SECRET=your-random-32-byte-hex-secret
+
 R2_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
 R2_ACCESS_KEY_ID=your-r2-access-key
 R2_SECRET_ACCESS_KEY=your-r2-secret-key

--- a/backend/src/lib/downloadTokens.ts
+++ b/backend/src/lib/downloadTokens.ts
@@ -10,11 +10,14 @@ import crypto from "crypto";
  */
 
 function getSecret(): string {
-    return (
-        process.env.DOWNLOAD_SIGNING_SECRET ??
-        process.env.SUPABASE_SECRET_KEY ??
-        "dev-secret"
-    );
+    const secret =
+        process.env.DOWNLOAD_SIGNING_SECRET ?? process.env.SUPABASE_SECRET_KEY;
+    if (!secret) {
+        throw new Error(
+            "DOWNLOAD_SIGNING_SECRET (or SUPABASE_SECRET_KEY) must be set; refusing to sign with a default value.",
+        );
+    }
+    return secret;
 }
 
 function b64urlEncode(buf: Buffer): string {

--- a/backend/src/lib/llm/claude.ts
+++ b/backend/src/lib/llm/claude.ts
@@ -10,6 +10,11 @@ import type {
 } from "./types";
 import { toClaudeTools } from "./tools";
 
+// Streamed content includes user prompts, document context, and assistant
+// output — i.e. potentially privileged matter content. Persisting it to
+// disk by default is a confidentiality risk for a legal platform, so we
+// only write the raw stream log when explicitly opted-in.
+const DEBUG_RAW_STREAM = process.env.DEBUG_LLM_STREAM === "true";
 const RAW_STREAM_LOG_PATH = path.resolve(
     process.cwd(),
     "claude-raw-stream.log",
@@ -80,11 +85,13 @@ export async function streamClaude(
 
         let sawThinking = false;
 
-        stream.on("streamEvent", (event) => {
-            const line = JSON.stringify(event);
-            console.log("[claude raw stream]", line);
-            fs.appendFile(RAW_STREAM_LOG_PATH, line + "\n", () => {});
-        });
+        if (DEBUG_RAW_STREAM) {
+            stream.on("streamEvent", (event) => {
+                const line = JSON.stringify(event);
+                console.log("[claude raw stream]", line);
+                fs.appendFile(RAW_STREAM_LOG_PATH, line + "\n", () => {});
+            });
+        }
 
         stream.on("text", (delta) => {
             callbacks.onContentDelta?.(delta);

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -52,8 +52,24 @@ chatRouter.get("/", requireAuth, async (req, res) => {
 // POST /chat/create
 chatRouter.post("/create", requireAuth, async (req, res) => {
     const userId = res.locals.userId as string;
+    const userEmail = res.locals.userEmail as string | undefined;
     const projectId: string | null = req.body.project_id ?? null;
     const db = createServerSupabase();
+
+    // Without this check, any authenticated user could attach a chat to
+    // any project ID (the service-role client bypasses RLS, and the FK
+    // only enforces project existence — not membership).
+    if (projectId) {
+        const access = await checkProjectAccess(
+            projectId,
+            userId,
+            userEmail,
+            db,
+        );
+        if (!access.ok)
+            return void res.status(404).json({ detail: "Project not found" });
+    }
+
     const { data, error } = await db
         .from("chats")
         .insert({ user_id: userId, project_id: projectId ?? undefined })


### PR DESCRIPTION
## Summary

Bundles fixes for three small-surface-area security issues, each with its own commit so they can be reviewed (or split out) individually:

- **`#1`** — `POST /chat/create` now calls `checkProjectAccess` before inserting, closing the cross-project chat injection. The helper was already imported in `routes/chat.ts`.
- **`#7`** — `getSecret()` in `downloadTokens.ts` no longer falls back to the literal `"dev-secret"`; it throws when neither env var is set. `DOWNLOAD_SIGNING_SECRET` is now documented in `backend/.env.example`.
- **`#9`** — Raw Claude stream logging is now gated behind `DEBUG_LLM_STREAM=true`, so privileged matter content is no longer persisted to `claude-raw-stream.log` by default. (`*.log` is already gitignored, so the accidental-commit sub-point in the issue is already covered.)

Each commit references the issue it closes. `npm run build` passes in `backend/`.

## Test plan

- [x] `npm run build` in `backend/` (tsc clean)
- [ ] Manual: `POST /chat/create` with a `project_id` the caller does not own returns 404
- [ ] Manual: starting the backend with neither `DOWNLOAD_SIGNING_SECRET` nor `SUPABASE_SECRET_KEY` set, then hitting a route that signs a download URL, throws instead of producing a forgeable token
- [ ] Manual: with `DEBUG_LLM_STREAM` unset, no `claude-raw-stream.log` file is written during a chat session; setting it to `true` restores the previous behaviour

Happy to split into three PRs if you'd prefer that — let me know.