### PR TITLE
fix: handle JSONB shared_with filters and path-style S3

### DIFF
--- a/backend/src/lib/access.ts
+++ b/backend/src/lib/access.ts
@@ -135,7 +135,7 @@ export async function listAccessibleProjectIds(
             ? db
                   .from("projects")
                   .select("id")
-                  .contains("shared_with", [userEmail])
+                  .filter("shared_with", "cs", JSON.stringify([userEmail]))
                   .neq("user_id", userId)
             : Promise.resolve({ data: [] as { id: string }[] }),
     ]);

--- a/backend/src/lib/storage.ts
+++ b/backend/src/lib/storage.ts
@@ -21,6 +21,7 @@ function getClient(): S3Client {
   return new S3Client({
     region: "auto",
     endpoint: process.env.R2_ENDPOINT_URL!,
+    forcePathStyle: true,
     credentials: {
       accessKeyId: process.env.R2_ACCESS_KEY_ID!,
       secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -31,7 +31,7 @@ projectsRouter.get("/", requireAuth, async (req, res) => {
     ? await db
         .from("projects")
         .select("*")
-        .contains("shared_with", [userEmail])
+        .filter("shared_with", "cs", JSON.stringify([userEmail]))
         .neq("user_id", userId)
         .order("created_at", { ascending: false })
     : { data: [], error: null };


### PR DESCRIPTION
## Summary

Fixes project sharing queries against the `shared_with` JSONB column and improves compatibility with local/S3-compatible storage providers.

## Changes

- Replaced Supabase `.contains("shared_with", [email])` calls with `.filter("shared_with", "cs", JSON.stringify([email]))`.
- Applied the JSONB containment fix to:
  - `GET /projects`
  - `listAccessibleProjectIds`
- Added `forcePathStyle: true` to the S3 client configuration.

## Why

`shared_with` is a JSONB column. Passing a JavaScript array to `.contains()` can be serialized in a way that PostgREST treats as Postgres array syntax instead of JSON, causing `GET /projects` to fail for users with shared projects.

`forcePathStyle: true` allows the S3 client to work with local MinIO and other S3-compatible endpoints that do not support virtual-hosted-style bucket URLs.

## Testing

- Synced from private repo to OSS export.