### PR TITLE
fix: cache s3 client construction

### DIFF
--- a/backend/src/lib/storage.ts
+++ b/backend/src/lib/storage.ts
@@ -17,16 +17,21 @@ import {
 } from "@aws-sdk/client-s3";
 import { getSignedUrl as awsGetSignedUrl } from "@aws-sdk/s3-request-presigner";
 
+let cachedClient: S3Client | undefined;
+
 function getClient(): S3Client {
-  return new S3Client({
-    region: "auto",
-    endpoint: process.env.R2_ENDPOINT_URL!,
-    forcePathStyle: true,
-    credentials: {
-      accessKeyId: process.env.R2_ACCESS_KEY_ID!,
-      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
-    },
-  });
+  if (!cachedClient) {
+    cachedClient = new S3Client({
+      region: "auto",
+      endpoint: process.env.R2_ENDPOINT_URL!,
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+        secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+      },
+    });
+  }
+  return cachedClient;
 }
 
 const BUCKET = process.env.R2_BUCKET_NAME ?? "mike";


### PR DESCRIPTION
# Summary

Caching the S3 client in `backend/src/lib/storage.ts`.

# What

Replaced `getClient()`'s `new S3Client(...)` call with module-level cached client. 

# Why

Previously, every `uploadFile`, `downloadFile`, `deleteFile` and `getSignedUrl` call constructed a new client. This is wasteful as config is static.

# Testing

Local runs only. Not sure if this repo is missing tests at the time of writing, happy to be corrected. Also ran a Claude Code `/security-review`, no high-confidence issues.