### PR TITLE
fix: require dedicated download signing secret

### DIFF
--- a/backend/src/lib/downloadTokens.ts
+++ b/backend/src/lib/downloadTokens.ts
@@ -10,12 +10,10 @@ import crypto from "crypto";
  */
 
 function getSecret(): string {
-    const secret =
-        process.env.DOWNLOAD_SIGNING_SECRET ??
-        process.env.SUPABASE_SECRET_KEY;
+    const secret = process.env.DOWNLOAD_SIGNING_SECRET;
     if (!secret) {
         throw new Error(
-            "DOWNLOAD_SIGNING_SECRET (or SUPABASE_SECRET_KEY as a fallback) must be set. " +
+            "DOWNLOAD_SIGNING_SECRET must be set. " +
                 "Generate a strong random value (e.g. `openssl rand -hex 32`) and set it in the environment.",
         );
     }


### PR DESCRIPTION
## Summary

Require `DOWNLOAD_SIGNING_SECRET` for download token signing.

## Changes

- Removed the fallback from `DOWNLOAD_SIGNING_SECRET` to `SUPABASE_SECRET_KEY`.
- Updated the missing-secret error message to require `DOWNLOAD_SIGNING_SECRET` directly.

## Why

Download token signing should use a dedicated secret instead of falling back to the Supabase service-role key. This keeps unrelated secrets separate and makes configuration failures clearer.

## Testing

- `npm run build --prefix backend`
