### PR TITLE
feat: folder-grouped tabular reviews with per-user page limit

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -299,6 +299,7 @@ create table if not exists public.tabular_reviews (
   columns_config jsonb,
   workflow_id uuid references public.workflows(id) on delete set null,
   practice text,
+  document_grouping text not null default 'document' check (document_grouping in ('document', 'folder')),
   shared_with jsonb not null default '[]'::jsonb,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
@@ -313,10 +314,36 @@ create index if not exists idx_tabular_reviews_project
 create index if not exists tabular_reviews_shared_with_idx
   on public.tabular_reviews using gin (shared_with);
 
+create table if not exists public.tabular_review_rows (
+  id uuid primary key default gen_random_uuid(),
+  review_id uuid not null references public.tabular_reviews(id) on delete cascade,
+  label text not null,
+  row_type text not null check (row_type in ('document', 'folder')),
+  folder_id uuid references public.project_subfolders(id) on delete set null,
+  document_id uuid references public.documents(id) on delete set null,
+  sort_index integer not null default 0,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_tabular_review_rows_review
+  on public.tabular_review_rows(review_id, sort_index);
+
+create table if not exists public.tabular_review_row_sources (
+  row_id uuid not null references public.tabular_review_rows(id) on delete cascade,
+  document_id uuid not null references public.documents(id) on delete cascade,
+  sort_index integer not null default 0,
+  created_at timestamptz not null default now(),
+  primary key (row_id, document_id)
+);
+
+create index if not exists idx_tabular_review_row_sources_document
+  on public.tabular_review_row_sources(document_id);
+
 create table if not exists public.tabular_cells (
   id uuid primary key default gen_random_uuid(),
   review_id uuid not null references public.tabular_reviews(id) on delete cascade,
-  document_id uuid not null references public.documents(id) on delete cascade,
+  row_id uuid references public.tabular_review_rows(id) on delete cascade,
+  document_id uuid references public.documents(id) on delete cascade,
   column_index integer not null,
   content text,
   citations jsonb,
@@ -326,6 +353,9 @@ create table if not exists public.tabular_cells (
 
 create index if not exists idx_tabular_cells_review
   on public.tabular_cells(review_id, document_id, column_index);
+
+create index if not exists idx_tabular_cells_review_row
+  on public.tabular_cells(review_id, row_id, column_index);
 
 create table if not exists public.tabular_review_chats (
   id uuid primary key default gen_random_uuid(),
@@ -491,6 +521,8 @@ alter table public.workflow_shares enable row level security;
 alter table public.chats enable row level security;
 alter table public.chat_messages enable row level security;
 alter table public.tabular_reviews enable row level security;
+alter table public.tabular_review_rows enable row level security;
+alter table public.tabular_review_row_sources enable row level security;
 alter table public.tabular_cells enable row level security;
 alter table public.tabular_review_chats enable row level security;
 alter table public.tabular_review_chat_messages enable row level security;
@@ -910,6 +942,115 @@ create policy "Review owners can delete tabular reviews"
   on public.tabular_reviews for delete
   using (user_id = public.current_user_id_text());
 
+drop policy if exists "Users can view accessible tabular review rows" on public.tabular_review_rows;
+create policy "Users can view accessible tabular review rows"
+  on public.tabular_review_rows for select
+  using (public.review_is_accessible(review_id));
+
+drop policy if exists "Review owners can insert tabular review rows" on public.tabular_review_rows;
+create policy "Review owners can insert tabular review rows"
+  on public.tabular_review_rows for insert
+  with check (
+    exists (
+      select 1
+      from public.tabular_reviews r
+      where r.id = review_id
+        and r.user_id = public.current_user_id_text()
+    )
+  );
+
+drop policy if exists "Review owners can update tabular review rows" on public.tabular_review_rows;
+create policy "Review owners can update tabular review rows"
+  on public.tabular_review_rows for update
+  using (
+    exists (
+      select 1
+      from public.tabular_reviews r
+      where r.id = review_id
+        and r.user_id = public.current_user_id_text()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.tabular_reviews r
+      where r.id = review_id
+        and r.user_id = public.current_user_id_text()
+    )
+  );
+
+drop policy if exists "Review owners can delete tabular review rows" on public.tabular_review_rows;
+create policy "Review owners can delete tabular review rows"
+  on public.tabular_review_rows for delete
+  using (
+    exists (
+      select 1
+      from public.tabular_reviews r
+      where r.id = review_id
+        and r.user_id = public.current_user_id_text()
+    )
+  );
+
+drop policy if exists "Users can view accessible tabular row sources" on public.tabular_review_row_sources;
+create policy "Users can view accessible tabular row sources"
+  on public.tabular_review_row_sources for select
+  using (
+    exists (
+      select 1
+      from public.tabular_review_rows trr
+      where trr.id = row_id
+        and public.review_is_accessible(trr.review_id)
+    )
+  );
+
+drop policy if exists "Review owners can insert tabular row sources" on public.tabular_review_row_sources;
+create policy "Review owners can insert tabular row sources"
+  on public.tabular_review_row_sources for insert
+  with check (
+    exists (
+      select 1
+      from public.tabular_review_rows trr
+      join public.tabular_reviews review on review.id = trr.review_id
+      where trr.id = row_id
+        and review.user_id = public.current_user_id_text()
+    )
+  );
+
+drop policy if exists "Review owners can update tabular row sources" on public.tabular_review_row_sources;
+create policy "Review owners can update tabular row sources"
+  on public.tabular_review_row_sources for update
+  using (
+    exists (
+      select 1
+      from public.tabular_review_rows trr
+      join public.tabular_reviews review on review.id = trr.review_id
+      where trr.id = row_id
+        and review.user_id = public.current_user_id_text()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.tabular_review_rows trr
+      join public.tabular_reviews review on review.id = trr.review_id
+      where trr.id = row_id
+        and review.user_id = public.current_user_id_text()
+    )
+  );
+
+drop policy if exists "Review owners can delete tabular row sources" on public.tabular_review_row_sources;
+create policy "Review owners can delete tabular row sources"
+  on public.tabular_review_row_sources for delete
+  using (
+    exists (
+      select 1
+      from public.tabular_review_rows trr
+      join public.tabular_reviews review on review.id = trr.review_id
+      where trr.id = row_id
+        and review.user_id = public.current_user_id_text()
+    )
+  );
+
 drop policy if exists "Users can view accessible tabular cells" on public.tabular_cells;
 create policy "Users can view accessible tabular cells"
   on public.tabular_cells for select
@@ -1067,6 +1208,8 @@ revoke all on public.workflow_shares from anon, authenticated;
 revoke all on public.chats from anon, authenticated;
 revoke all on public.chat_messages from anon, authenticated;
 revoke all on public.tabular_reviews from anon, authenticated;
+revoke all on public.tabular_review_rows from anon, authenticated;
+revoke all on public.tabular_review_row_sources from anon, authenticated;
 revoke all on public.tabular_cells from anon, authenticated;
 revoke all on public.tabular_review_chats from anon, authenticated;
 revoke all on public.tabular_review_chat_messages from anon, authenticated;

--- a/backend/src/lib/chatTools.ts
+++ b/backend/src/lib/chatTools.ts
@@ -58,7 +58,7 @@ export type DocIndex = Record<
 export type TabularCellStore = {
     columns: { index: number; name: string }[];
     documents: { id: string; filename: string }[];
-    /** key: `${colIndex}:${docId}` */
+    /** key: `${colIndex}:${rowId}` */
     cells: Map<
         string,
         { summary: string; flag?: string; reasoning?: string } | null
@@ -712,6 +712,7 @@ export async function extractPdfText(buf: ArrayBuffer): Promise<string> {
         ).getDocument({
             data: new Uint8Array(buf),
             standardFontDataUrl: STANDARD_FONT_DATA_URL,
+            verbosity: 0,
         }).promise;
         const parts: string[] = [];
         for (let i = 1; i <= pdf.numPages; i++) {

--- a/backend/src/lib/userSettings.ts
+++ b/backend/src/lib/userSettings.ts
@@ -11,6 +11,7 @@ import { getUserApiKeys as getStoredUserApiKeys } from "./userApiKeys";
 export type UserModelSettings = {
     title_model: string;
     tabular_model: string;
+    tabular_max_pages: number;
     api_keys: UserApiKeys;
 };
 
@@ -32,7 +33,7 @@ export async function getUserModelSettings(
     const client = db ?? createServerSupabase();
     const { data } = await client
         .from("user_profiles")
-        .select("tabular_model")
+        .select("tabular_model, tabular_max_pages")
         .eq("user_id", userId)
         .single();
     const api_keys = await getStoredUserApiKeys(userId, client);
@@ -40,6 +41,7 @@ export async function getUserModelSettings(
     return {
         title_model: resolveTitleModel(api_keys),
         tabular_model: resolveModel(data?.tabular_model, DEFAULT_TABULAR_MODEL),
+        tabular_max_pages: (data?.tabular_max_pages as number | null) ?? 250,
         api_keys,
     };
 }

--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { Router } from "express";
 import { requireAuth } from "../middleware/auth";
 import { createServerSupabase } from "../lib/supabase";
@@ -26,6 +27,15 @@ import { singleFileUpload } from "../lib/upload";
 
 export const documentsRouter = Router();
 const ALLOWED_TYPES = new Set(["pdf", "docx", "doc"]);
+
+const STANDARD_FONT_DATA_URL = (() => {
+    try {
+        const pkgPath = require.resolve("pdfjs-dist/package.json");
+        return path.join(path.dirname(pkgPath), "standard_fonts") + path.sep;
+    } catch {
+        return undefined;
+    }
+})();
 
 // GET /single-documents
 documentsRouter.get("/", requireAuth, async (req, res) => {
@@ -977,7 +987,7 @@ async function countPdfPages(buf: ArrayBuffer): Promise<number | null> {
           promise: Promise<{ numPages: number }>;
         };
       }
-    ).getDocument({ data: new Uint8Array(buf) }).promise;
+    ).getDocument({ data: new Uint8Array(buf), standardFontDataUrl: STANDARD_FONT_DATA_URL, verbosity: 0 }).promise;
     return pdf.numPages;
   } catch {
     return null;

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { Router } from "express";
 import { requireAuth } from "../middleware/auth";
 import { createServerSupabase } from "../lib/supabase";
@@ -13,6 +14,15 @@ import { singleFileUpload } from "../lib/upload";
 
 export const projectsRouter = Router();
 const ALLOWED_TYPES = new Set(["pdf", "docx", "doc"]);
+
+const STANDARD_FONT_DATA_URL = (() => {
+  try {
+    const pkgPath = require.resolve("pdfjs-dist/package.json");
+    return path.join(path.dirname(pkgPath), "standard_fonts") + path.sep;
+  } catch {
+    return undefined;
+  }
+})();
 
 // GET /projects
 projectsRouter.get("/", requireAuth, async (req, res) => {
@@ -31,7 +41,7 @@ projectsRouter.get("/", requireAuth, async (req, res) => {
     ? await db
         .from("projects")
         .select("*")
-        .filter("shared_with", "cs", JSON.stringify([userEmail]))
+        .contains("shared_with", JSON.stringify([userEmail]))
         .neq("user_id", userId)
         .order("created_at", { ascending: false })
     : { data: [], error: null };
@@ -758,7 +768,7 @@ async function countPdfPages(buf: ArrayBuffer): Promise<number | null> {
           promise: Promise<{ numPages: number }>;
         };
       }
-    ).getDocument({ data: new Uint8Array(buf) }).promise;
+    ).getDocument({ data: new Uint8Array(buf), standardFontDataUrl: STANDARD_FONT_DATA_URL, verbosity: 0 }).promise;
     return pdf.numPages;
   } catch {
     return null;
@@ -784,7 +794,7 @@ async function extractStructureTree(
             }>;
           };
         }
-      ).getDocument({ data: new Uint8Array(content) }).promise;
+      ).getDocument({ data: new Uint8Array(content), standardFontDataUrl: STANDARD_FONT_DATA_URL, verbosity: 0 }).promise;
       if (pdf.numPages <= 5) return null;
       const outline = await pdf.getOutline();
       if (outline?.length) {

--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -15,7 +15,6 @@ import { getUserApiKeys, getUserModelSettings } from "../lib/userSettings";
 import {
     checkProjectAccess,
     ensureReviewAccess,
-    filterAccessibleDocumentIds,
     listAccessibleProjectIds,
 } from "../lib/access";
 
@@ -45,6 +44,289 @@ function formatPromptSuffix(format?: string, tags?: string[]): string {
 }
 
 export const tabularRouter = Router();
+
+
+const TABULAR_UNKNOWN_PAGE_COUNT_FALLBACK = Number(
+    process.env.TABULAR_UNKNOWN_PAGE_COUNT_FALLBACK ?? 50,
+);
+
+type DocumentGrouping = "document" | "folder";
+type ReviewRow = {
+    id: string;
+    review_id: string;
+    label: string;
+    row_type: "document" | "folder";
+    folder_id: string | null;
+    document_id: string | null;
+    sort_index: number;
+    source_document_ids?: string[];
+};
+type SourceDocument = {
+    id: string;
+    filename: string;
+    file_type: string | null;
+    folder_id?: string | null;
+    page_count?: number | null;
+    created_at?: string | null;
+};
+type SupabaseDb = ReturnType<typeof createServerSupabase>;
+
+function normalizeGrouping(value: unknown): DocumentGrouping {
+    return value === "folder" ? "folder" : "document";
+}
+
+function distinctStrings(values: unknown[]): string[] {
+    return [
+        ...new Set(
+            values.filter((value): value is string => typeof value === "string" && !!value),
+        ),
+    ];
+}
+
+async function getFolderPathMap(
+    db: SupabaseDb,
+    projectId: string | null | undefined,
+): Promise<Map<string, string>> {
+    if (!projectId) return new Map();
+    const { data } = await db
+        .from("project_subfolders")
+        .select("id, name, parent_folder_id")
+        .eq("project_id", projectId);
+    const folders = (data ?? []) as {
+        id: string;
+        name: string;
+        parent_folder_id: string | null;
+    }[];
+    const byId = new Map(folders.map((folder) => [folder.id, folder]));
+    const cache = new Map<string, string>();
+    const resolve = (id: string): string => {
+        const cached = cache.get(id);
+        if (cached) return cached;
+        const folder = byId.get(id);
+        if (!folder) return "Unknown folder";
+        const parent = folder.parent_folder_id
+            ? `${resolve(folder.parent_folder_id)} / `
+            : "";
+        const path = `${parent}${folder.name}`;
+        cache.set(id, path);
+        return path;
+    };
+    for (const folder of folders) resolve(folder.id);
+    return cache;
+}
+
+async function fetchSourceDocuments(
+    db: SupabaseDb,
+    documentIds: string[],
+): Promise<SourceDocument[]> {
+    if (documentIds.length === 0) return [];
+    const { data } = await db
+        .from("documents")
+        .select("id, filename, file_type, folder_id, page_count, created_at")
+        .in("id", documentIds);
+    const docs = (data ?? []) as SourceDocument[];
+    const position = new Map(documentIds.map((id, index) => [id, index]));
+    return docs.sort(
+        (a, b) => (position.get(a.id) ?? 0) - (position.get(b.id) ?? 0),
+    );
+}
+
+async function createRowsForReview(
+    db: SupabaseDb,
+    reviewId: string,
+    projectId: string | null | undefined,
+    documentIds: string[],
+    columns: Column[],
+    grouping: DocumentGrouping,
+): Promise<ReviewRow[]> {
+    const docs = await fetchSourceDocuments(db, documentIds);
+    const folderPaths = await getFolderPathMap(db, projectId);
+    const rowInputs: {
+        label: string;
+        row_type: "document" | "folder";
+        folder_id: string | null;
+        document_id: string | null;
+        sourceIds: string[];
+    }[] = [];
+
+    if (grouping === "folder" && projectId) {
+        const byFolder = new Map<string, SourceDocument[]>();
+        for (const doc of docs) {
+            if (!doc.folder_id) {
+                rowInputs.push({
+                    label: doc.filename,
+                    row_type: "document",
+                    folder_id: null,
+                    document_id: doc.id,
+                    sourceIds: [doc.id],
+                });
+                continue;
+            }
+            byFolder.set(doc.folder_id, [
+                ...(byFolder.get(doc.folder_id) ?? []),
+                doc,
+            ]);
+        }
+        for (const [folderId, folderDocs] of byFolder) {
+            rowInputs.push({
+                label: folderPaths.get(folderId) ?? "Unknown folder",
+                row_type: "folder",
+                folder_id: folderId,
+                document_id: null,
+                sourceIds: folderDocs.map((doc) => doc.id),
+            });
+        }
+    } else {
+        for (const doc of docs) {
+            rowInputs.push({
+                label: doc.filename,
+                row_type: "document",
+                folder_id: null,
+                document_id: doc.id,
+                sourceIds: [doc.id],
+            });
+        }
+    }
+
+    rowInputs.sort((a, b) => a.label.localeCompare(b.label));
+    const { data: insertedRows, error: rowError } = await db
+        .from("tabular_review_rows")
+        .insert(
+            rowInputs.map((row, index) => ({
+                review_id: reviewId,
+                label: row.label,
+                row_type: row.row_type,
+                folder_id: row.folder_id,
+                document_id: row.document_id,
+                sort_index: index,
+            })),
+        )
+        .select("*");
+    if (rowError) throw new Error(rowError.message);
+
+    const rows = ((insertedRows ?? []) as ReviewRow[]).sort(
+        (a, b) => a.sort_index - b.sort_index,
+    );
+    const rowSourceRecords = rows.flatMap((row) => {
+        const input = rowInputs[row.sort_index];
+        return (input?.sourceIds ?? []).map((documentId, index) => ({
+            row_id: row.id,
+            document_id: documentId,
+            sort_index: index,
+        }));
+    });
+    if (rowSourceRecords.length) {
+        const { error } = await db
+            .from("tabular_review_row_sources")
+            .insert(rowSourceRecords);
+        if (error) throw new Error(error.message);
+    }
+
+    const cells = rows.flatMap((row) =>
+        columns.map((col) => ({
+            review_id: reviewId,
+            row_id: row.id,
+            document_id: row.document_id,
+            column_index: col.index,
+            status: "pending",
+        })),
+    );
+    if (cells.length) {
+        const { error } = await db.from("tabular_cells").insert(cells);
+        if (error) throw new Error(error.message);
+    }
+    return rows;
+}
+
+async function loadReviewRows(db: SupabaseDb, reviewId: string): Promise<ReviewRow[]> {
+    const { data } = await db
+        .from("tabular_review_rows")
+        .select("*")
+        .eq("review_id", reviewId)
+        .order("sort_index", { ascending: true });
+    const rows = (data ?? []) as ReviewRow[];
+    if (rows.length === 0) return rows;
+    const { data: sources } = await db
+        .from("tabular_review_row_sources")
+        .select("row_id, document_id")
+        .in(
+            "row_id",
+            rows.map((row) => row.id),
+        )
+        .order("sort_index", { ascending: true });
+    const byRow = new Map<string, string[]>();
+    for (const source of sources ?? []) {
+        byRow.set(source.row_id, [
+            ...(byRow.get(source.row_id) ?? []),
+            source.document_id,
+        ]);
+    }
+    return rows.map((row) => ({
+        ...row,
+        source_document_ids:
+            byRow.get(row.id) ?? (row.document_id ? [row.document_id] : []),
+    }));
+}
+
+function cellKey(rowId: string, columnIndex: number): string {
+    return `${rowId}:${columnIndex}`;
+}
+
+function rowSourceKey(row: ReviewRow): string {
+    return [...(row.source_document_ids ?? [])].sort().join("|");
+}
+
+function pageCountForDocs(docs: SourceDocument[]): number {
+    return docs.reduce(
+        (sum, doc) =>
+            sum +
+            (Number.isFinite(doc.page_count ?? NaN)
+                ? Number(doc.page_count)
+                : TABULAR_UNKNOWN_PAGE_COUNT_FALLBACK),
+        0,
+    );
+}
+
+function pageLimitError(totalPages: number, maxPages: number): CellResult {
+    return {
+        summary: `Not processed: this row contains ${totalPages} pages, above the configured ${maxPages}-page limit.`,
+        flag: "red",
+        reasoning: "The grouped row was skipped before extraction to keep tabular review requests within the configured page limit.",
+    };
+}
+
+async function loadSourceTexts(
+    docs: SourceDocument[],
+    db: SupabaseDb,
+): Promise<{ documentId: string; filename: string; text: string }[]> {
+    return Promise.all(
+        docs.map(async (doc) => {
+            let markdown = "";
+            const active = await loadActiveVersion(doc.id, db);
+            if (active) {
+                const buf = await downloadFile(active.storage_path);
+                if (buf) {
+                    try {
+                        markdown =
+                            doc.file_type === "pdf"
+                                ? await extractPdfMarkdown(buf)
+                                : await extractDocxMarkdown(buf);
+                    } catch (err) {
+                        console.error(
+                            `[tabular] extraction error doc=${doc.id}`,
+                            err,
+                        );
+                    }
+                }
+            }
+            return {
+                documentId: doc.id,
+                filename: doc.filename,
+                text: markdown,
+            };
+        }),
+    );
+}
 
 // GET /tabular-review
 tabularRouter.get("/", requireAuth, async (req, res) => {
@@ -140,17 +422,31 @@ tabularRouter.get("/", requireAuth, async (req, res) => {
         reviews.push(r as Record<string, unknown>);
     }
 
-    // Fetch distinct document counts per review
+    // Fetch row counts per review. Falls back to legacy distinct document
+    // counts if a review has not been backfilled yet.
     const reviewIds = reviews.map((r) => (r as { id: string }).id);
     let docCounts: Record<string, number> = {};
     if (reviewIds.length > 0) {
-        const { data: cells } = await db
+        const { data: rows } = await db
+            .from("tabular_review_rows")
+            .select("review_id")
+            .in("review_id", reviewIds);
+        if (rows?.length) {
+            for (const row of rows) {
+                docCounts[row.review_id] = (docCounts[row.review_id] ?? 0) + 1;
+            }
+        }
+        const missingReviewIds = reviewIds.filter((id) => !docCounts[id]);
+        const { data: cells } = missingReviewIds.length
+            ? await db
             .from("tabular_cells")
             .select("review_id, document_id")
-            .in("review_id", reviewIds);
+                  .in("review_id", missingReviewIds)
+            : { data: [] as { review_id: string; document_id: string | null }[] };
         if (cells) {
             const seen = new Set<string>();
             for (const cell of cells) {
+                if (!cell.document_id) continue;
                 const key = `${cell.review_id}:${cell.document_id}`;
                 if (!seen.has(key)) {
                     seen.add(key);
@@ -173,14 +469,22 @@ tabularRouter.get("/", requireAuth, async (req, res) => {
 tabularRouter.post("/", requireAuth, async (req, res) => {
     const userId = res.locals.userId as string;
     const userEmail = res.locals.userEmail as string | undefined;
-    const { title, document_ids, columns_config, workflow_id, project_id } =
-        req.body as {
-            title?: string;
-            document_ids: string[];
-            columns_config: { index: number; name: string; prompt: string }[];
-            workflow_id?: string;
-            project_id?: string;
-        };
+    const {
+        title,
+        document_ids,
+        columns_config,
+        workflow_id,
+        project_id,
+        document_grouping,
+    } = req.body as {
+        title?: string;
+        document_ids: string[];
+        columns_config: Column[];
+        workflow_id?: string;
+        project_id?: string;
+        document_grouping?: DocumentGrouping;
+    };
+    const grouping = normalizeGrouping(document_grouping);
 
     const db = createServerSupabase();
     if (project_id) {
@@ -209,6 +513,7 @@ tabularRouter.post("/", requireAuth, async (req, res) => {
             columns_config,
             project_id: project_id ?? null,
             workflow_id: workflow_id ?? null,
+            document_grouping: grouping,
         })
         .select("*")
         .single();
@@ -217,15 +522,24 @@ tabularRouter.post("/", requireAuth, async (req, res) => {
             .status(500)
             .json({ detail: error?.message ?? "Failed to create review" });
 
-    const cells = allowedDocumentIds.flatMap((docId) =>
-        columns_config.map((col) => ({
-            review_id: review.id,
-            document_id: docId,
-            column_index: col.index,
-            status: "pending",
-        })),
-    );
-    if (cells.length) await db.from("tabular_cells").insert(cells);
+    try {
+        await createRowsForReview(
+            db,
+            review.id,
+            project_id ?? null,
+            allowedDocumentIds,
+            columns_config ?? [],
+            grouping,
+        );
+    } catch (err) {
+        await db.from("tabular_reviews").delete().eq("id", review.id);
+        return void res.status(500).json({
+            detail:
+                err instanceof Error
+                    ? err.message
+                    : "Failed to create review rows",
+        });
+    }
 
     res.status(201).json(review);
 });
@@ -323,7 +637,10 @@ tabularRouter.get("/:reviewId", requireAuth, async (req, res) => {
         .from("tabular_cells")
         .select("*")
         .eq("review_id", reviewId);
-    const docIds = [...new Set((cells ?? []).map((c) => c.document_id))];
+    const rows = await loadReviewRows(db, reviewId);
+    const rowSourceIds = rows.flatMap((row) => row.source_document_ids ?? []);
+    const legacyDocIds = (cells ?? []).map((c) => c.document_id);
+    const docIds = distinctStrings([...rowSourceIds, ...legacyDocIds]);
     const docsResult =
         docIds.length > 0
             ? await db.from("documents").select("*").in("id", docIds)
@@ -342,6 +659,19 @@ tabularRouter.get("/:reviewId", requireAuth, async (req, res) => {
             content: parseCellContent(cell.content),
         })),
         documents: docsResult.data ?? [],
+        rows:
+            rows.length > 0
+                ? rows
+                : (docsResult.data ?? []).map((doc, index) => ({
+                      id: doc.id,
+                      review_id: reviewId,
+                      label: doc.filename,
+                      row_type: "document",
+                      folder_id: doc.folder_id ?? null,
+                      document_id: doc.id,
+                      sort_index: index,
+                      source_document_ids: [doc.id],
+                  })),
     });
 });
 
@@ -437,6 +767,10 @@ tabularRouter.patch("/:reviewId", requireAuth, async (req, res) => {
         updates.columns_config = req.body.columns_config;
     if (req.body.project_id !== undefined)
         updates.project_id = req.body.project_id;
+    if (req.body.document_grouping != null)
+        updates.document_grouping = normalizeGrouping(
+            req.body.document_grouping,
+        );
     // shared_with edits are owner-only — gated below after we know who's
     // making the call. Normalize lowercase + dedupe + drop empties.
     let sharedWithUpdate: string[] | undefined;
@@ -489,92 +823,93 @@ tabularRouter.patch("/:reviewId", requireAuth, async (req, res) => {
             detail: updateError?.message ?? "Failed to update review",
         });
 
-    if (
-        Array.isArray(req.body.columns_config) ||
-        Array.isArray(req.body.document_ids)
-    ) {
-        const { data: existingCells } = await db
+    if (Array.isArray(req.body.document_ids)) {
+        const oldRows = await loadReviewRows(db, reviewId);
+        const oldRowById = new Map(oldRows.map((row) => [row.id, row]));
+        const { data: oldCells } = await db
             .from("tabular_cells")
-            .select("document_id,column_index")
+            .select("row_id,column_index,content,status")
             .eq("review_id", reviewId);
-        const existingKeys = new Set(
-            (existingCells ?? []).map(
-                (cell) => `${cell.document_id}:${cell.column_index}`,
-            ),
-        );
-
-        let documentIds: string[];
-
-        if (Array.isArray(req.body.document_ids)) {
-            // document_ids is the new source of truth — delete removed docs' cells
-            const requestedDocIds = req.body.document_ids as string[];
-            const existingDocIds = (existingCells ?? []).map(
-                (cell) => cell.document_id,
+        const oldCellBySourceKey = new Map<
+            string,
+            { content: unknown; status: string }
+        >();
+        for (const cell of oldCells ?? []) {
+            if (!cell.row_id) continue;
+            const row = oldRowById.get(cell.row_id);
+            if (!row) continue;
+            oldCellBySourceKey.set(
+                `${rowSourceKey(row)}:${cell.column_index}`,
+                { content: cell.content, status: cell.status },
             );
-            const existingDocIdSet = new Set(existingDocIds);
-            const newDocCandidates = requestedDocIds.filter(
-                (id) => !existingDocIdSet.has(id),
-            );
-            const newDocAllowed = await filterAccessibleDocumentIds(
-                newDocCandidates,
-                userId,
-                userEmail,
-                db,
-            );
-            const newDocAllowedSet = new Set(newDocAllowed);
-            const newDocIds = requestedDocIds.filter(
-                (id) => existingDocIdSet.has(id) || newDocAllowedSet.has(id),
-            );
-            const removedDocIds = existingDocIds.filter(
-                (id) => !newDocIds.includes(id),
-            );
-
-            if (removedDocIds.length > 0) {
-                const { error: deleteError } = await db
-                    .from("tabular_cells")
-                    .delete()
-                    .eq("review_id", reviewId)
-                    .in("document_id", removedDocIds);
-                if (deleteError)
-                    return void res
-                        .status(500)
-                        .json({ detail: deleteError.message });
-            }
-
-            documentIds = newDocIds;
-        } else {
-            // No document change — derive from existing cells
-            documentIds = [
-                ...new Set(
-                    (existingCells ?? []).map((cell) => cell.document_id),
-                ),
-            ];
-            if (documentIds.length === 0 && existingReview.project_id) {
-                const { data: projectDocs } = await db
-                    .from("documents")
-                    .select("id")
-                    .eq("project_id", existingReview.project_id);
-                documentIds = (projectDocs ?? []).map((doc) => doc.id);
-            }
         }
 
-        const activeColumns = Array.isArray(req.body.columns_config)
-            ? req.body.columns_config
-            : (updatedReview.columns_config ?? []);
-        const newCells = documentIds.flatMap((documentId) =>
+        const { error: deleteRowsError } = await db
+            .from("tabular_review_rows")
+            .delete()
+            .eq("review_id", reviewId);
+        if (deleteRowsError)
+            return void res.status(500).json({ detail: deleteRowsError.message });
+        try {
+            await createRowsForReview(
+                db,
+                reviewId,
+                updatedReview.project_id,
+                req.body.document_ids as string[],
+                (updatedReview.columns_config ?? []) as Column[],
+                normalizeGrouping(updatedReview.document_grouping),
+            );
+            const newRows = await loadReviewRows(db, reviewId);
+            for (const row of newRows) {
+                for (const column of (updatedReview.columns_config ?? []) as Column[]) {
+                    const previous = oldCellBySourceKey.get(
+                        `${rowSourceKey(row)}:${column.index}`,
+                    );
+                    if (!previous?.content) continue;
+                    await db
+                        .from("tabular_cells")
+                        .update({
+                            content: previous.content,
+                            status: previous.status,
+                        })
+                        .eq("review_id", reviewId)
+                        .eq("row_id", row.id)
+                        .eq("column_index", column.index);
+                }
+            }
+        } catch (err) {
+            return void res.status(500).json({
+                detail:
+                    err instanceof Error
+                        ? err.message
+                        : "Failed to rebuild review rows",
+            });
+        }
+    } else if (Array.isArray(req.body.columns_config)) {
+        const rows = await loadReviewRows(db, reviewId);
+        const activeColumns = (updatedReview.columns_config ?? []) as Column[];
+        const { data: existingCells } = await db
+            .from("tabular_cells")
+            .select("row_id,document_id,column_index")
+            .eq("review_id", reviewId);
+        const existingKeys = new Set(
+            (existingCells ?? []).map((cell) =>
+                cell.row_id
+                    ? cellKey(cell.row_id, cell.column_index)
+                    : `${cell.document_id}:${cell.column_index}`,
+            ),
+        );
+        const newCells = rows.flatMap((row) =>
             activeColumns
-                .filter(
-                    (column: { index: number }) =>
-                        !existingKeys.has(`${documentId}:${column.index}`),
-                )
-                .map((column: { index: number }) => ({
+                .filter((column) => !existingKeys.has(cellKey(row.id, column.index)))
+                .map((column) => ({
                     review_id: reviewId,
-                    document_id: documentId,
+                    row_id: row.id,
+                    document_id: row.document_id,
                     column_index: column.index,
                     status: "pending",
                 })),
         );
-
         if (newCells.length > 0) {
             const { error: insertError } = await db
                 .from("tabular_cells")
@@ -604,18 +939,24 @@ tabularRouter.delete("/:reviewId", requireAuth, async (req, res) => {
 });
 
 // POST /tabular-review/:reviewId/clear-cells
-// Reset cells to an empty/pending state for the given document_ids. Does not
+// Reset cells to an empty/pending state for the given row_ids/document_ids. Does not
 // delete the rows — it blanks `content` and sets `status` back to "pending".
 tabularRouter.post("/:reviewId/clear-cells", requireAuth, async (req, res) => {
     const userId = res.locals.userId as string;
     const userEmail = res.locals.userEmail as string | undefined;
     const { reviewId } = req.params;
-    const { document_ids } = req.body as { document_ids?: string[] };
+    const { document_ids, row_ids } = req.body as {
+        document_ids?: string[];
+        row_ids?: string[];
+    };
 
-    if (!Array.isArray(document_ids) || document_ids.length === 0)
+    if (
+        (!Array.isArray(row_ids) || row_ids.length === 0) &&
+        (!Array.isArray(document_ids) || document_ids.length === 0)
+    )
         return void res
             .status(400)
-            .json({ detail: "document_ids is required" });
+            .json({ detail: "row_ids or document_ids is required" });
 
     const db = createServerSupabase();
     const { data: review, error: reviewError } = await db
@@ -629,11 +970,14 @@ tabularRouter.post("/:reviewId/clear-cells", requireAuth, async (req, res) => {
     if (!access.ok)
         return void res.status(404).json({ detail: "Review not found" });
 
-    const { error } = await db
+    let query = db
         .from("tabular_cells")
         .update({ content: null, status: "pending" })
-        .eq("review_id", reviewId)
-        .in("document_id", document_ids);
+        .eq("review_id", reviewId);
+    query = Array.isArray(row_ids) && row_ids.length > 0
+        ? query.in("row_id", row_ids)
+        : query.in("document_id", document_ids ?? []);
+    const { error } = await query;
     if (error) return void res.status(500).json({ detail: error.message });
     res.status(204).send();
 });
@@ -646,15 +990,16 @@ tabularRouter.post(
         const userId = res.locals.userId as string;
         const userEmail = res.locals.userEmail as string | undefined;
         const { reviewId } = req.params;
-        const { document_id, column_index } = req.body as {
-            document_id: string;
+        const { document_id, row_id, column_index } = req.body as {
+            document_id?: string;
+            row_id?: string;
             column_index: number;
         };
 
-        if (!document_id || column_index == null)
+        if ((!row_id && !document_id) || column_index == null)
             return void res
                 .status(400)
-                .json({ detail: "document_id and column_index are required" });
+                .json({ detail: "row_id or document_id and column_index are required" });
 
         const db = createServerSupabase();
         const { data: review, error: reviewError } = await db
@@ -680,59 +1025,49 @@ tabularRouter.post(
         if (!column)
             return void res.status(400).json({ detail: "Column not found" });
 
-        const docAllowed = await filterAccessibleDocumentIds(
-            [document_id],
-            userId,
-            userEmail,
-            db,
-        );
-        if (docAllowed.length === 0)
-            return void res.status(404).json({ detail: "Document not found" });
-        const { data: doc } = await db
-            .from("documents")
-            .select("id, filename, file_type")
-            .eq("id", document_id)
-            .single();
-        if (!doc)
-            return void res.status(404).json({ detail: "Document not found" });
-        const docActive = await loadActiveVersion(document_id, db);
+        const rows = await loadReviewRows(db, reviewId);
+        const row = row_id
+            ? rows.find((candidate) => candidate.id === row_id)
+            : rows.find((candidate) => candidate.document_id === document_id);
+        if (!row)
+            return void res.status(404).json({ detail: "Row not found" });
+        const sourceIds = row.source_document_ids ?? [];
+        const sourceDocs = await fetchSourceDocuments(db, sourceIds);
+        const totalPages = pageCountForDocs(sourceDocs);
 
         await db
             .from("tabular_cells")
             .update({ status: "generating", content: null })
             .eq("review_id", reviewId)
-            .eq("document_id", document_id)
+            .eq("row_id", row.id)
             .eq("column_index", column_index);
 
-        let markdown = "";
-        if (docActive) {
-            const buf = await downloadFile(docActive.storage_path);
-            if (buf) {
-                try {
-                    markdown =
-                        (doc.file_type as string) === "pdf"
-                            ? await extractPdfMarkdown(buf)
-                            : await extractDocxMarkdown(buf);
-                } catch (err) {
-                    console.error(
-                        `[regenerate-cell] extraction error doc=${document_id}`,
-                        err,
-                    );
-                }
-            }
-        }
-
-        const { tabular_model, api_keys } = await getUserModelSettings(
+        const { tabular_model, tabular_max_pages, api_keys } = await getUserModelSettings(
             userId,
             db,
         );
-        const result = await queryGemini(
+
+        if (totalPages > tabular_max_pages) {
+            const result = pageLimitError(totalPages, tabular_max_pages);
+            await db
+                .from("tabular_cells")
+                .update({ content: JSON.stringify(result), status: "error" })
+                .eq("review_id", reviewId)
+                .eq("row_id", row.id)
+                .eq("column_index", column_index);
+            return void res.status(400).json({ detail: result.summary });
+        }
+
+        const sources = await loadSourceTexts(sourceDocs, db);
+        let result: CellResult | null = null;
+        await queryGeminiAllColumns(
             tabular_model,
-            doc.filename as string,
-            markdown,
-            column.prompt,
-            column.format,
-            column.tags,
+            row.label,
+            sources,
+            [column],
+            async (_columnIndex, cellResult) => {
+                result = cellResult;
+            },
             api_keys,
         );
 
@@ -741,7 +1076,7 @@ tabularRouter.post(
                 .from("tabular_cells")
                 .update({ status: "error" })
                 .eq("review_id", reviewId)
-                .eq("document_id", document_id)
+                .eq("row_id", row.id)
                 .eq("column_index", column_index);
             return void res.status(500).json({ detail: "Generation failed" });
         }
@@ -750,7 +1085,7 @@ tabularRouter.post(
             .from("tabular_cells")
             .update({ content: JSON.stringify(result), status: "done" })
             .eq("review_id", reviewId)
-            .eq("document_id", document_id)
+            .eq("row_id", row.id)
             .eq("column_index", column_index);
 
         res.json(result);
@@ -790,34 +1125,33 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
         .select("*")
         .eq("review_id", reviewId);
     const cellMap = new Map<string, Record<string, unknown>>();
-    for (const cell of cells ?? [])
-        cellMap.set(`${cell.document_id}:${cell.column_index}`, cell);
-
-    const docIds = [...new Set((cells ?? []).map((c) => c.document_id))];
-    const allowedDocIds = new Set(
-        await filterAccessibleDocumentIds(docIds, userId, userEmail, db),
-    );
-    let docs: Record<string, unknown>[] = [];
-    if (docIds.length > 0) {
-        const filteredIds = docIds.filter((id) => allowedDocIds.has(id));
-        const { data } =
-            filteredIds.length > 0
-                ? await db
-                      .from("documents")
-                      .select("id, filename, file_type, page_count")
-                      .in("id", filteredIds)
-                : { data: [] as Record<string, unknown>[] };
-        docs = data ?? [];
-    } else if (review.project_id) {
-        const { data } = await db
-            .from("documents")
-            .select("id, filename, file_type, page_count")
-            .eq("project_id", review.project_id)
-            .order("created_at", { ascending: true });
-        docs = data ?? [];
+    for (const cell of cells ?? []) {
+        const rowKey = cell.row_id ?? cell.document_id;
+        if (rowKey) cellMap.set(cellKey(rowKey, cell.column_index), cell);
     }
 
-    const { tabular_model, api_keys } = await getUserModelSettings(userId, db);
+    let rows = await loadReviewRows(db, reviewId);
+    if (rows.length === 0) {
+        const legacyDocIds = distinctStrings((cells ?? []).map((c) => c.document_id));
+        if (legacyDocIds.length > 0) {
+            await createRowsForReview(
+                db,
+                reviewId,
+                review.project_id,
+                legacyDocIds,
+                columns,
+                "document",
+            );
+            rows = await loadReviewRows(db, reviewId);
+        }
+    }
+    const sourceDocIds = distinctStrings(
+        rows.flatMap((row) => row.source_document_ids ?? []),
+    );
+    const sourceDocs = await fetchSourceDocuments(db, sourceDocIds);
+    const docsById = new Map(sourceDocs.map((doc) => [doc.id, doc]));
+
+    const { tabular_model, tabular_max_pages, api_keys } = await getUserModelSettings(userId, db);
 
     res.setHeader("Content-Type", "text/event-stream");
     res.setHeader("Cache-Control", "no-cache");
@@ -829,42 +1163,37 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
 
     try {
         await Promise.all(
-            docs.map(async (doc) => {
-                const docId = doc.id as string;
-                const filename = doc.filename as string;
-                let markdown = "";
-
-                const active = await loadActiveVersion(docId, db);
-                if (active) {
-                    const buf = await downloadFile(active.storage_path);
-                    if (buf) {
-                        try {
-                            markdown =
-                                (doc.file_type as string) === "pdf"
-                                    ? await extractPdfMarkdown(buf)
-                                    : await extractDocxMarkdown(buf);
-                        } catch (err) {
-                            console.error(
-                                `[tabular/generate] extraction error doc=${docId}`,
-                                err,
-                            );
-                        }
-                    }
-                }
-
+            rows.map(async (row) => {
+                const rowDocs = (row.source_document_ids ?? [])
+                    .map((id) => docsById.get(id))
+                    .filter((doc): doc is SourceDocument => !!doc);
                 // Filter to only columns that need processing
                 const columnsToProcess = columns.filter((col) => {
-                    const cell = cellMap.get(`${docId}:${col.index}`);
+                    const cell = cellMap.get(cellKey(row.id, col.index));
                     return !(cell?.status === "done" && cell?.content);
                 });
                 if (columnsToProcess.length === 0) return;
 
+                if (rowDocs.length === 0) {
+                    console.error(`[tabular/generate] row=${row.id} has no source documents (source_document_ids=${JSON.stringify(row.source_document_ids)})`);
+                    const noDocsContent = JSON.stringify({ summary: "No source documents found for this row.", flag: "red" });
+                    for (const col of columnsToProcess) {
+                        await db.from("tabular_cells")
+                            .update({ status: "error", content: noDocsContent })
+                            .eq("review_id", reviewId)
+                            .eq("row_id", row.id)
+                            .eq("column_index", col.index);
+                        write(`data: ${JSON.stringify({ type: "cell_update", row_id: row.id, document_id: row.document_id, column_index: col.index, content: JSON.parse(noDocsContent), status: "error" })}\n\n`);
+                    }
+                    return;
+                }
+
                 // Mark all as generating upfront
                 for (const col of columnsToProcess) {
                     write(
-                        `data: ${JSON.stringify({ type: "cell_update", document_id: docId, column_index: col.index, content: null, status: "generating" })}\n\n`,
+                        `data: ${JSON.stringify({ type: "cell_update", row_id: row.id, document_id: row.document_id, column_index: col.index, content: null, status: "generating" })}\n\n`,
                     );
-                    const existingCell = cellMap.get(`${docId}:${col.index}`);
+                    const existingCell = cellMap.get(cellKey(row.id, col.index));
                     if (existingCell) {
                         await db
                             .from("tabular_cells")
@@ -873,20 +1202,43 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
                     } else {
                         await db.from("tabular_cells").insert({
                             review_id: reviewId,
-                            document_id: docId,
+                            row_id: row.id,
+                            document_id: row.document_id,
                             column_index: col.index,
                             status: "generating",
                         });
                     }
                 }
 
+                const totalPages = pageCountForDocs(rowDocs);
+                if (totalPages > tabular_max_pages) {
+                    const result = pageLimitError(totalPages, tabular_max_pages);
+                    for (const col of columnsToProcess) {
+                        await db
+                            .from("tabular_cells")
+                            .update({
+                                content: JSON.stringify(result),
+                                status: "error",
+                            })
+                            .eq("review_id", reviewId)
+                            .eq("row_id", row.id)
+                            .eq("column_index", col.index);
+                        write(
+                            `data: ${JSON.stringify({ type: "cell_update", row_id: row.id, document_id: row.document_id, column_index: col.index, content: result, status: "error" })}\n\n`,
+                        );
+                    }
+                    return;
+                }
+
+                const sources = await loadSourceTexts(rowDocs, db);
+
                 // Single LLM call for all columns, streaming one JSON line per column
                 const receivedColumns = new Set<number>();
                 try {
                     await queryGeminiAllColumns(
                         tabular_model,
-                        filename,
-                        markdown,
+                        row.label,
+                        sources,
                         columnsToProcess,
                         async (columnIndex, result) => {
                             receivedColumns.add(columnIndex);
@@ -897,17 +1249,17 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
                                     status: "done",
                                 })
                                 .eq("review_id", reviewId)
-                                .eq("document_id", docId)
+                                .eq("row_id", row.id)
                                 .eq("column_index", columnIndex);
                             write(
-                                `data: ${JSON.stringify({ type: "cell_update", document_id: docId, column_index: columnIndex, content: result, status: "done" })}\n\n`,
+                                `data: ${JSON.stringify({ type: "cell_update", row_id: row.id, document_id: row.document_id, column_index: columnIndex, content: result, status: "done" })}\n\n`,
                             );
                         },
                         api_keys,
                     );
                 } catch (err) {
                     console.error(
-                        `[tabular/generate] queryGeminiAllColumns error doc=${docId}`,
+                        `[tabular/generate] queryGeminiAllColumns error row=${row.id}`,
                         err,
                     );
                 }
@@ -915,14 +1267,20 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
                 // Mark any columns the LLM didn't return as error
                 for (const col of columnsToProcess) {
                     if (!receivedColumns.has(col.index)) {
+                        const errorContent = JSON.stringify({
+                            summary: rowDocs.length === 0
+                                ? "No source documents found for this row."
+                                : "Generation failed. Check server logs for details.",
+                            flag: "red",
+                        });
                         await db
                             .from("tabular_cells")
-                            .update({ status: "error" })
+                            .update({ status: "error", content: errorContent })
                             .eq("review_id", reviewId)
-                            .eq("document_id", docId)
+                            .eq("row_id", row.id)
                             .eq("column_index", col.index);
                         write(
-                            `data: ${JSON.stringify({ type: "cell_update", document_id: docId, column_index: col.index, content: null, status: "error" })}\n\n`,
+                            `data: ${JSON.stringify({ type: "cell_update", row_id: row.id, document_id: row.document_id, column_index: col.index, content: JSON.parse(errorContent), status: "error" })}\n\n`,
                         );
                     }
                 }
@@ -1175,24 +1533,19 @@ tabularRouter.post("/:reviewId/chat", requireAuth, async (req, res) => {
     if (!reviewAccess.ok)
         return void res.status(404).json({ detail: "Review not found" });
 
-    // Fetch all cells and documents for this review
+    // Fetch all cells and rows for this review
     const { data: cells } = await db
         .from("tabular_cells")
         .select("*")
         .eq("review_id", reviewId);
 
-    const docIds = [
-        ...new Set((cells ?? []).map((c: any) => c.document_id as string)),
-    ];
-    let docs: { id: string; filename: string }[] = [];
-    if (docIds.length > 0) {
-        const { data } = await db
-            .from("documents")
-            .select("id, filename")
-            .in("id", docIds)
-            .order("created_at", { ascending: true });
-        docs = (data ?? []) as { id: string; filename: string }[];
-    }
+    const rows = await loadReviewRows(db, reviewId);
+    const tabularRows =
+        rows.length > 0
+            ? rows.map((row) => ({ id: row.id, filename: row.label }))
+            : distinctStrings((cells ?? []).map((c: any) => c.document_id)).map(
+                  (id) => ({ id, filename: id }),
+              );
 
     const sortedColumns = (
         (review.columns_config ?? []) as { index: number; name: string }[]
@@ -1200,10 +1553,10 @@ tabularRouter.post("/:reviewId/chat", requireAuth, async (req, res) => {
 
     const tabularStore: TabularCellStore = {
         columns: sortedColumns,
-        documents: docs,
+        documents: tabularRows,
         cells: new Map(
             (cells ?? []).map((c: any) => [
-                `${c.column_index}:${c.document_id}`,
+                `${c.column_index}:${c.row_id ?? c.document_id}`,
                 parseCellContent(c.content),
             ]),
         ),
@@ -1536,8 +1889,8 @@ type Column = {
 
 async function queryGeminiAllColumns(
     model: string,
-    filename: string,
-    documentText: string,
+    rowLabel: string,
+    sources: { documentId: string; filename: string; text: string }[],
     columns: Column[],
     onResult: (columnIndex: number, result: CellResult) => Promise<void>,
     apiKeys?: import("../lib/llm").UserApiKeys,
@@ -1558,13 +1911,19 @@ Line format:
 {"column_index": <N>, "summary": <string>, "flag": <"green"|"grey"|"yellow"|"red">, "reasoning": <string>}
 
 Rules:
-- "summary": the extracted value with inline citations [[page:N||quote:verbatim excerpt ≤25 words]] after every factual claim. No explanation or reasoning here. Quotes must be narrowly scoped to the specific claim — extract only the exact supporting words, not the full surrounding sentence. Do not reuse one long quote across multiple statements; give each claim its own short, precise quote.
+- "summary": the extracted value with inline citations after every factual claim. Use [[doc_id:<document UUID>||page:N||quote:verbatim excerpt ≤25 words]]. For a single-document row, [[page:N||quote:...]] is also accepted but doc_id is preferred. Quotes must be narrowly scoped to the specific claim — extract only the exact supporting words, not the full surrounding sentence. Do not reuse one long quote across multiple statements; give each claim its own short, precise quote.
 - "flag": green = standard/favorable, yellow = needs attention, red = problematic/unfavorable, grey = neutral/not found
 - "reasoning": brief explanation of the extraction
 - The "summary" and "reasoning" string VALUES may use markdown (bullets, bold, italics, etc.) — escape newlines as \\n inside the JSON string. This markdown is rendered in the UI.
 - Output ONLY the JSON lines themselves. Do NOT wrap the response in markdown code fences (e.g. \`\`\`json), and do not add any preamble or summary.`;
 
-    const USER = `Document: ${filename}\n\n${documentText.slice(0, 120_000)}\n\n---\nColumns to extract:\n${columnsDesc}`;
+    const sourceText = sources
+        .map(
+            (source) =>
+                `<source document_id="${source.documentId}" filename="${source.filename}">\n${source.text.slice(0, 80_000)}\n</source>`,
+        )
+        .join("\n\n");
+    const USER = `Review row: ${rowLabel}\n\nSources:\n${sourceText}\n\n---\nColumns to extract:\n${columnsDesc}`;
 
     let contentBuffer = "";
     const pending: Promise<unknown>[] = [];

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -14,6 +14,8 @@ export const userRouter = Router();
 
 const MONTHLY_CREDIT_LIMIT = 999999;
 
+const DEFAULT_TABULAR_MAX_PAGES = 250;
+
 type UserProfileRow = {
   display_name: string | null;
   organisation: string | null;
@@ -21,6 +23,12 @@ type UserProfileRow = {
   credits_reset_date: string;
   tier: string;
   tabular_model: string;
+  tabular_max_pages: number;
+};
+
+type OAuthProfileMetadata = {
+  displayName?: string | null;
+  organisation?: string | null;
 };
 
 function serializeProfile(
@@ -36,8 +44,41 @@ function serializeProfile(
     creditsRemaining: Math.max(MONTHLY_CREDIT_LIMIT - creditsUsed, 0),
     tier: row.tier || "Free",
     tabularModel: resolveModel(row.tabular_model, DEFAULT_TABULAR_MODEL),
+    tabularMaxPages: row.tabular_max_pages ?? DEFAULT_TABULAR_MAX_PAGES,
     ...(apiKeyStatus ? { apiKeyStatus } : {}),
   };
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function profileMetadataFromOAuth(
+  metadata: unknown,
+  email: string,
+): OAuthProfileMetadata {
+  const raw =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>)
+      : {};
+  const displayName = firstString(
+    raw.full_name,
+    raw.name,
+    raw.display_name,
+    raw.user_name,
+  );
+  const organisation = firstString(
+    raw.organization,
+    raw.organisation,
+    raw.company,
+    email.endsWith("@kairosvista.com") ? "KairosVista" : null,
+  );
+  return { displayName, organisation };
 }
 
 function validateProfilePayload(body: unknown):
@@ -60,6 +101,7 @@ function validateProfilePayload(body: unknown):
     "displayName",
     "organisation",
     "tabularModel",
+    "tabularMaxPages",
   ]);
   const invalidField = Object.keys(raw).find((key) => !allowedFields.has(key));
   if (invalidField) {
@@ -70,6 +112,7 @@ function validateProfilePayload(body: unknown):
     display_name?: string | null;
     organisation?: string | null;
     tabular_model?: string;
+    tabular_max_pages?: number;
     updated_at: string;
   } = { updated_at: new Date().toISOString() };
 
@@ -98,31 +141,81 @@ function validateProfilePayload(body: unknown):
     update.tabular_model = resolved;
   }
 
+  if ("tabularMaxPages" in raw) {
+    const v = Number(raw.tabularMaxPages);
+    if (!Number.isInteger(v) || v < 10 || v > 2000) {
+      return { ok: false, detail: "tabularMaxPages must be an integer between 10 and 2000" };
+    }
+    update.tabular_max_pages = v;
+  }
+
   return { ok: true, update };
 }
 
 async function ensureProfileRow(
   db: ReturnType<typeof createServerSupabase>,
   userId: string,
+  defaults: OAuthProfileMetadata = {},
 ) {
   const { error } = await db
     .from("user_profiles")
     .upsert(
-      { user_id: userId },
+      {
+        user_id: userId,
+        ...(defaults.displayName && { display_name: defaults.displayName }),
+        ...(defaults.organisation && { organisation: defaults.organisation }),
+      },
       { onConflict: "user_id", ignoreDuplicates: true },
     );
   return error;
 }
 
+async function backfillBlankProfileFields(
+  db: ReturnType<typeof createServerSupabase>,
+  userId: string,
+  row: UserProfileRow,
+  defaults: OAuthProfileMetadata,
+): Promise<{ data: UserProfileRow; error: Error | null }> {
+  const update: {
+    display_name?: string;
+    organisation?: string;
+    updated_at: string;
+  } = { updated_at: new Date().toISOString() };
+
+  if (!row.display_name && defaults.displayName) {
+    update.display_name = defaults.displayName;
+  }
+  if (!row.organisation && defaults.organisation) {
+    update.organisation = defaults.organisation;
+  }
+  if (!update.display_name && !update.organisation) {
+    return { data: row, error: null };
+  }
+
+  const { data, error } = await db
+    .from("user_profiles")
+    .update(update)
+    .eq("user_id", userId)
+    .select(
+      "display_name, organisation, message_credits_used, credits_reset_date, tier, tabular_model, tabular_max_pages",
+    )
+    .single();
+  if (error) return { data: row, error };
+  return { data: data as UserProfileRow, error: null };
+}
+
 async function loadProfile(
   db: ReturnType<typeof createServerSupabase>,
   userId: string,
-  options: { repairMissing?: boolean } = {},
+  options: {
+    repairMissing?: boolean;
+    defaults?: OAuthProfileMetadata;
+  } = {},
 ) {
   let { data, error } = await db
     .from("user_profiles")
     .select(
-      "display_name, organisation, message_credits_used, credits_reset_date, tier, tabular_model",
+      "display_name, organisation, message_credits_used, credits_reset_date, tier, tabular_model, tabular_max_pages",
     )
     .eq("user_id", userId)
     .maybeSingle();
@@ -133,13 +226,13 @@ async function loadProfile(
       return { data: null, error: new Error("Profile not found") };
     }
 
-    const ensureError = await ensureProfileRow(db, userId);
+    const ensureError = await ensureProfileRow(db, userId, options.defaults);
     if (ensureError) return { data: null, error: ensureError };
 
     const created = await db
       .from("user_profiles")
       .select(
-        "display_name, organisation, message_credits_used, credits_reset_date, tier, tabular_model",
+        "display_name, organisation, message_credits_used, credits_reset_date, tier, tabular_model, tabular_max_pages",
       )
       .eq("user_id", userId)
       .single();
@@ -148,6 +241,15 @@ async function loadProfile(
   }
 
   let row = data as UserProfileRow;
+  const backfilled = await backfillBlankProfileFields(
+    db,
+    userId,
+    row,
+    options.defaults ?? {},
+  );
+  if (backfilled.error) return { data: null, error: backfilled.error };
+  row = backfilled.data;
+
   if (row.credits_reset_date && new Date() > new Date(row.credits_reset_date)) {
     const creditsResetDate = new Date();
     creditsResetDate.setDate(creditsResetDate.getDate() + 30);
@@ -160,7 +262,7 @@ async function loadProfile(
       })
       .eq("user_id", userId)
       .select(
-        "display_name, organisation, message_credits_used, credits_reset_date, tier, tabular_model",
+        "display_name, organisation, message_credits_used, credits_reset_date, tier, tabular_model, tabular_max_pages",
       )
       .single();
 
@@ -174,8 +276,13 @@ async function loadProfile(
 // POST /user/profile
 userRouter.post("/profile", requireAuth, async (_req, res) => {
   const userId = res.locals.userId as string;
+  const userEmail = res.locals.userEmail as string;
+  const defaults = profileMetadataFromOAuth(
+    res.locals.userMetadata,
+    userEmail,
+  );
   const db = createServerSupabase();
-  const error = await ensureProfileRow(db, userId);
+  const error = await ensureProfileRow(db, userId, defaults);
   if (error) return void res.status(500).json({ detail: error.message });
   res.json({ ok: true });
 });
@@ -183,9 +290,15 @@ userRouter.post("/profile", requireAuth, async (_req, res) => {
 // GET /user/profile
 userRouter.get("/profile", requireAuth, async (_req, res) => {
   const userId = res.locals.userId as string;
+  const userEmail = res.locals.userEmail as string;
+  const defaults = profileMetadataFromOAuth(
+    res.locals.userMetadata,
+    userEmail,
+  );
   const db = createServerSupabase();
   const { data, error } = await loadProfile(db, userId, {
     repairMissing: true,
+    defaults,
   });
   if (error) return void res.status(500).json({ detail: error.message });
   const apiKeyStatus = await getUserApiKeyStatus(userId, db);

--- a/frontend/src/app/(pages)/account/models/page.tsx
+++ b/frontend/src/app/(pages)/account/models/page.tsx
@@ -40,7 +40,7 @@ const API_KEY_FIELDS = [
 ] as const;
 
 export default function ModelsAndApiKeysPage() {
-    const { profile, updateModelPreference, updateApiKey } = useUserProfile();
+    const { profile, updateModelPreference, updateTabularMaxPages, updateApiKey } = useUserProfile();
 
     return (
         <div className="space-y-4">
@@ -69,6 +69,18 @@ export default function ModelsAndApiKeysPage() {
                             onChange={(id) =>
                                 updateModelPreference("tabularModel", id)
                             }
+                        />
+                    </div>
+                    <div>
+                        <label className="text-sm text-gray-600 block mb-2">
+                            Max pages per grouped row
+                        </label>
+                        <p className="text-xs text-gray-400 mb-2">
+                            Rows exceeding this page count will be skipped with an error. Range: 10–2000.
+                        </p>
+                        <MaxPagesField
+                            value={profile?.tabularMaxPages ?? 250}
+                            onSave={updateTabularMaxPages}
                         />
                     </div>
                 </div>
@@ -207,6 +219,53 @@ function TabularModelDropdown({
                 })}
             </DropdownMenuContent>
         </DropdownMenu>
+    );
+}
+
+function MaxPagesField({
+    value,
+    onSave,
+}: {
+    value: number;
+    onSave: (v: number) => Promise<boolean>;
+}) {
+    const [input, setInput] = useState(String(value));
+    const [saving, setSaving] = useState(false);
+    const [saved, setSaved] = useState(false);
+
+    const parsed = Number(input);
+    const valid = Number.isInteger(parsed) && parsed >= 10 && parsed <= 2000;
+    const dirty = parsed !== value && valid;
+
+    const handleSave = async () => {
+        if (!valid) return;
+        setSaving(true);
+        const ok = await onSave(parsed);
+        setSaving(false);
+        if (ok) {
+            setSaved(true);
+            setTimeout(() => setSaved(false), 2000);
+        }
+    };
+
+    return (
+        <div className="flex gap-2 max-w-xs">
+            <Input
+                type="number"
+                min={10}
+                max={2000}
+                value={input}
+                onChange={(e) => { setInput(e.target.value); setSaved(false); }}
+                className="w-32"
+            />
+            <Button
+                onClick={handleSave}
+                disabled={saving || !dirty || saved}
+                className="min-w-20 transition-all bg-black hover:bg-gray-900 text-white"
+            >
+                {saving ? "Saving..." : saved ? <><Check className="h-4 w-3" />Saved</> : "Save"}
+            </Button>
+        </div>
     );
 }
 

--- a/frontend/src/app/(pages)/tabular-reviews/page.tsx
+++ b/frontend/src/app/(pages)/tabular-reviews/page.tsx
@@ -130,6 +130,7 @@ export default function TabularReviewsPage() {
         columnsConfig?:
             | import("@/app/components/shared/types").ColumnConfig[]
             | null,
+        documentGrouping?: "document" | "folder",
     ) => {
         setCreating(true);
         try {
@@ -137,6 +138,7 @@ export default function TabularReviewsPage() {
                 title,
                 document_ids: documentIds ?? [],
                 columns_config: columnsConfig ?? [],
+                document_grouping: documentGrouping,
                 ...(projectId && { project_id: projectId }),
             });
             router.push(

--- a/frontend/src/app/components/projects/ProjectPage.tsx
+++ b/frontend/src/app/components/projects/ProjectPage.tsx
@@ -692,6 +692,7 @@ export function ProjectPage({ projectId, initialTab = "documents" }: Props) {
         _projectId?: string,
         documentIds?: string[],
         columnsConfig?: any,
+        documentGrouping?: "document" | "folder",
     ) {
         setCreatingReview(true);
         try {
@@ -701,6 +702,7 @@ export function ProjectPage({ projectId, initialTab = "documents" }: Props) {
                 document_ids: documentIds ?? docs.map((d) => d.id),
                 columns_config: columnsConfig ?? [],
                 project_id: projectId,
+                document_grouping: documentGrouping,
             });
             router.push(`/projects/${projectId}/tabular-reviews/${review.id}`);
         } finally {

--- a/frontend/src/app/components/shared/types.ts
+++ b/frontend/src/app/components/shared/types.ts
@@ -45,6 +45,18 @@ export interface MikeDocument {
   latest_version_number?: number | null;
 }
 
+export interface TabularReviewRow {
+  id: string;
+  review_id: string;
+  label: string;
+  row_type: "document" | "folder";
+  folder_id: string | null;
+  document_id: string | null;
+  sort_index: number;
+  source_document_ids: string[];
+  created_at?: string | null;
+}
+
 export interface StructureNode {
   id: string;
   title: string;
@@ -247,6 +259,7 @@ export interface TabularReview {
   columns_config: ColumnConfig[] | null;
   workflow_id: string | null;
   practice?: string | null;
+  document_grouping: "document" | "folder";
   /** Per-review email list. Used so standalone (project_id null) reviews can be shared directly. */
   shared_with?: string[];
   /** Server-set: true when the requesting user is the review's creator. */
@@ -259,7 +272,8 @@ export interface TabularReview {
 export interface TabularCell {
   id: string;
   review_id: string;
-  document_id: string;
+  row_id?: string | null;
+  document_id?: string | null;
   column_index: number;
   content: {
     summary: string;
@@ -298,4 +312,5 @@ export interface TabularReviewDetailOut {
   review: TabularReview;
   cells: TabularCell[];
   documents: MikeDocument[];
+  rows: TabularReviewRow[];
 }

--- a/frontend/src/app/components/tabular/AddNewTRModal.tsx
+++ b/frontend/src/app/components/tabular/AddNewTRModal.tsx
@@ -23,6 +23,7 @@ interface Props {
         projectId?: string,
         documentIds?: string[],
         columnsConfig?: MikeWorkflow["columns_config"],
+        documentGrouping?: "document" | "folder",
     ) => void;
     projects?: MikeProject[];
     /** When provided, skip the project/directory picker and show only these docs */
@@ -60,6 +61,7 @@ export function AddNewTRModal({
     const [selectedDocIds, setSelectedDocIds] = useState<Set<string>>(
         new Set(),
     );
+    const [groupBySubfolder, setGroupBySubfolder] = useState(false);
     const [uploading, setUploading] = useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -124,6 +126,7 @@ export function AddNewTRModal({
         setStandaloneDocs([]);
         setDirectoryProjects([]);
         setSelectedDocIds(new Set());
+        setGroupBySubfolder(false);
         setSelectedWorkflowId(null);
         setWorkflowDropdownOpen(false);
         onClose();
@@ -141,6 +144,9 @@ export function AddNewTRModal({
             underProject ? selectedProjectId : undefined,
             selectedDocIds.size > 0 ? [...selectedDocIds] : undefined,
             selectedWorkflow?.columns_config ?? undefined,
+            groupBySubfolder && (isProjectMode || underProject)
+                ? "folder"
+                : "document",
         );
         handleClose();
     }
@@ -476,6 +482,20 @@ export function AddNewTRModal({
                                     />
                                 </div>
                             </div>
+                        )}
+
+                        {(isProjectMode || underProject) && (
+                            <label className="flex items-center gap-2.5 text-sm text-gray-600">
+                                <input
+                                    type="checkbox"
+                                    checked={groupBySubfolder}
+                                    onChange={(e) =>
+                                        setGroupBySubfolder(e.target.checked)
+                                    }
+                                    className="h-3.5 w-3.5 rounded border-gray-300 accent-gray-900"
+                                />
+                                Treat documents in the same project subfolder as one review row
+                            </label>
                         )}
                     </div>
 

--- a/frontend/src/app/components/tabular/TRSidePanel.tsx
+++ b/frontend/src/app/components/tabular/TRSidePanel.tsx
@@ -31,6 +31,7 @@ function isDocxDocument(d: {
 interface Props {
     cell: TabularCell;
     document: MikeDocument;
+    documents?: MikeDocument[];
     column: ColumnConfig;
     columns: ColumnConfig[];
     onClose: () => void;
@@ -42,6 +43,7 @@ interface Props {
     citationQuote?: string;
     /** Page to scroll to when opening document panel */
     citationPage?: number;
+    citationDocumentId?: string;
 }
 
 const FLAG_BADGE: Record<string, string> = {
@@ -58,6 +60,7 @@ const FLAG_BADGE: Record<string, string> = {
 export function TRSidePanel({
     cell,
     document: doc,
+    documents = [doc],
     column,
     columns,
     onClose,
@@ -66,6 +69,7 @@ export function TRSidePanel({
     displayDocument = false,
     citationQuote,
     citationPage,
+    citationDocumentId,
 }: Props) {
     const sortedColumns = [...columns].sort((a, b) => a.index - b.index);
     const currentPos = sortedColumns.findIndex((c) => c.index === column.index);
@@ -81,22 +85,26 @@ export function TRSidePanel({
 
     // Internal state — initialised from props, also toggled by badge clicks inside the panel
     const [docCitation, setDocCitation] = useState<
-        { quote: string; page: number } | undefined
+        { quote: string; page: number; documentId?: string } | undefined
     >(
         displayDocument && citationQuote
-            ? { quote: citationQuote, page: citationPage ?? 1 }
+            ? { quote: citationQuote, page: citationPage ?? 1, documentId: citationDocumentId }
             : undefined,
     );
+    const displayDoc =
+        (docCitation?.documentId
+            ? documents.find((candidate) => candidate.id === docCitation.documentId)
+            : null) ?? doc;
 
     // Re-sync when the panel opens for a different cell or citation
     useEffect(() => {
         setDocCitation(
             displayDocument && citationQuote
-                ? { quote: citationQuote, page: citationPage ?? 1 }
+                ? { quote: citationQuote, page: citationPage ?? 1, documentId: citationDocumentId }
                 : undefined,
         );
         setQuoteExpanded(false);
-    }, [cell.id, displayDocument, citationQuote, citationPage]);
+    }, [cell.id, displayDocument, citationQuote, citationPage, citationDocumentId]);
 
     useEffect(() => {
         const el = quoteParagraphRef.current;
@@ -129,9 +137,9 @@ export function TRSidePanel({
                     <div className="flex items-center gap-2 pt-3 shrink-0 border-b border-white/30">
                         <p
                             className="flex-1 truncate text-sm font-semibold font-sans text-slate-700 font-serif"
-                            title={doc.filename}
+                            title={displayDoc.filename}
                         >
-                            {doc.filename}
+                            {displayDoc.filename}
                         </p>
                         <button
                             onClick={() => setDocCitation(undefined)}
@@ -167,9 +175,9 @@ export function TRSidePanel({
                             </div>
                         </div>
                     )}
-                    {isDocxDocument(doc) && !doc.pdf_storage_path ? (
+                    {isDocxDocument(displayDoc) && !displayDoc.pdf_storage_path ? (
                         <DocxView
-                            documentId={doc.id}
+                            documentId={displayDoc.id}
                             quotes={[
                                 {
                                     page: docCitation.page,
@@ -179,7 +187,7 @@ export function TRSidePanel({
                         />
                     ) : (
                         <DocView
-                            doc={{ document_id: doc.id }}
+                            doc={{ document_id: displayDoc.id }}
                             quote={docCitation.quote}
                             fallbackPage={docCitation.page}
                         />
@@ -278,11 +286,18 @@ export function TRSidePanel({
                                 Results
                             </h4>
                             <div className="text-xs leading-relaxed text-slate-600">
-                                <MarkdownContent
-                                    citations={summaryCitations}
-                                    onCitationClick={setDocCitation}
-                                    column={column}
-                                >
+                                    <MarkdownContent
+                                        citations={summaryCitations}
+                                        onCitationClick={(citation) => {
+                                            if (
+                                                documents.length > 1 &&
+                                                !citation.documentId
+                                            )
+                                                return;
+                                            setDocCitation(citation);
+                                        }}
+                                        column={column}
+                                    >
                                     {summaryText || "—"}
                                 </MarkdownContent>
                             </div>
@@ -297,7 +312,14 @@ export function TRSidePanel({
                                 <div className="text-xs leading-relaxed text-slate-600">
                                     <MarkdownContent
                                         citations={reasoningCitations}
-                                        onCitationClick={setDocCitation}
+                                        onCitationClick={(citation) => {
+                                            if (
+                                                documents.length > 1 &&
+                                                !citation.documentId
+                                            )
+                                                return;
+                                            setDocCitation(citation);
+                                        }}
                                         citationOffset={summaryCitations.length}
                                         column={column}
                                         inline
@@ -325,7 +347,7 @@ function CitationBadge({
 }: {
     index: number;
     citation: ParsedCitation;
-    onClick: (c: { quote: string; page: number }) => void;
+    onClick: (c: { quote: string; page: number; documentId?: string }) => void;
 }) {
     return (
         <button
@@ -334,7 +356,11 @@ function CitationBadge({
             data-quote={citation.quote}
             title={`Page ${citation.page}: "${citation.quote}"`}
             onClick={() =>
-                onClick({ quote: citation.quote, page: citation.page })
+                onClick({
+                    quote: citation.quote,
+                    page: citation.page,
+                    documentId: citation.documentId,
+                })
             }
             className="inline-flex items-center justify-center rounded-full bg-gray-200 w-3.5 h-3.5 text-[9px] font-medium text-gray-700 align-super cursor-pointer hover:bg-gray-300 transition-colors"
         >
@@ -353,7 +379,7 @@ function MarkdownContent({
 }: {
     children: string;
     citations: ParsedCitation[];
-    onCitationClick: (c: { quote: string; page: number }) => void;
+    onCitationClick: (c: { quote: string; page: number; documentId?: string }) => void;
     inline?: boolean;
     citationOffset?: number;
     column?: ColumnConfig;

--- a/frontend/src/app/components/tabular/TRTable.tsx
+++ b/frontend/src/app/components/tabular/TRTable.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { forwardRef, useImperativeHandle, useRef } from "react";
-import { Plus, Table2 } from "lucide-react";
-import type { ColumnConfig, MikeDocument, TabularCell } from "../shared/types";
+import { AlertCircle, Plus, Table2 } from "lucide-react";
+import type { ColumnConfig, TabularCell, TabularReviewRow } from "../shared/types";
 import { TabularCell as TabularCellComponent } from "./TabularCell";
 import { TREditColumnMenu } from "./TREditColumnMenu";
 
@@ -25,15 +25,15 @@ export interface TRTableHandle {
 interface Props {
     loading: boolean;
     columns: ColumnConfig[];
-    documents: MikeDocument[];
+    rows: TabularReviewRow[];
     cells: TabularCell[];
     savingColumn: boolean;
     savingColumnsConfig: boolean;
-    selectedDocIds: string[];
+    selectedRowIds: string[];
     highlightedCell?: { colIdx: number; rowIdx: number } | null;
     onSelectionChange: (ids: string[]) => void;
     onExpand: (cell: TabularCell) => void;
-    onCitationClick: (cell: TabularCell, page: number, quote: string) => void;
+    onCitationClick: (cell: TabularCell, page: number, quote: string, documentId?: string) => void;
     onUpdateColumn: (col: ColumnConfig) => void;
     onDeleteColumn: (colIndex: number) => void;
     onAddColumn: () => void;
@@ -44,11 +44,11 @@ export const TRTable = forwardRef<TRTableHandle, Props>(function TRTable(
     {
         loading,
         columns,
-        documents,
+        rows,
         cells,
         savingColumn,
         savingColumnsConfig,
-        selectedDocIds,
+        selectedRowIds,
         highlightedCell,
         onSelectionChange,
         onExpand,
@@ -92,31 +92,31 @@ export const TRTable = forwardRef<TRTableHandle, Props>(function TRTable(
         },
     }));
 
-    function getCell(docId: string, colIdx: number) {
+    function getCell(rowId: string, colIdx: number) {
         return cells.find(
-            (c) => c.document_id === docId && c.column_index === colIdx,
+            (c) => (c.row_id ?? c.document_id) === rowId && c.column_index === colIdx,
         );
     }
 
     const allSelected =
-        documents.length > 0 &&
-        documents.every((d) => selectedDocIds.includes(d.id));
+        rows.length > 0 &&
+        rows.every((row) => selectedRowIds.includes(row.id));
     const someSelected =
-        !allSelected && documents.some((d) => selectedDocIds.includes(d.id));
+        !allSelected && rows.some((row) => selectedRowIds.includes(row.id));
 
     function toggleAll() {
         if (allSelected) {
             onSelectionChange([]);
         } else {
-            onSelectionChange(documents.map((d) => d.id));
+            onSelectionChange(rows.map((row) => row.id));
         }
     }
 
-    function toggleDoc(id: string) {
-        if (selectedDocIds.includes(id)) {
-            onSelectionChange(selectedDocIds.filter((x) => x !== id));
+    function toggleRow(id: string) {
+        if (selectedRowIds.includes(id)) {
+            onSelectionChange(selectedRowIds.filter((x) => x !== id));
         } else {
-            onSelectionChange([...selectedDocIds, id]);
+            onSelectionChange([...selectedRowIds, id]);
         }
     }
 
@@ -165,7 +165,7 @@ export const TRTable = forwardRef<TRTableHandle, Props>(function TRTable(
         );
     }
 
-    if (columns.length === 0 && documents.length === 0) {
+    if (columns.length === 0 && rows.length === 0) {
         return (
             <div className="flex flex-1 flex-col overflow-hidden">
                 <div className="flex items-center border-b border-gray-200">
@@ -258,15 +258,24 @@ export const TRTable = forwardRef<TRTableHandle, Props>(function TRTable(
             </div>
 
             {/* Rows */}
-            {documents.map((doc, docIdx) => {
-                const rowBg = selectedDocIds.includes(doc.id)
+            {rows.map((row, rowIdx) => {
+                const sourceCount = row.source_document_ids?.length ?? 0;
+                const rowBg = selectedRowIds.includes(row.id)
                     ? "bg-gray-100"
-                    : docIdx % 2 === 0
+                    : rowIdx % 2 === 0
                       ? "bg-white"
                       : "bg-gray-50";
+
+                // Detect page-limit error: all cells for this row are errors
+                // with a "Not processed" summary (page limit hit).
+                const rowCells = columns.map((col) => getCell(row.id, col.index)).filter(Boolean);
+                const pageLimitMessage = rowCells.length > 0 && rowCells.every(
+                    (c) => c!.status === "error" && c!.content?.summary?.startsWith("Not processed:"),
+                ) ? rowCells[0]!.content!.summary : null;
+
                 return (
                     <div
-                        key={doc.id}
+                        key={row.id}
                         className={`flex ${rowBg}`}
                         style={{ minWidth: totalContentWidth }}
                     >
@@ -275,49 +284,66 @@ export const TRTable = forwardRef<TRTableHandle, Props>(function TRTable(
                         >
                             <input
                                 type="checkbox"
-                                checked={selectedDocIds.includes(doc.id)}
-                                onChange={() => toggleDoc(doc.id)}
+                                checked={selectedRowIds.includes(row.id)}
+                                onChange={() => toggleRow(row.id)}
                                 className="h-2.5 w-2.5 shrink-0 rounded border-gray-200 cursor-pointer accent-black"
                             />
                         </div>
                         <div
                             className={`sticky left-8 z-[60] ${COL_W} border-b border-r border-gray-200 p-2 text-xs text-gray-800 flex items-center ${rowBg}`}
                         >
-                            <span className="line-clamp-1" title={doc.filename}>
-                                {doc.filename}
-                            </span>
+                            <div className="min-w-0">
+                                <span className="line-clamp-1" title={row.label}>
+                                    {row.label}
+                                </span>
+                                {row.row_type === "folder" && (
+                                    <span className="block text-[10px] text-gray-400">
+                                        {sourceCount} documents
+                                    </span>
+                                )}
+                            </div>
                         </div>
-                        {columns.map((col) => {
-                            const cell = getCell(doc.id, col.index);
-                            const colPos = sortedColumns.findIndex(
-                                (c) => c.index === col.index,
-                            );
-                            const isHighlighted =
-                                highlightedCell?.colIdx === colPos &&
-                                highlightedCell?.rowIdx === docIdx;
-                            return (
-                                <div
-                                    key={col.index}
-                                    className={`${COL_W} border-b border-r border-gray-200 transition-colors ${isHighlighted ? "bg-blue-200" : ""}`}
-                                >
-                                    {cell && (
-                                        <TabularCellComponent
-                                            cell={cell}
-                                            column={col}
-                                            onExpand={() => onExpand(cell)}
-                                            onCitationClick={(page, quote) =>
-                                                onCitationClick(
-                                                    cell,
-                                                    page,
-                                                    quote,
-                                                )
-                                            }
-                                        />
-                                    )}
-                                </div>
-                            );
-                        })}
-                        <div className="flex-1 border-b border-gray-200 min-h-8 min-w-8" />
+                        {pageLimitMessage ? (
+                            <div className="flex-1 border-b border-gray-200 flex items-center gap-2 px-3 min-h-10">
+                                <AlertCircle className="h-3.5 w-3.5 shrink-0 text-red-400" />
+                                <span className="text-xs text-red-500">{pageLimitMessage}</span>
+                            </div>
+                        ) : (
+                            <>
+                                {columns.map((col) => {
+                                    const cell = getCell(row.id, col.index);
+                                    const colPos = sortedColumns.findIndex(
+                                        (c) => c.index === col.index,
+                                    );
+                                    const isHighlighted =
+                                        highlightedCell?.colIdx === colPos &&
+                                        highlightedCell?.rowIdx === rowIdx;
+                                    return (
+                                        <div
+                                            key={col.index}
+                                            className={`${COL_W} border-b border-r border-gray-200 transition-colors ${isHighlighted ? "bg-blue-200" : ""}`}
+                                        >
+                                            {cell && (
+                                                <TabularCellComponent
+                                                    cell={cell}
+                                                    column={col}
+                                                    onExpand={() => onExpand(cell)}
+                                                    onCitationClick={(page, quote, documentId) =>
+                                                        onCitationClick(
+                                                            cell,
+                                                            page,
+                                                            quote,
+                                                            documentId,
+                                                        )
+                                                    }
+                                                />
+                                            )}
+                                        </div>
+                                    );
+                                })}
+                                <div className="flex-1 border-b border-gray-200 min-h-8 min-w-8" />
+                            </>
+                        )}
                     </div>
                 );
             })}

--- a/frontend/src/app/components/tabular/TabularCell.tsx
+++ b/frontend/src/app/components/tabular/TabularCell.tsx
@@ -12,7 +12,7 @@ interface Props {
     cell: TCell;
     column?: ColumnConfig;
     onExpand: () => void;
-    onCitationClick?: (page: number, quote: string) => void;
+    onCitationClick?: (page: number, quote: string, documentId?: string) => void;
 }
 
 const FLAG_STYLES = {
@@ -53,7 +53,7 @@ function CellMarkdown({
     citations: ParsedCitation[];
     pills: string[];
     column?: ColumnConfig;
-    onCitationClick?: (page: number, quote: string) => void;
+    onCitationClick?: (page: number, quote: string, documentId?: string) => void;
     onExpand: () => void;
     inline?: boolean;
 }) {
@@ -105,6 +105,7 @@ function CellMarkdown({
                                             onCitationClick(
                                                 citation.page,
                                                 citation.quote,
+                                                citation.documentId,
                                             );
                                         } else {
                                             onExpand();
@@ -179,8 +180,9 @@ export function TabularCell({
     }
 
     if (cell.status === "error") {
+        const errorMsg = cell.content?.summary || "Generation failed";
         return (
-            <div className="h-10 flex items-center justify-center text-gray-300">
+            <div className="h-10 flex items-center justify-center text-gray-300" title={errorMsg}>
                 <AlertCircle className="h-4 w-4 text-red-300" />
             </div>
         );
@@ -197,9 +199,9 @@ export function TabularCell({
     const firstLine = processed.split("\n").find((l) => l.trim()) ?? processed;
     const collapsedDisplay = firstLine.replace(/^[-*•]\s+/, "");
 
-    function handleCitationClickInOverlay(page: number, quote: string) {
+    function handleCitationClickInOverlay(page: number, quote: string, documentId?: string) {
         setInlineExpanded(false);
-        onCitationClick?.(page, quote);
+        onCitationClick?.(page, quote, documentId);
     }
 
     function handleSeeDetails() {

--- a/frontend/src/app/components/tabular/TabularReviewView.tsx
+++ b/frontend/src/app/components/tabular/TabularReviewView.tsx
@@ -20,6 +20,7 @@ import type {
     MikeProject,
     TabularCell,
     TabularReview,
+    TabularReviewRow,
 } from "../shared/types";
 import { AddColumnModal } from "./AddColumnModal";
 import { AddDocumentsModal } from "../shared/AddDocumentsModal";
@@ -53,6 +54,7 @@ export function TRView({ reviewId, projectId }: Props) {
     const [project, setProject] = useState<MikeProject | null>(null);
     const [cells, setCells] = useState<TabularCell[]>([]);
     const [documents, setDocuments] = useState<MikeDocument[]>([]);
+    const [rows, setRows] = useState<TabularReviewRow[]>([]);
     const [columns, setColumns] = useState<ColumnConfig[]>([]);
     const [loading, setLoading] = useState(true);
     const [generating, setGenerating] = useState(false);
@@ -65,9 +67,9 @@ export function TRView({ reviewId, projectId }: Props) {
     const { user } = useAuth();
     const [expandedCell, setExpandedCell] = useState<TabularCell | null>(null);
     const [expandedCellCitation, setExpandedCellCitation] = useState<
-        { quote: string; page: number } | undefined
+        { quote: string; page: number; documentId?: string } | undefined
     >(undefined);
-    const [selectedDocIds, setSelectedDocIds] = useState<string[]>([]);
+    const [selectedRowIds, setSelectedRowIds] = useState<string[]>([]);
     const [actionsOpen, setActionsOpen] = useState(false);
     const [search, setSearch] = useState("");
     const searchParams = useSearchParams();
@@ -118,10 +120,11 @@ export function TRView({ reviewId, projectId }: Props) {
 
     useEffect(() => {
         const fetches: Promise<unknown>[] = [
-            getTabularReview(reviewId).then(({ review, cells, documents }) => {
+            getTabularReview(reviewId).then(({ review, cells, documents, rows }) => {
                 setReview(review);
                 setCells(cells);
                 setDocuments(documents);
+                setRows(rows);
                 setColumns(review.columns_config || []);
             }),
         ];
@@ -146,10 +149,13 @@ export function TRView({ reviewId, projectId }: Props) {
         try {
             const updated = await updateTabularReview(reviewId, {
                 columns_config: nextColumns,
-                document_ids: documents.map((document) => document.id),
             });
             setReview(updated);
             setColumns(updated.columns_config || nextColumns);
+            const refreshed = await getTabularReview(reviewId);
+            setCells(refreshed.cells);
+            setDocuments(refreshed.documents);
+            setRows(refreshed.rows);
         } finally {
             setSavingColumnsConfig(false);
         }
@@ -169,29 +175,17 @@ export function TRView({ reviewId, projectId }: Props) {
             document_ids: allIds,
             columns_config: columns,
         });
-        setDocuments((prev) => [...prev, ...toAdd]);
-        if (columns.length > 0) {
-            setCells((prev) => [
-                ...prev,
-                ...toAdd.flatMap((doc) =>
-                    columns.map((col) => ({
-                        id: `new-${doc.id}-${col.index}`,
-                        review_id: reviewId,
-                        document_id: doc.id,
-                        column_index: col.index,
-                        content: null,
-                        status: "pending" as const,
-                        created_at: new Date().toISOString(),
-                    })),
-                ),
-            ]);
-        }
+        const refreshed = await getTabularReview(reviewId);
+        setReview(refreshed.review);
+        setCells(refreshed.cells);
+        setDocuments(refreshed.documents);
+        setRows(refreshed.rows);
     }
 
-    async function handleRegenerateCell(docId: string, colIndex: number) {
+    async function handleRegenerateCell(rowId: string, colIndex: number) {
         setCells((prev) =>
             prev.map((c) =>
-                c.document_id === docId && c.column_index === colIndex
+                (c.row_id ?? c.document_id) === rowId && c.column_index === colIndex
                     ? { ...c, status: "generating" as const, content: null }
                     : c,
             ),
@@ -204,12 +198,12 @@ export function TRView({ reviewId, projectId }: Props) {
         try {
             const result = await regenerateTabularCell(
                 reviewId,
-                docId,
+                rowId,
                 colIndex,
             );
             setCells((prev) =>
                 prev.map((c) =>
-                    c.document_id === docId && c.column_index === colIndex
+                    (c.row_id ?? c.document_id) === rowId && c.column_index === colIndex
                         ? { ...c, status: "done" as const, content: result }
                         : c,
                 ),
@@ -223,7 +217,7 @@ export function TRView({ reviewId, projectId }: Props) {
             console.error("Regeneration failed", err);
             setCells((prev) =>
                 prev.map((c) =>
-                    c.document_id === docId && c.column_index === colIndex
+                    (c.row_id ?? c.document_id) === rowId && c.column_index === colIndex
                         ? { ...c, status: "error" as const }
                         : c,
                 ),
@@ -249,11 +243,11 @@ export function TRView({ reviewId, projectId }: Props) {
 
         // Optimistically set empty/pending/error cells to generating (skip done cells)
         setCells((prev) =>
-            documents.flatMap((doc) =>
+            rows.flatMap((row) =>
                 columns.map((col) => {
                     const existing = prev.find(
                         (c) =>
-                            c.document_id === doc.id &&
+                            (c.row_id ?? c.document_id) === row.id &&
                             c.column_index === col.index,
                     );
                     if (existing?.status === "done" && existing?.content) {
@@ -266,9 +260,10 @@ export function TRView({ reviewId, projectId }: Props) {
                               content: null,
                           }
                         : {
-                              id: `${doc.id}-${col.index}`,
+                              id: `${row.id}-${col.index}`,
                               review_id: reviewId,
-                              document_id: doc.id,
+                              row_id: row.id,
+                              document_id: row.document_id,
                               column_index: col.index,
                               content: null,
                               status: "generating" as const,
@@ -302,7 +297,8 @@ export function TRView({ reviewId, projectId }: Props) {
                         if (data.type === "cell_update") {
                             setCells((prev) =>
                                 prev.map((c) =>
-                                    c.document_id === data.document_id &&
+                                    (c.row_id ?? c.document_id) ===
+                                        (data.row_id ?? data.document_id) &&
                                     c.column_index === data.column_index
                                         ? {
                                               ...c,
@@ -334,31 +330,32 @@ export function TRView({ reviewId, projectId }: Props) {
         setColumns(newCols);
         setCells((prev) => [
             ...prev,
-            ...documents
-                .filter((doc) =>
+            ...rows
+                .filter((row) =>
                     normalizedColumns.some(
                         (column) =>
                             !prev.some(
                                 (cell) =>
-                                    cell.document_id === doc.id &&
+                                    (cell.row_id ?? cell.document_id) === row.id &&
                                     cell.column_index === column.index,
                             ),
                     ),
                 )
-                .flatMap((doc) =>
+                .flatMap((row) =>
                     normalizedColumns
                         .filter(
                             (column) =>
                                 !prev.some(
                                     (cell) =>
-                                        cell.document_id === doc.id &&
+                                        (cell.row_id ?? cell.document_id) === row.id &&
                                         cell.column_index === column.index,
                                 ),
                         )
                         .map((column) => ({
-                            id: `new-${doc.id}-${column.index}`,
+                            id: `new-${row.id}-${column.index}`,
                             review_id: reviewId,
-                            document_id: doc.id,
+                            row_id: row.id,
+                            document_id: row.document_id,
                             column_index: column.index,
                             content: null,
                             status: "pending" as const,
@@ -422,34 +419,42 @@ export function TRView({ reviewId, projectId }: Props) {
     }
 
     async function handleDeleteDocuments() {
+        const removedDocIds = rows
+            .filter((row) => selectedRowIds.includes(row.id))
+            .flatMap((row) => row.source_document_ids);
         const remaining = documents.filter(
-            (d) => !selectedDocIds.includes(d.id),
+            (d) => !removedDocIds.includes(d.id),
         );
         setDocuments(remaining);
+        setRows((prev) => prev.filter((row) => !selectedRowIds.includes(row.id)));
         setCells((prev) =>
-            prev.filter((c) => !selectedDocIds.includes(c.document_id)),
+            prev.filter((c) => !selectedRowIds.includes(c.row_id ?? c.document_id ?? "")),
         );
-        setSelectedDocIds([]);
+        setSelectedRowIds([]);
         setActionsOpen(false);
         await updateTabularReview(reviewId, {
             document_ids: remaining.map((d) => d.id),
             columns_config: columns,
         });
+        const refreshed = await getTabularReview(reviewId);
+        setCells(refreshed.cells);
+        setDocuments(refreshed.documents);
+        setRows(refreshed.rows);
     }
 
     async function handleClearResults() {
-        const docIds = [...selectedDocIds];
-        if (docIds.length === 0) return;
+        const rowIds = [...selectedRowIds];
+        if (rowIds.length === 0) return;
         setCells((prev) =>
             prev.map((c) =>
-                docIds.includes(c.document_id)
+                rowIds.includes(c.row_id ?? c.document_id ?? "")
                     ? { ...c, content: null, status: "pending" }
                     : c,
             ),
         );
-        setSelectedDocIds([]);
+        setSelectedRowIds([]);
         setActionsOpen(false);
-        await clearTabularCells(reviewId, docIds);
+        await clearTabularCells(reviewId, rowIds);
     }
 
     async function handleTitleCommit(newTitle: string) {
@@ -459,9 +464,9 @@ export function TRView({ reviewId, projectId }: Props) {
     }
 
     const q = search.toLowerCase();
-    const filteredDocuments = q
-        ? documents.filter((d) => d.filename.toLowerCase().includes(q))
-        : documents;
+    const filteredRows = q
+        ? rows.filter((row) => row.label.toLowerCase().includes(q))
+        : rows;
 
     return (
         <div className="flex h-full overflow-hidden bg-white">
@@ -551,14 +556,14 @@ export function TRView({ reviewId, projectId }: Props) {
                                     exportTabularReviewToExcel({
                                         reviewTitle: review?.title || "Tabular Review",
                                         columns,
-                                        documents,
+                                        rows,
                                         cells,
                                     })
                                 }
-                                disabled={columns.length === 0 || documents.length === 0}
+                                disabled={columns.length === 0 || rows.length === 0}
                                 title="Export to Excel"
                                 className={`flex h-8 items-center justify-center gap-1.5 px-3 text-sm transition-colors ${
-                                    columns.length === 0 || documents.length === 0
+                                    columns.length === 0 || rows.length === 0
                                         ? "text-gray-300 cursor-default"
                                         : "text-gray-700 hover:text-gray-900 cursor-pointer"
                                 }`}
@@ -571,13 +576,13 @@ export function TRView({ reviewId, projectId }: Props) {
                                 disabled={
                                     generating ||
                                     columns.length === 0 ||
-                                    documents.length === 0 ||
+                                    rows.length === 0 ||
                                     savingColumnsConfig
                                 }
                                 className={`flex h-8 items-center justify-center gap-1.5 px-3 text-sm transition-colors ${
                                     generating ||
                                     columns.length === 0 ||
-                                    documents.length === 0 ||
+                                    rows.length === 0 ||
                                     savingColumnsConfig
                                         ? "text-gray-300 cursor-default"
                                         : "text-gray-700 hover:text-gray-900 cursor-pointer"
@@ -602,9 +607,9 @@ export function TRView({ reviewId, projectId }: Props) {
                             if (chatOpen) setSelectedChatId(null);
                             setChatOpen((v) => !v);
                         }}
-                        disabled={loading || columns.length === 0 || documents.length === 0}
+                        disabled={loading || columns.length === 0 || rows.length === 0}
                         className={`flex items-center gap-1 text-xs font-medium transition-colors ${
-                            loading || columns.length === 0 || documents.length === 0
+                            loading || columns.length === 0 || rows.length === 0
                                 ? "text-gray-300 cursor-default"
                                 : "text-gray-700 hover:text-gray-900"
                         }`}
@@ -613,7 +618,7 @@ export function TRView({ reviewId, projectId }: Props) {
                         Assistant in Tabular Review
                     </button>
                     <div className="ml-auto flex items-center gap-4">
-                        {selectedDocIds.length > 0 && (
+                        {selectedRowIds.length > 0 && (
                             <div ref={actionsRef} className="relative">
                                 <button
                                     onClick={() => setActionsOpen((v) => !v)}
@@ -691,20 +696,26 @@ export function TRView({ reviewId, projectId }: Props) {
                         ref={tableRef}
                         loading={loading}
                         columns={columns}
-                        documents={filteredDocuments}
+                        rows={filteredRows}
                         cells={cells}
                         highlightedCell={highlightedCell}
                         savingColumn={savingColumn}
                         savingColumnsConfig={savingColumnsConfig}
-                        selectedDocIds={selectedDocIds}
-                        onSelectionChange={setSelectedDocIds}
+                        selectedRowIds={selectedRowIds}
+                        onSelectionChange={setSelectedRowIds}
                         onExpand={(cell) => {
                             setExpandedCell(cell);
                             setExpandedCellCitation(undefined);
                         }}
-                        onCitationClick={(cell, page, quote) => {
+                        onCitationClick={(cell, page, quote, documentId) => {
+                            const rowId = cell.row_id ?? cell.document_id ?? "";
+                            const row = rows.find((candidate) => candidate.id === rowId);
                             setExpandedCell(cell);
-                            setExpandedCellCitation({ quote, page });
+                            if (row?.row_type === "folder" && !documentId) {
+                                setExpandedCellCitation(undefined);
+                                return;
+                            }
+                            setExpandedCellCitation({ quote, page, documentId });
                         }}
                         onUpdateColumn={handleUpdateColumn}
                         onDeleteColumn={handleDeleteColumn}
@@ -717,9 +728,22 @@ export function TRView({ reviewId, projectId }: Props) {
             {/* Cell detail side panel */}
             {expandedCell &&
                 (() => {
-                    const expandedDoc = documents.find(
-                        (d) => d.id === expandedCell.document_id,
+                    const expandedRowId = expandedCell.row_id ?? expandedCell.document_id ?? "";
+                    const expandedRow = rows.find((row) => row.id === expandedRowId);
+                    const sourceDocIds =
+                        expandedRow?.source_document_ids ??
+                        (expandedCell.document_id ? [expandedCell.document_id] : []);
+                    const sourceDocs = documents.filter((d) =>
+                        sourceDocIds.includes(d.id),
                     );
+                    const expandedDoc =
+                        (expandedCellCitation?.documentId
+                            ? sourceDocs.find(
+                                  (d) => d.id === expandedCellCitation.documentId,
+                              )
+                            : null) ??
+                        sourceDocs[0] ??
+                        documents.find((d) => d.id === expandedCell.document_id);
                     const expandedCol = columns.find(
                         (c) => c.index === expandedCell.column_index,
                     );
@@ -728,6 +752,7 @@ export function TRView({ reviewId, projectId }: Props) {
                         <TRSidePanel
                             cell={expandedCell}
                             document={expandedDoc}
+                            documents={sourceDocs.length ? sourceDocs : documents}
                             column={expandedCol}
                             columns={columns}
                             onClose={() => {
@@ -737,8 +762,8 @@ export function TRView({ reviewId, projectId }: Props) {
                             onNavigate={(columnIndex) => {
                                 const nextCell = cells.find(
                                     (c) =>
-                                        c.document_id ===
-                                            expandedCell.document_id &&
+                                        (c.row_id ?? c.document_id) ===
+                                            expandedRowId &&
                                         c.column_index === columnIndex,
                                 );
                                 if (nextCell) {
@@ -748,13 +773,14 @@ export function TRView({ reviewId, projectId }: Props) {
                             }}
                             onRegenerate={() =>
                                 handleRegenerateCell(
-                                    expandedCell.document_id,
+                                    expandedRowId,
                                     expandedCell.column_index,
                                 )
                             }
                             displayDocument={expandedCellCitation !== undefined}
                             citationQuote={expandedCellCitation?.quote}
                             citationPage={expandedCellCitation?.page}
+                            citationDocumentId={expandedCellCitation?.documentId}
                         />
                     );
                 })()}

--- a/frontend/src/app/components/tabular/citation-utils.ts
+++ b/frontend/src/app/components/tabular/citation-utils.ts
@@ -1,8 +1,9 @@
 "use client";
 
-const PAGE_CITATION_RE = /\[\[page:(\d+)\|\|(?:quote:)?((?:[^\[\]]|\[[^\]]*\])+)\]\]/gi;
+const PAGE_CITATION_RE = /\[\[(?:doc_id:([^|\]]+)\|\|)?page:(\d+)\|\|(?:quote:)?((?:[^\[\]]|\[[^\]]*\])+)\]\]/gi;
 
 export interface ParsedCitation {
+    documentId?: string;
     page: number;
     quote: string;
 }
@@ -17,9 +18,13 @@ export function preprocessCitations(text: string): {
 } {
     const citations: ParsedCitation[] = [];
     PAGE_CITATION_RE.lastIndex = 0;
-    const processed = text.replace(PAGE_CITATION_RE, (_, page, quote) => {
+    const processed = text.replace(PAGE_CITATION_RE, (_, documentId, page, quote) => {
         const idx = citations.length;
-        citations.push({ page: parseInt(page, 10), quote: quote.trim() });
+        citations.push({
+            documentId: typeof documentId === "string" ? documentId.trim() : undefined,
+            page: parseInt(page, 10),
+            quote: quote.trim(),
+        });
         return `§${idx}§`;
     });
     return { processed, citations };

--- a/frontend/src/app/components/tabular/exportToExcel.ts
+++ b/frontend/src/app/components/tabular/exportToExcel.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import ExcelJS from "exceljs";
-import type { ColumnConfig, MikeDocument, TabularCell } from "../shared/types";
+import type { ColumnConfig, TabularCell, TabularReviewRow } from "../shared/types";
 import { preprocessCitations } from "./citation-utils";
 
 function formatCellForExport(cell: TabularCell | undefined): string {
@@ -31,20 +31,23 @@ function sanitizeFilename(name: string): string {
 export async function exportTabularReviewToExcel(params: {
     reviewTitle: string;
     columns: ColumnConfig[];
-    documents: MikeDocument[];
+    rows: TabularReviewRow[];
     cells: TabularCell[];
 }) {
-    const { reviewTitle, columns, documents, cells } = params;
+    const { reviewTitle, columns, rows, cells } = params;
 
     const sortedCols = [...columns].sort((a, b) => a.index - b.index);
     const cellMap = new Map<string, TabularCell>();
-    for (const c of cells) cellMap.set(`${c.document_id}:${c.column_index}`, c);
+    for (const c of cells) {
+        const rowId = c.row_id ?? c.document_id;
+        if (rowId) cellMap.set(`${rowId}:${c.column_index}`, c);
+    }
 
     const wb = new ExcelJS.Workbook();
     const ws = wb.addWorksheet("Review");
 
     ws.columns = [
-        { header: "Document", width: 40 },
+        { header: "Document / Group", width: 40 },
         ...sortedCols.map((c) => ({ header: c.name, width: 40 })),
     ];
 
@@ -57,10 +60,10 @@ export async function exportTabularReviewToExcel(params: {
         fgColor: { argb: "FFF3F4F6" },
     };
 
-    for (const doc of documents) {
-        const row: string[] = [doc.filename];
+    for (const reviewRow of rows) {
+        const row: string[] = [reviewRow.label];
         for (const col of sortedCols) {
-            row.push(formatCellForExport(cellMap.get(`${doc.id}:${col.index}`)));
+            row.push(formatCellForExport(cellMap.get(`${reviewRow.id}:${col.index}`)));
         }
         const excelRow = ws.addRow(row);
         excelRow.alignment = { vertical: "top", wrapText: true };

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -105,6 +105,7 @@ export interface UserProfile {
     creditsRemaining: number;
     tier: string;
     tabularModel: string;
+    tabularMaxPages: number;
     apiKeyStatus: ApiKeyStatus;
 }
 
@@ -116,6 +117,7 @@ export async function updateUserProfile(payload: {
     displayName?: string | null;
     organisation?: string | null;
     tabularModel?: string;
+    tabularMaxPages?: number;
 }): Promise<UserProfile> {
     return apiRequest<UserProfile>("/user/profile", {
         method: "PATCH",
@@ -545,6 +547,7 @@ export async function createTabularReview(payload: {
     columns_config: { index: number; name: string; prompt: string }[];
     workflow_id?: string;
     project_id?: string;
+    document_grouping?: "document" | "folder";
 }): Promise<TabularReview> {
     return apiRequest<TabularReview>("/tabular-review", {
         method: "POST",
@@ -566,6 +569,7 @@ export async function updateTabularReview(
         columns_config?: { index: number; name: string; prompt: string }[];
         document_ids?: string[];
         project_id?: string | null;
+        document_grouping?: "document" | "folder";
         shared_with?: string[];
     },
 ): Promise<TabularReview> {
@@ -739,7 +743,7 @@ export async function deleteTabularChat(
 
 export async function regenerateTabularCell(
     reviewId: string,
-    documentId: string,
+    rowId: string,
     columnIndex: number,
 ): Promise<{
     summary: string;
@@ -750,7 +754,7 @@ export async function regenerateTabularCell(
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-            document_id: documentId,
+            row_id: rowId,
             column_index: columnIndex,
         }),
     });
@@ -758,12 +762,12 @@ export async function regenerateTabularCell(
 
 export async function clearTabularCells(
     reviewId: string,
-    documentIds: string[],
+    rowIds: string[],
 ): Promise<void> {
     await apiRequest(`/tabular-review/${reviewId}/clear-cells`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ document_ids: documentIds }),
+        body: JSON.stringify({ row_ids: rowIds }),
     });
 }
 

--- a/frontend/src/contexts/UserProfileContext.tsx
+++ b/frontend/src/contexts/UserProfileContext.tsx
@@ -26,6 +26,7 @@ interface UserProfile {
     creditsRemaining: number;
     tier: string;
     tabularModel: string;
+    tabularMaxPages: number;
     apiKeys: ApiKeyState;
 }
 
@@ -38,6 +39,7 @@ interface UserProfileContextType {
         field: "tabularModel",
         value: string,
     ) => Promise<boolean>;
+    updateTabularMaxPages: (value: number) => Promise<boolean>;
     updateApiKey: (
         provider: ApiKeyProvider,
         value: string | null,
@@ -158,9 +160,23 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
             if (!user) return false;
             if (field !== "tabularModel") return false;
             try {
-                const updated = await updateUserProfile({
-                    tabularModel: value,
-                });
+                const updated = await updateUserProfile({ tabularModel: value });
+                setProfile((prev) =>
+                    prev ? { ...prev, ...toProfile(updated) } : null,
+                );
+                return true;
+            } catch {
+                return false;
+            }
+        },
+        [user],
+    );
+
+    const updateTabularMaxPages = useCallback(
+        async (value: number): Promise<boolean> => {
+            if (!user) return false;
+            try {
+                const updated = await updateUserProfile({ tabularMaxPages: value });
                 setProfile((prev) =>
                     prev ? { ...prev, ...toProfile(updated) } : null,
                 );
@@ -230,6 +246,7 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
                 updateDisplayName,
                 updateOrganisation,
                 updateModelPreference,
+                updateTabularMaxPages,
                 updateApiKey,
                 reloadProfile,
                 incrementMessageCredits,

--- a/supabase/migrations/20240101000000_initial_schema.sql
+++ b/supabase/migrations/20240101000000_initial_schema.sql
@@ -1,0 +1,387 @@
+-- Mike one-shot Supabase schema
+-- Based on supabase-migration.sql plus the later backend/migrations/*.sql files.
+-- Use this for a fresh Supabase database. Existing deployments should continue
+-- to apply the incremental migration files instead.
+
+create extension if not exists "pgcrypto";
+
+-- ---------------------------------------------------------------------------
+-- User profiles
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.user_profiles (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null unique references auth.users(id) on delete cascade,
+  display_name text,
+  organisation text,
+  tier text not null default 'Free',
+  message_credits_used integer not null default 0,
+  credits_reset_date timestamptz not null default (now() + interval '30 days'),
+  tabular_model text not null default 'gemini-3-flash-preview',
+  claude_api_key text,
+  gemini_api_key text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_user_profiles_user
+  on public.user_profiles(user_id);
+
+alter table public.user_profiles enable row level security;
+
+drop policy if exists "Users can view their own profile" on public.user_profiles;
+create policy "Users can view their own profile"
+  on public.user_profiles for select
+  using (auth.uid() = user_id);
+
+drop policy if exists "Users can update their own profile" on public.user_profiles;
+create policy "Users can update their own profile"
+  on public.user_profiles for update
+  using (auth.uid() = user_id);
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.user_profiles (user_id)
+  values (new.id)
+  on conflict (user_id) do nothing;
+  return new;
+exception when others then
+  -- Never block signup if the profile insert fails.
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute procedure public.handle_new_user();
+
+create table if not exists public.user_api_keys (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  provider text not null check (provider in ('claude', 'gemini', 'openai')),
+  encrypted_key text not null,
+  iv text not null,
+  auth_tag text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(user_id, provider)
+);
+
+create index if not exists idx_user_api_keys_user
+  on public.user_api_keys(user_id);
+
+alter table public.user_api_keys enable row level security;
+
+-- ---------------------------------------------------------------------------
+-- Projects and documents
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.projects (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null,
+  name text not null,
+  cm_number text,
+  visibility text not null default 'private',
+  shared_with jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_projects_user
+  on public.projects(user_id);
+
+create index if not exists projects_shared_with_idx
+  on public.projects using gin (shared_with);
+
+create table if not exists public.project_subfolders (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  user_id text not null,
+  name text not null,
+  parent_folder_id uuid references public.project_subfolders(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_project_subfolders_project
+  on public.project_subfolders(project_id);
+
+create table if not exists public.documents (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid references public.projects(id) on delete cascade,
+  user_id text not null,
+  filename text not null,
+  file_type text,
+  size_bytes integer not null default 0,
+  page_count integer,
+  structure_tree jsonb,
+  status text not null default 'pending',
+  folder_id uuid references public.project_subfolders(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_documents_user_project
+  on public.documents(user_id, project_id);
+
+create index if not exists idx_documents_project_folder
+  on public.documents(project_id, folder_id);
+
+create table if not exists public.document_versions (
+  id uuid primary key default gen_random_uuid(),
+  document_id uuid not null references public.documents(id) on delete cascade,
+  storage_path text not null,
+  pdf_storage_path text,
+  source text not null default 'upload',
+  version_number integer,
+  display_name text,
+  created_at timestamptz not null default now(),
+  constraint document_versions_source_check
+    check (source = any (array[
+      'upload'::text,
+      'user_upload'::text,
+      'assistant_edit'::text,
+      'user_accept'::text,
+      'user_reject'::text,
+      'generated'::text
+    ]))
+);
+
+create index if not exists document_versions_document_id_idx
+  on public.document_versions(document_id, created_at desc);
+
+create index if not exists document_versions_doc_vnum_idx
+  on public.document_versions(document_id, version_number);
+
+alter table public.documents
+  add column if not exists current_version_id uuid
+  references public.document_versions(id) on delete set null;
+
+create table if not exists public.document_edits (
+  id uuid primary key default gen_random_uuid(),
+  document_id uuid not null references public.documents(id) on delete cascade,
+  chat_message_id uuid,
+  version_id uuid not null references public.document_versions(id) on delete cascade,
+  change_id text not null,
+  del_w_id text,
+  ins_w_id text,
+  deleted_text text not null default '',
+  inserted_text text not null default '',
+  context_before text,
+  context_after text,
+  status text not null default 'pending'
+    check (status = any (array[
+      'pending'::text,
+      'accepted'::text,
+      'rejected'::text
+    ])),
+  created_at timestamptz not null default now(),
+  resolved_at timestamptz
+);
+
+create index if not exists document_edits_document_id_idx
+  on public.document_edits(document_id, created_at desc);
+
+create index if not exists document_edits_message_id_idx
+  on public.document_edits(chat_message_id);
+
+create index if not exists document_edits_version_id_idx
+  on public.document_edits(version_id);
+
+-- ---------------------------------------------------------------------------
+-- Workflows
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.workflows (
+  id uuid primary key default gen_random_uuid(),
+  user_id text,
+  title text not null,
+  type text not null,
+  prompt_md text,
+  columns_config jsonb,
+  practice text,
+  is_system boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_workflows_user
+  on public.workflows(user_id);
+
+create table if not exists public.hidden_workflows (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null,
+  workflow_id text not null,
+  created_at timestamptz not null default now(),
+  unique(user_id, workflow_id)
+);
+
+create index if not exists idx_hidden_workflows_user
+  on public.hidden_workflows(user_id);
+
+create table if not exists public.workflow_shares (
+  id uuid primary key default gen_random_uuid(),
+  workflow_id uuid not null references public.workflows(id) on delete cascade,
+  shared_by_user_id text not null,
+  shared_with_email text not null,
+  allow_edit boolean not null default false,
+  created_at timestamptz not null default now(),
+  constraint workflow_shares_workflow_email_unique
+    unique(workflow_id, shared_with_email)
+);
+
+create index if not exists workflow_shares_workflow_id_idx
+  on public.workflow_shares(workflow_id);
+
+create index if not exists workflow_shares_email_idx
+  on public.workflow_shares(shared_with_email);
+
+-- ---------------------------------------------------------------------------
+-- Assistant chats
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.chats (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid references public.projects(id) on delete cascade,
+  user_id text not null,
+  title text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_chats_user
+  on public.chats(user_id);
+
+create index if not exists idx_chats_project
+  on public.chats(project_id);
+
+create table if not exists public.chat_messages (
+  id uuid primary key default gen_random_uuid(),
+  chat_id uuid not null references public.chats(id) on delete cascade,
+  role text not null,
+  content jsonb,
+  files jsonb,
+  annotations jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_chat_messages_chat
+  on public.chat_messages(chat_id);
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'document_edits_chat_message_id_fkey'
+      and conrelid = 'public.document_edits'::regclass
+  ) then
+    alter table public.document_edits
+      add constraint document_edits_chat_message_id_fkey
+      foreign key (chat_message_id)
+      references public.chat_messages(id)
+      on delete set null;
+  end if;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Tabular reviews
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.tabular_reviews (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid references public.projects(id) on delete cascade,
+  user_id text not null,
+  title text,
+  columns_config jsonb,
+  workflow_id uuid references public.workflows(id) on delete set null,
+  practice text,
+  document_grouping text not null default 'document' check (document_grouping in ('document', 'folder')),
+  shared_with jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_tabular_reviews_user
+  on public.tabular_reviews(user_id);
+
+create index if not exists idx_tabular_reviews_project
+  on public.tabular_reviews(project_id);
+
+create index if not exists tabular_reviews_shared_with_idx
+  on public.tabular_reviews using gin (shared_with);
+
+create table if not exists public.tabular_review_rows (
+  id uuid primary key default gen_random_uuid(),
+  review_id uuid not null references public.tabular_reviews(id) on delete cascade,
+  label text not null,
+  row_type text not null check (row_type in ('document', 'folder')),
+  folder_id uuid references public.project_subfolders(id) on delete set null,
+  document_id uuid references public.documents(id) on delete set null,
+  sort_index integer not null default 0,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_tabular_review_rows_review
+  on public.tabular_review_rows(review_id, sort_index);
+
+create table if not exists public.tabular_review_row_sources (
+  row_id uuid not null references public.tabular_review_rows(id) on delete cascade,
+  document_id uuid not null references public.documents(id) on delete cascade,
+  sort_index integer not null default 0,
+  created_at timestamptz not null default now(),
+  primary key (row_id, document_id)
+);
+
+create index if not exists idx_tabular_review_row_sources_document
+  on public.tabular_review_row_sources(document_id);
+
+create table if not exists public.tabular_cells (
+  id uuid primary key default gen_random_uuid(),
+  review_id uuid not null references public.tabular_reviews(id) on delete cascade,
+  row_id uuid references public.tabular_review_rows(id) on delete cascade,
+  document_id uuid references public.documents(id) on delete cascade,
+  column_index integer not null,
+  content text,
+  citations jsonb,
+  status text not null default 'pending',
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_tabular_cells_review
+  on public.tabular_cells(review_id, document_id, column_index);
+
+create index if not exists idx_tabular_cells_review_row
+  on public.tabular_cells(review_id, row_id, column_index);
+
+create table if not exists public.tabular_review_chats (
+  id uuid primary key default gen_random_uuid(),
+  review_id uuid not null references public.tabular_reviews(id) on delete cascade,
+  user_id text not null,
+  title text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists tabular_review_chats_review_idx
+  on public.tabular_review_chats(review_id, updated_at desc);
+
+create index if not exists tabular_review_chats_user_idx
+  on public.tabular_review_chats(user_id);
+
+create table if not exists public.tabular_review_chat_messages (
+  id uuid primary key default gen_random_uuid(),
+  chat_id uuid not null references public.tabular_review_chats(id) on delete cascade,
+  role text not null,
+  content jsonb,
+  annotations jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists tabular_review_chat_messages_chat_idx
+  on public.tabular_review_chat_messages(chat_id, created_at);

--- a/supabase/migrations/20260510000000_tabular_review_rows.sql
+++ b/supabase/migrations/20260510000000_tabular_review_rows.sql
@@ -1,0 +1,277 @@
+-- Folder-aware tabular reviews.
+-- Rows are now first-class records; a row can represent either one document or
+-- a direct project subfolder containing multiple source documents.
+
+-- Ensure helper functions exist (omitted from initial migration).
+create or replace function public.current_user_id_text()
+returns text
+language sql
+stable
+set search_path = public, auth
+as $$
+  select auth.uid()::text;
+$$;
+
+create or replace function public.current_user_email()
+returns text
+language sql
+stable
+set search_path = public, auth
+as $$
+  select lower(coalesce(auth.jwt() ->> 'email', ''));
+$$;
+
+create or replace function public.email_is_shared(shared_with jsonb)
+returns boolean
+language sql
+stable
+set search_path = public
+as $$
+  select public.current_user_email() <> ''
+    and exists (
+      select 1
+      from jsonb_array_elements_text(coalesce(shared_with, '[]'::jsonb)) as emails(email)
+      where lower(emails.email) = public.current_user_email()
+    );
+$$;
+
+create or replace function public.project_is_accessible(target_project_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, auth
+as $$
+  select exists (
+    select 1
+    from public.projects p
+    where p.id = target_project_id
+      and (
+        p.user_id = public.current_user_id_text()
+        or public.email_is_shared(p.shared_with)
+      )
+  );
+$$;
+
+create or replace function public.review_is_accessible(target_review_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, auth
+as $$
+  select exists (
+    select 1
+    from public.tabular_reviews r
+    where r.id = target_review_id
+      and (
+        r.user_id = public.current_user_id_text()
+        or public.email_is_shared(r.shared_with)
+        or (
+          r.project_id is not null
+          and public.project_is_accessible(r.project_id)
+        )
+      )
+  );
+$$;
+
+alter table public.tabular_reviews
+  add column if not exists document_grouping text not null default 'document'
+  check (document_grouping in ('document', 'folder'));
+
+create table if not exists public.tabular_review_rows (
+  id uuid primary key default gen_random_uuid(),
+  review_id uuid not null references public.tabular_reviews(id) on delete cascade,
+  label text not null,
+  row_type text not null check (row_type in ('document', 'folder')),
+  folder_id uuid references public.project_subfolders(id) on delete set null,
+  document_id uuid references public.documents(id) on delete set null,
+  sort_index integer not null default 0,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_tabular_review_rows_review
+  on public.tabular_review_rows(review_id, sort_index);
+
+create table if not exists public.tabular_review_row_sources (
+  row_id uuid not null references public.tabular_review_rows(id) on delete cascade,
+  document_id uuid not null references public.documents(id) on delete cascade,
+  sort_index integer not null default 0,
+  created_at timestamptz not null default now(),
+  primary key (row_id, document_id)
+);
+
+create index if not exists idx_tabular_review_row_sources_document
+  on public.tabular_review_row_sources(document_id);
+
+alter table public.tabular_cells
+  add column if not exists row_id uuid references public.tabular_review_rows(id) on delete cascade;
+
+alter table public.tabular_cells
+  alter column document_id drop not null;
+
+create index if not exists idx_tabular_cells_review_row
+  on public.tabular_cells(review_id, row_id, column_index);
+
+-- Backfill one row per existing document-backed row.
+with source_docs as (
+  select distinct c.review_id, c.document_id, d.filename
+  from public.tabular_cells c
+  join public.documents d on d.id = c.document_id
+  where c.row_id is null
+),
+numbered as (
+  select
+    review_id,
+    document_id,
+    filename,
+    row_number() over (partition by review_id order by filename, document_id) - 1 as sort_index
+  from source_docs
+),
+inserted as (
+  insert into public.tabular_review_rows (review_id, label, row_type, document_id, sort_index)
+  select review_id, filename, 'document', document_id, sort_index
+  from numbered n
+  where not exists (
+    select 1
+    from public.tabular_review_rows r
+    where r.review_id = n.review_id
+      and r.row_type = 'document'
+      and r.document_id = n.document_id
+  )
+  returning id, review_id, document_id
+)
+insert into public.tabular_review_row_sources (row_id, document_id, sort_index)
+select id, document_id, 0
+from inserted
+on conflict do nothing;
+
+insert into public.tabular_review_row_sources (row_id, document_id, sort_index)
+select r.id, r.document_id, 0
+from public.tabular_review_rows r
+where r.row_type = 'document'
+  and r.document_id is not null
+on conflict do nothing;
+
+update public.tabular_cells c
+set row_id = r.id
+from public.tabular_review_rows r
+where c.row_id is null
+  and c.review_id = r.review_id
+  and c.document_id = r.document_id;
+
+alter table public.tabular_review_rows enable row level security;
+alter table public.tabular_review_row_sources enable row level security;
+
+drop policy if exists "Users can view accessible tabular review rows" on public.tabular_review_rows;
+create policy "Users can view accessible tabular review rows"
+  on public.tabular_review_rows for select
+  using (public.review_is_accessible(review_id));
+
+drop policy if exists "Review owners can insert tabular review rows" on public.tabular_review_rows;
+create policy "Review owners can insert tabular review rows"
+  on public.tabular_review_rows for insert
+  with check (
+    exists (
+      select 1
+      from public.tabular_reviews r
+      where r.id = review_id
+        and r.user_id = public.current_user_id_text()
+    )
+  );
+
+drop policy if exists "Review owners can update tabular review rows" on public.tabular_review_rows;
+create policy "Review owners can update tabular review rows"
+  on public.tabular_review_rows for update
+  using (
+    exists (
+      select 1
+      from public.tabular_reviews r
+      where r.id = review_id
+        and r.user_id = public.current_user_id_text()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.tabular_reviews r
+      where r.id = review_id
+        and r.user_id = public.current_user_id_text()
+    )
+  );
+
+drop policy if exists "Review owners can delete tabular review rows" on public.tabular_review_rows;
+create policy "Review owners can delete tabular review rows"
+  on public.tabular_review_rows for delete
+  using (
+    exists (
+      select 1
+      from public.tabular_reviews r
+      where r.id = review_id
+        and r.user_id = public.current_user_id_text()
+    )
+  );
+
+drop policy if exists "Users can view accessible tabular row sources" on public.tabular_review_row_sources;
+create policy "Users can view accessible tabular row sources"
+  on public.tabular_review_row_sources for select
+  using (
+    exists (
+      select 1
+      from public.tabular_review_rows r
+      where r.id = row_id
+        and public.review_is_accessible(r.review_id)
+    )
+  );
+
+drop policy if exists "Review owners can insert tabular row sources" on public.tabular_review_row_sources;
+create policy "Review owners can insert tabular row sources"
+  on public.tabular_review_row_sources for insert
+  with check (
+    exists (
+      select 1
+      from public.tabular_review_rows trr
+      join public.tabular_reviews review on review.id = trr.review_id
+      where trr.id = row_id
+        and review.user_id = public.current_user_id_text()
+    )
+  );
+
+drop policy if exists "Review owners can update tabular row sources" on public.tabular_review_row_sources;
+create policy "Review owners can update tabular row sources"
+  on public.tabular_review_row_sources for update
+  using (
+    exists (
+      select 1
+      from public.tabular_review_rows trr
+      join public.tabular_reviews review on review.id = trr.review_id
+      where trr.id = row_id
+        and review.user_id = public.current_user_id_text()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.tabular_review_rows trr
+      join public.tabular_reviews review on review.id = trr.review_id
+      where trr.id = row_id
+        and review.user_id = public.current_user_id_text()
+    )
+  );
+
+drop policy if exists "Review owners can delete tabular row sources" on public.tabular_review_row_sources;
+create policy "Review owners can delete tabular row sources"
+  on public.tabular_review_row_sources for delete
+  using (
+    exists (
+      select 1
+      from public.tabular_review_rows trr
+      join public.tabular_reviews review on review.id = trr.review_id
+      where trr.id = row_id
+        and review.user_id = public.current_user_id_text()
+    )
+  );
+
+grant usage on schema public to anon, authenticated;
+grant select, insert, update, delete on public.tabular_review_rows to authenticated;
+grant select, insert, update, delete on public.tabular_review_row_sources to authenticated;

--- a/supabase/migrations/20260510000001_user_tabular_max_pages.sql
+++ b/supabase/migrations/20260510000001_user_tabular_max_pages.sql
@@ -1,0 +1,3 @@
+alter table public.user_profiles
+  add column if not exists tabular_max_pages integer not null default 250
+  check (tabular_max_pages >= 10 and tabular_max_pages <= 2000);


### PR DESCRIPTION
## Summary

- **Folder-grouped rows**: a new toggle in the tabular review creation flow lets users treat all documents inside the same project subfolder as a single review row (label = folder path, subtitle = N documents). Documents without a subfolder still get their own row.
- **Per-user page limit**: a configurable `tabular_max_pages` setting (10–2000, default 250) in Account → Models & API Keys controls how large a grouped row can be before it is skipped. Rows that exceed the limit now surface a single, full-width error banner instead of repeating the error icon in every column.
- **PDF.js noise fixes**: all `getDocument` calls now pass `standardFontDataUrl` and `verbosity: 0`, eliminating the `standardFontDataUrl` and `TT: undefined function: 32` console warnings.

## Database changes

Two new migrations ship alongside an updated `schema.sql`:

| Migration | Purpose |
|---|---|
| `20260510000000_tabular_review_rows.sql` | Adds `document_grouping` to `tabular_reviews`; introduces `tabular_review_rows` and `tabular_review_row_sources` tables; backfills existing cells; adds RLS policies |
| `20260510000001_user_tabular_max_pages.sql` | Adds `tabular_max_pages integer default 250` to `user_profiles` |

The initial schema (`20240101000000_initial_schema.sql`) is also updated to keep it in sync with the new tables for fresh installs.

## Test plan

- [x] Create a project with at least two subfolders, each containing multiple documents
- [x] Start a tabular review → enable "Treat documents in the same subfolder as one row" → confirm rows are grouped by folder with correct labels and document counts
- [x] Run all columns → confirm each folder row is processed as a unit
- [x] In Account → Models & API Keys, set Max pages to a low value (e.g. 10) and re-run → confirm the row shows the full-width error banner with the page-count message
- [x] Confirm no `standardFontDataUrl` or `TT: undefined function` warnings in backend logs after PDF upload/processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)