### PR TITLE
fix: update encryption key retrieval to use only USER_API_KEYS_ENCRYPTION_SECRET

### DIFF
--- a/backend/src/lib/userApiKeys.ts
+++ b/backend/src/lib/userApiKeys.ts
@@ -37,12 +37,9 @@ export function hasEnvApiKey(provider: ApiKeyProvider): boolean {
 }
 
 function encryptionKey(): Buffer {
-    const secret =
-        process.env.USER_API_KEYS_ENCRYPTION_SECRET ||
-        process.env.API_KEYS_ENCRYPTION_SECRET ||
-        process.env.SUPABASE_SECRET_KEY;
+    const secret = process.env.USER_API_KEYS_ENCRYPTION_SECRET;
     if (!secret) {
-        throw new Error("API key encryption secret is not configured");
+        throw new Error("USER_API_KEYS_ENCRYPTION_SECRET is not configured");
     }
     return crypto.createHash("sha256").update(secret).digest();
 }


### PR DESCRIPTION


## Summary

Require `USER_API_KEYS_ENCRYPTION_SECRET` for stored user API key encryption.

## Changes

- Removed fallback to `API_KEYS_ENCRYPTION_SECRET`.
- Removed fallback to `SUPABASE_SECRET_KEY`.
- Updated the runtime error to explicitly require `USER_API_KEYS_ENCRYPTION_SECRET`.

## Why

Stored user API keys should be encrypted with a dedicated secret only. Falling back to the Supabase service role key couples unrelated secrets and makes rotation/deployment behavior harder to reason about.

## Testing

- `npm run build --prefix backend` passes in the private repo.
- OSS backend build was blocked by missing local type packages in `open-source-export/backend`: `@types/cors`, `@types/express`, `@types/multer`.
