### PR TITLE
docs: add security reporting guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,12 @@ Thanks for helping improve Mike. Please keep contributions small, focused, and e
     - why
     - testing
 
+## Security
+
+Do not open a public issue for security vulnerabilities. Use [GitHub's private vulnerability reporting](https://github.com/willchen96/mike/security/advisories/new) instead.
+
+We will aim to respond promptly and coordinate a disclosure timeline with you.
+
 ## Local Development
 
 Backend:


### PR DESCRIPTION
## Summary

Add security reporting guidance to the contributing guide.

## Changes

- Added a `Security` section to `CONTRIBUTING.md`.
- Directs security vulnerability reports to GitHub private vulnerability reporting instead of public issues.
- Notes that maintainers will aim to respond promptly and coordinate disclosure.

## Why

Security reports should avoid public disclosure until they can be reviewed and remediated responsibly.

## Testing

- Not run; docs-only change.