### PR TITLE
fix(security): fail fast when download HMAC secret is missing (closes #7)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,10 @@
 PORT=3001
 FRONTEND_URL=http://localhost:3000
+
+# HMAC key used to sign /download/:token URLs. Required at startup.
+# Generate with: openssl rand -hex 32
+# Use a dedicated secret distinct from SUPABASE_SECRET_KEY.
+DOWNLOAD_SIGNING_SECRET=replace-with-a-random-32-byte-hex-string
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SECRET_KEY=your-supabase-service-role-key
 

--- a/backend/src/lib/downloadTokens.ts
+++ b/backend/src/lib/downloadTokens.ts
@@ -10,11 +10,16 @@ import crypto from "crypto";
  */
 
 function getSecret(): string {
-    return (
+    const secret =
         process.env.DOWNLOAD_SIGNING_SECRET ??
-        process.env.SUPABASE_SECRET_KEY ??
-        "dev-secret"
-    );
+        process.env.SUPABASE_SECRET_KEY;
+    if (!secret) {
+        throw new Error(
+            "DOWNLOAD_SIGNING_SECRET (or SUPABASE_SECRET_KEY as a fallback) must be set. " +
+                "Generate a strong random value (e.g. `openssl rand -hex 32`) and set it in the environment.",
+        );
+    }
+    return secret;
 }
 
 function b64urlEncode(buf: Buffer): string {


### PR DESCRIPTION
Closes #7.

## Problem

`backend/src/lib/downloadTokens.ts` resolves its HMAC signing key with:

```ts
return (
    process.env.DOWNLOAD_SIGNING_SECRET ??
    process.env.SUPABASE_SECRET_KEY ??
    "dev-secret"
);
```

Because this repo is public, the `"dev-secret"` fallback is known to everyone. Any deployment that's missing both env vars accepts forged `/download/:token` signatures for arbitrary R2 paths.

It was also undocumented — `DOWNLOAD_SIGNING_SECRET` wasn't in `backend/.env.example`, so a deployer following the README would never know to set it.

## Fix

1. Remove the `"dev-secret"` fallback. `getSecret()` now throws on first call if neither env var is set, with a message pointing at `openssl rand -hex 32`.
2. Add `DOWNLOAD_SIGNING_SECRET` to `backend/.env.example` with a comment explaining it should be a dedicated random secret distinct from the Supabase key.

Matches the proposed fix in the issue. Two files, +14/-4.