### PR TITLE
fix(security): scope tabular-review document_ids by access (CWE-639)

### DIFF
--- a/backend/src/lib/access.ts
+++ b/backend/src/lib/access.ts
@@ -120,6 +120,47 @@ export async function ensureReviewAccess(
 }
 
 /**
+ * Filter a list of document IDs down to those the caller is actually
+ * authorised to read — owners pass, plus any document whose `project_id`
+ * the caller has access to (own project or `shared_with` member).
+ *
+ * The tabular-review routes accept user-supplied `document_ids` from
+ * request bodies; without this filter an attacker who has any review of
+ * their own can plant arbitrary doc UUIDs and have the server fetch + run
+ * an LLM extraction over their bytes (CWE-639).
+ */
+export async function filterAccessibleDocumentIds(
+    documentIds: string[],
+    userId: string,
+    userEmail: string | null | undefined,
+    db: Db,
+): Promise<string[]> {
+    if (documentIds.length === 0) return [];
+    const { data: docs } = await db
+        .from("documents")
+        .select("id, user_id, project_id")
+        .in("id", documentIds);
+    const rows = (docs ?? []) as {
+        id: string;
+        user_id: string;
+        project_id: string | null;
+    }[];
+    if (rows.length === 0) return [];
+    const accessibleProjectIds = new Set(
+        await listAccessibleProjectIds(userId, userEmail, db),
+    );
+    const out: string[] = [];
+    for (const d of rows) {
+        if (d.user_id === userId) {
+            out.push(d.id);
+        } else if (d.project_id && accessibleProjectIds.has(d.project_id)) {
+            out.push(d.id);
+        }
+    }
+    return out;
+}
+
+/**
  * Returns the set of project IDs the user can access — own projects plus
  * any project where their email is in `shared_with`. Used to scope chat
  * lists and similar collection queries.

--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -15,6 +15,7 @@ import { getUserApiKeys, getUserModelSettings } from "../lib/userSettings";
 import {
     checkProjectAccess,
     ensureReviewAccess,
+    filterAccessibleDocumentIds,
     listAccessibleProjectIds,
 } from "../lib/access";
 
@@ -192,6 +193,18 @@ tabularRouter.post("/", requireAuth, async (req, res) => {
         if (!access.ok)
             return void res.status(404).json({ detail: "Project not found" });
     }
+    // Drop any document_ids the caller can't access. Without this filter a
+    // user can stuff foreign UUIDs into document_ids, then call /generate
+    // or /regenerate-cell to read those documents' bytes back through the
+    // LLM (CWE-639).
+    const allowedDocumentIds = Array.isArray(document_ids)
+        ? await filterAccessibleDocumentIds(
+              document_ids,
+              userId,
+              userEmail,
+              db,
+          )
+        : [];
     const { data: review, error } = await db
         .from("tabular_reviews")
         .insert({
@@ -208,7 +221,7 @@ tabularRouter.post("/", requireAuth, async (req, res) => {
             .status(500)
             .json({ detail: error?.message ?? "Failed to create review" });
 
-    const cells = document_ids.flatMap((docId) =>
+    const cells = allowedDocumentIds.flatMap((docId) =>
         columns_config.map((col) => ({
             review_id: review.id,
             document_id: docId,
@@ -498,9 +511,26 @@ tabularRouter.patch("/:reviewId", requireAuth, async (req, res) => {
 
         if (Array.isArray(req.body.document_ids)) {
             // document_ids is the new source of truth — delete removed docs' cells
-            const newDocIds = req.body.document_ids as string[];
+            const requestedDocIds = req.body.document_ids as string[];
             const existingDocIds = (existingCells ?? []).map(
                 (cell) => cell.document_id,
+            );
+            // Drop any newly-added doc_ids the caller can't read; preserve
+            // already-attached docs so a non-owner collaborator's PATCH
+            // doesn't accidentally orphan cells they can't directly access.
+            const existingDocIdSet = new Set(existingDocIds);
+            const newDocCandidates = requestedDocIds.filter(
+                (id) => !existingDocIdSet.has(id),
+            );
+            const newDocAllowed = await filterAccessibleDocumentIds(
+                newDocCandidates,
+                userId,
+                userEmail,
+                db,
+            );
+            const newDocAllowedSet = new Set(newDocAllowed);
+            const newDocIds = requestedDocIds.filter(
+                (id) => existingDocIdSet.has(id) || newDocAllowedSet.has(id),
             );
             const removedDocIds = existingDocIds.filter(
                 (id) => !newDocIds.includes(id),
@@ -657,6 +687,17 @@ tabularRouter.post(
         if (!column)
             return void res.status(400).json({ detail: "Column not found" });
 
+        // Defense-in-depth — refuse to extract bytes for a document the
+        // caller can't read, even if a stale tabular_cells row points at it
+        // from before the access filter was added (CWE-639).
+        const docAllowed = await filterAccessibleDocumentIds(
+            [document_id],
+            userId,
+            userEmail,
+            db,
+        );
+        if (docAllowed.length === 0)
+            return void res.status(404).json({ detail: "Document not found" });
         const { data: doc } = await db
             .from("documents")
             .select("id, filename, file_type")
@@ -763,12 +804,21 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
         cellMap.set(`${cell.document_id}:${cell.column_index}`, cell);
 
     const docIds = [...new Set((cells ?? []).map((c) => c.document_id))];
+    // Same defense-in-depth as /regenerate-cell — filter to docs the caller
+    // can actually read, so legacy cells planted before the access check
+    // can't be coerced into running an LLM extraction (CWE-639).
+    const allowedDocIds = new Set(
+        await filterAccessibleDocumentIds(docIds, userId, userEmail, db),
+    );
     let docs: Record<string, unknown>[] = [];
     if (docIds.length > 0) {
-        const { data } = await db
-            .from("documents")
-            .select("id, filename, file_type, page_count")
-            .in("id", docIds);
+        const filteredIds = docIds.filter((id) => allowedDocIds.has(id));
+        const { data } = filteredIds.length > 0
+            ? await db
+                  .from("documents")
+                  .select("id, filename, file_type, page_count")
+                  .in("id", filteredIds)
+            : { data: [] as Record<string, unknown>[] };
         docs = data ?? [];
     } else if (review.project_id) {
         const { data } = await db


### PR DESCRIPTION
## Summary

Four endpoints in `backend/src/routes/tabular.ts` accept user-supplied `document_id` (or read it out of `tabular_cells` rows the same user planted) without verifying the caller can read those documents. The downstream pipeline then downloads the bytes from R2, runs an LLM extraction with an attacker-controlled column prompt, and stores the result back in `tabular_cells.content` — which the attacker reads via the standard review GET.

By contrast the chat path (`backend/src/lib/chatTools.ts:buildDocContext`) does the right thing — it filters `documents.user_id = userId`, which is why regular chat is unaffected. The tabular path is the regression.

## Impact

A signed-in user with **knowledge of a document UUID** they don't own can extract the full text of that document by running it through their own tabular review. Three requests: create a review with `document_ids: [<victim_uuid>]` and a column prompt asking for verbatim text → `POST /:reviewId/generate` → `GET /:reviewId` returns the leaked content in `cells[0].content`. No project membership or sharing relationship required.

UUIDv4 is unguessable, but UUIDs leak in practice — a removed project collaborator retains every UUID they saw (browser cache, exported chats, screenshots). After they're dropped from `projects.shared_with` they legitimately lose access to project routes but can still extract via this path. It's a "former-insider keeps reading" class of bug, not a stranger-guesses-UUIDs class.

On a legal-document platform the data at risk is exactly the data the product is built to keep confidential.

## Location

- `backend/src/routes/tabular.ts:172-222` — `POST /tabular-review`
- `backend/src/routes/tabular.ts:484-567` — `PATCH /:reviewId`
- `backend/src/routes/tabular.ts:619-727` — `POST /:reviewId/regenerate-cell`
- `backend/src/routes/tabular.ts:730-…` — `POST /:reviewId/generate`

## Fix

Adds `filterAccessibleDocumentIds(documentIds, userId, userEmail, db)` in `backend/src/lib/access.ts`, alongside the existing `ensureDocAccess` / `ensureReviewAccess` / `listAccessibleProjectIds` helpers. The helper resolves each id to its `user_id` + `project_id` row and admits it only if the caller is owner-of-doc OR a member (own or `shared_with`) of the doc's project.

Applied at all four entry points:
- **POST /tabular-review** — filter `document_ids` before inserting `tabular_cells` (drop unauthorised silently).
- **PATCH /:reviewId** — drop newly-added unauthorised ids; preserve already-attached cells so a non-owner project collaborator's PATCH doesn't accidentally orphan rows they can't directly re-add.
- **POST /:reviewId/regenerate-cell** — refuse byte fetch when the caller can't read the underlying doc, even for stale `tabular_cells` rows that pre-date this fix.
- **POST /:reviewId/generate** — filter `docIds` before the parallel LLM fetch loop (same defense-in-depth as above).

Fails closed silently rather than 403'ing so legacy clients passing stale ids don't error out the whole review.

## Note on legacy data

This PR closes the **new** exfil path. Cells that were extracted before the fix already live in `tabular_cells.content` for the attacker's own review and remain readable via the standard GET (since they planted the row). Wiping or filtering those legacy rows is a separate data-migration concern — happy to do a follow-up if you want one.

## Detected by

Aeon + manual review of the cross-route document-access pattern (chat path filters by `user_id`, tabular path doesn't).
- Severity: **HIGH**
- CWE-639 (Authorization Bypass Through User-Controlled Key)

## Verification

- `npx tsc --noEmit -p backend/tsconfig.json` clean against the patched tree.
- No test suite in the backend (`scripts: build/dev/start` only) — no regression suite to run.
- Diff is +97 / -6 across two files, scoped to the access-control fix only.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
