### PR TITLE
feat(workflows): add JSON file download/upload for workflow transfer

### DIFF
--- a/frontend/src/app/components/workflows/UploadWorkflowButton.tsx
+++ b/frontend/src/app/components/workflows/UploadWorkflowButton.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Upload } from "lucide-react";
+import { createWorkflow } from "@/app/lib/mikeApi";
+import {
+    WorkflowFileError,
+    readWorkflowFile,
+} from "@/app/lib/workflowFile";
+import type { MikeWorkflow } from "../shared/types";
+
+interface Props {
+    onUploaded: (workflow: MikeWorkflow) => void;
+}
+
+export function UploadWorkflowButton({ onUploaded }: Props) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    function handleClick() {
+        setError(null);
+        inputRef.current?.click();
+    }
+
+    async function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+        const file = e.target.files?.[0];
+        e.target.value = ""; // allow re-upload of the same file
+        if (!file) return;
+        setBusy(true);
+        setError(null);
+        try {
+            const envelope = await readWorkflowFile(file);
+            const created = await createWorkflow({
+                title: envelope.title,
+                type: envelope.type,
+                practice: envelope.practice,
+                prompt_md: envelope.prompt_md ?? undefined,
+                columns_config: envelope.columns_config ?? undefined,
+            });
+            onUploaded(created);
+        } catch (err) {
+            const message =
+                err instanceof WorkflowFileError
+                    ? err.message
+                    : err instanceof Error && err.message
+                      ? err.message
+                      : "Failed to upload workflow.";
+            setError(message);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    return (
+        <div className="relative flex items-center">
+            <input
+                ref={inputRef}
+                type="file"
+                accept=".json,application/json"
+                className="hidden"
+                onChange={handleChange}
+            />
+            <button
+                onClick={handleClick}
+                disabled={busy}
+                aria-label="Upload workflow"
+                title="Upload workflow"
+                className="flex items-center justify-center p-1.5 text-gray-500 hover:text-gray-900 transition-colors disabled:opacity-40"
+            >
+                <Upload className="h-4 w-4" />
+            </button>
+            {error && (
+                <span
+                    className="ml-2 max-w-[280px] truncate text-xs text-red-500"
+                    title={error}
+                >
+                    {error}
+                </span>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/app/components/workflows/WorkflowList.tsx
+++ b/frontend/src/app/components/workflows/WorkflowList.tsx
@@ -10,6 +10,7 @@ import {
     User,
     ChevronDown,
     Check,
+    Download,
 } from "lucide-react";
 import { HeaderSearchBtn } from "../shared/HeaderSearchBtn";
 import {
@@ -23,6 +24,8 @@ import type { MikeWorkflow } from "../shared/types";
 import { BUILT_IN_WORKFLOWS, BUILT_IN_IDS } from "./builtinWorkflows";
 import { DisplayWorkflowModal } from "./DisplayWorkflowModal";
 import { NewWorkflowModal } from "./NewWorkflowModal";
+import { UploadWorkflowButton } from "./UploadWorkflowButton";
+import { downloadWorkflow } from "@/app/lib/workflowFile";
 import { ToolbarTabs } from "../shared/ToolbarTabs";
 import { RowActions } from "../shared/RowActions";
 import { MikeIcon } from "@/components/chat/mike-icon";
@@ -368,6 +371,11 @@ export function WorkflowList() {
                         onChange={setSearch}
                         placeholder="Search workflows…"
                     />
+                    <UploadWorkflowButton
+                        onUploaded={(wf) => {
+                            setCustom((prev) => [wf, ...prev]);
+                        }}
+                    />
                     <button
                         onClick={() => setNewModalOpen(true)}
                         className="flex items-center justify-center p-1.5 text-gray-500 hover:text-gray-900 transition-colors"
@@ -408,7 +416,7 @@ export function WorkflowList() {
                         <div className="ml-auto w-28 shrink-0">Type</div>
                         <div className="w-40 shrink-0">Practice</div>
                         <div className="w-28 shrink-0">Source</div>
-                        <div className="w-8 shrink-0" />
+                        <div className="w-16 shrink-0" />
                     </div>
 
                     {loading && activeTab !== "builtin" ? (
@@ -431,7 +439,7 @@ export function WorkflowList() {
                                     <div className="w-28 shrink-0">
                                         <div className="h-3 w-14 rounded bg-gray-100 animate-pulse" />
                                     </div>
-                                    <div className="w-8 shrink-0" />
+                                    <div className="w-16 shrink-0" />
                                 </div>
                             ))}
                         </div>
@@ -553,9 +561,19 @@ export function WorkflowList() {
                                     )}
                                 </div>
                                 <div
-                                    className="w-8 shrink-0 flex justify-end"
+                                    className="w-16 shrink-0 flex items-center justify-end gap-1"
                                     onClick={(e) => e.stopPropagation()}
                                 >
+                                    {activeTab !== "hidden" && (
+                                        <button
+                                            onClick={() => downloadWorkflow(wf)}
+                                            aria-label="Download workflow"
+                                            title="Download workflow"
+                                            className="flex items-center justify-center p-1 text-gray-400 hover:text-gray-900 transition-colors"
+                                        >
+                                            <Download className="h-3.5 w-3.5" />
+                                        </button>
+                                    )}
                                     {wf.is_system ? (
                                         activeTab === "hidden" ? (
                                             <RowActions

--- a/frontend/src/app/lib/workflowFile.ts
+++ b/frontend/src/app/lib/workflowFile.ts
@@ -1,0 +1,104 @@
+import type {
+    ColumnConfig,
+    MikeWorkflow,
+} from "@/app/components/shared/types";
+
+const WORKFLOW_FILE_FORMAT = "mike.workflow" as const;
+const WORKFLOW_FILE_VERSION = 1 as const;
+
+export interface WorkflowFile {
+    format: typeof WORKFLOW_FILE_FORMAT;
+    version: typeof WORKFLOW_FILE_VERSION;
+    title: string;
+    type: "assistant" | "tabular";
+    practice: string | null;
+    prompt_md: string | null;
+    columns_config: ColumnConfig[] | null;
+}
+
+export function buildWorkflowEnvelope(wf: MikeWorkflow): WorkflowFile {
+    return {
+        format: WORKFLOW_FILE_FORMAT,
+        version: WORKFLOW_FILE_VERSION,
+        title: wf.title,
+        type: wf.type,
+        practice: wf.practice ?? null,
+        prompt_md: wf.prompt_md ?? null,
+        columns_config: wf.columns_config ?? null,
+    };
+}
+
+function sanitizeFilename(title: string): string {
+    const cleaned = title
+        .normalize("NFKD")
+        .replace(/[^\w\s.-]/g, "")
+        .trim()
+        .replace(/\s+/g, "-");
+    return cleaned.length > 0 ? cleaned : "workflow";
+}
+
+export function downloadWorkflow(wf: MikeWorkflow): void {
+    const envelope = buildWorkflowEnvelope(wf);
+    const blob = new Blob([JSON.stringify(envelope, null, 2)], {
+        type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${sanitizeFilename(wf.title)}.mikeworkflow.json`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+export class WorkflowFileError extends Error {}
+
+export function parseWorkflowFile(raw: string): WorkflowFile {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        throw new WorkflowFileError("File is not valid JSON.");
+    }
+    if (!parsed || typeof parsed !== "object") {
+        throw new WorkflowFileError("File is not a workflow envelope.");
+    }
+    const obj = parsed as Record<string, unknown>;
+    if (obj.format !== WORKFLOW_FILE_FORMAT) {
+        throw new WorkflowFileError(
+            "Not a Mike workflow file (missing or wrong 'format').",
+        );
+    }
+    if (obj.version !== WORKFLOW_FILE_VERSION) {
+        throw new WorkflowFileError(
+            `Unsupported workflow file version: ${String(obj.version)}.`,
+        );
+    }
+    if (typeof obj.title !== "string" || !obj.title.trim()) {
+        throw new WorkflowFileError("Workflow file is missing a title.");
+    }
+    if (obj.type !== "assistant" && obj.type !== "tabular") {
+        throw new WorkflowFileError(
+            "Workflow type must be 'assistant' or 'tabular'.",
+        );
+    }
+    if (obj.columns_config != null && !Array.isArray(obj.columns_config)) {
+        throw new WorkflowFileError("columns_config must be an array.");
+    }
+    return {
+        format: WORKFLOW_FILE_FORMAT,
+        version: WORKFLOW_FILE_VERSION,
+        title: obj.title.trim(),
+        type: obj.type,
+        practice: (obj.practice as string | null | undefined) ?? null,
+        prompt_md: (obj.prompt_md as string | null | undefined) ?? null,
+        columns_config:
+            (obj.columns_config as ColumnConfig[] | null | undefined) ?? null,
+    };
+}
+
+export async function readWorkflowFile(file: File): Promise<WorkflowFile> {
+    const text = await file.text();
+    return parseWorkflowFile(text);
+}


### PR DESCRIPTION
## Summary

Adds a way to move a workflow between Mike instances by exporting it as a `.mikeworkflow.json` file and importing it elsewhere — useful for sharing built/customised workflows across teams, environments, or organisations without needing a shared account.

- **Download** — every workflow row in `/workflows` gets a small download icon that serialises the workflow to a JSON envelope (`format: "mike.workflow"`, `version: 1`) with `title`, `type`, `practice`, `prompt_md`, and `columns_config`.
- **Upload** — a new upload icon in the page header opens a file picker, validates the envelope, and creates a new workflow under the current user.
- **Scope is intentionally minimal**: no backend, schema, or Supabase config changes. Upload reuses the existing `POST /workflows` endpoint via `createWorkflow`. Email sharing is untouched.

## Files

- New: `frontend/src/app/lib/workflowFile.ts` — envelope builder, download helper, strict parser with typed errors.
- New: `frontend/src/app/components/workflows/UploadWorkflowButton.tsx` — file-picker button that creates a workflow from a parsed envelope and shows inline errors.
- Modified: `frontend/src/app/components/workflows/WorkflowList.tsx` — mounts the upload button next to `+ New`, adds a per-row download icon, widens the trailing actions column from `w-8` to `w-16`.

No new dependencies. All icons come from the existing `lucide-react` import.

## Test plan

- [ ] Create a custom assistant workflow with a prompt and practice → click the row's download icon → verify a `<title>.mikeworkflow.json` file downloads and the JSON contains `format: "mike.workflow"`, `version: 1`, and the expected fields.
- [ ] Click the header upload icon → pick the downloaded file → verify a new workflow appears in the list with identical fields, owned by you.
- [ ] Repeat with a tabular workflow → verify `columns_config` round-trips.
- [ ] Upload an arbitrary JSON file → expect a red inline error from the envelope validator.
- [ ] Upload a malformed envelope (wrong `format`) → expect a clear inline error.
- [ ] Confirm no regression to existing flows: `+ New`, email share modal, hide/unhide built-ins, bulk delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)