### PR TITLE
Add optional Hey Jude gateway routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ OPENAI_API_KEY=your-openai-key
 RESEND_API_KEY=your-resend-key
 USER_API_KEYS_ENCRYPTION_SECRET=your-long-random-secret
 
-# Optional: route Claude/Gemini calls through Hey Jude.
+# Optional: route model calls through Hey Jude.
 HEY_JUDE_ENABLED=false
 HEY_JUDE_BASE_URL=http://localhost:4005
 HEY_JUDE_API_KEY=sk-heyjude-dev
@@ -81,7 +81,7 @@ Supabase values come from the project dashboard. Use the project URL for `SUPABA
 
 Provider keys are only needed for the models and email features you plan to use. Model provider keys can be configured in `backend/.env` for the whole instance, or per user in **Account > Models & API Keys**. If a provider key is present in `backend/.env`, that provider is available by default and the matching browser API key field is read-only.
 
-To pseudonymize Claude or Gemini prompts before provider calls, run [Hey Jude](https://github.com/sure-scale/hey-jude) locally and set `HEY_JUDE_ENABLED=true`. Mike still stores original chat text in its database.
+To pseudonymize provider prompts before model calls, run [Hey Jude](https://github.com/sure-scale/hey-jude) locally and set `HEY_JUDE_ENABLED=true`. Mike still stores original chat text in its database.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ ANTHROPIC_API_KEY=your-anthropic-key
 OPENAI_API_KEY=your-openai-key
 RESEND_API_KEY=your-resend-key
 USER_API_KEYS_ENCRYPTION_SECRET=your-long-random-secret
+
+# Optional: route Claude/Gemini calls through Hey Jude.
+HEY_JUDE_ENABLED=false
+HEY_JUDE_BASE_URL=http://localhost:4005
+HEY_JUDE_API_KEY=sk-heyjude-dev
 ```
 
 Create `frontend/.env.local`:
@@ -75,6 +80,8 @@ NEXT_PUBLIC_API_BASE_URL=http://localhost:3001
 Supabase values come from the project dashboard. Use the project URL for `SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_URL`, the service role key for the backend `SUPABASE_SECRET_KEY`, and the anon/public key for `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`. If your Supabase project shows multiple key formats, use the legacy JWT-style anon and service role keys expected by the Supabase client libraries.
 
 Provider keys are only needed for the models and email features you plan to use. Model provider keys can be configured in `backend/.env` for the whole instance, or per user in **Account > Models & API Keys**. If a provider key is present in `backend/.env`, that provider is available by default and the matching browser API key field is read-only.
+
+To pseudonymize Claude or Gemini prompts before provider calls, run [Hey Jude](https://github.com/sure-scale/hey-jude) locally and set `HEY_JUDE_ENABLED=true`. Mike still stores original chat text in its database.
 
 ## Install
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,3 +18,8 @@ ANTHROPIC_API_KEY=your-anthropic-key
 OPENAI_API_KEY=your-openai-key
 RESEND_API_KEY=your-resend-key
 USER_API_KEYS_ENCRYPTION_SECRET=your-long-random-secret
+
+# Optional: route Claude/Gemini calls through Hey Jude.
+HEY_JUDE_ENABLED=false
+HEY_JUDE_BASE_URL=http://localhost:4005
+HEY_JUDE_API_KEY=sk-heyjude-dev

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,7 +19,7 @@ OPENAI_API_KEY=your-openai-key
 RESEND_API_KEY=your-resend-key
 USER_API_KEYS_ENCRYPTION_SECRET=your-long-random-secret
 
-# Optional: route Claude/Gemini calls through Hey Jude.
+# Optional: route model calls through Hey Jude.
 HEY_JUDE_ENABLED=false
 HEY_JUDE_BASE_URL=http://localhost:4005
 HEY_JUDE_API_KEY=sk-heyjude-dev

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -249,6 +249,7 @@ create table if not exists public.chat_messages (
   role text not null,
   content jsonb,
   files jsonb,
+  workflow jsonb,
   annotations jsonb,
   created_at timestamptz not null default now()
 );

--- a/backend/src/lib/llm/claude.ts
+++ b/backend/src/lib/llm/claude.ts
@@ -6,6 +6,7 @@ import type {
     NormalizedToolCall,
     NormalizedToolResult,
 } from "./types";
+import { heyJudeApiKey, heyJudeBaseUrl, heyJudeEnabled } from "./heyJude";
 import { toClaudeTools } from "./tools";
 
 type ContentBlock =
@@ -31,6 +32,12 @@ function apiKey(override?: string | null): string {
 }
 
 function client(override?: string | null): Anthropic {
+    if (heyJudeEnabled()) {
+        return new Anthropic({
+            apiKey: heyJudeApiKey(),
+            baseURL: heyJudeBaseUrl(),
+        });
+    }
     const apiKeyValue = apiKey(override);
     return new Anthropic({ apiKey: apiKeyValue });
 }

--- a/backend/src/lib/llm/gemini.ts
+++ b/backend/src/lib/llm/gemini.ts
@@ -4,6 +4,7 @@ import type {
     StreamChatResult,
     NormalizedToolCall,
 } from "./types";
+import { heyJudeApiKey, heyJudeBaseUrl, heyJudeEnabled } from "./heyJude";
 import { toGeminiTools } from "./tools";
 
 type GeminiPart = {
@@ -39,6 +40,12 @@ function apiKey(override?: string | null): string {
 }
 
 function client(override?: string | null): GoogleGenAI {
+    if (heyJudeEnabled()) {
+        return new GoogleGenAI({
+            apiKey: heyJudeApiKey(),
+            httpOptions: { baseUrl: heyJudeBaseUrl() },
+        });
+    }
     return new GoogleGenAI({ apiKey: apiKey(override) });
 }
 

--- a/backend/src/lib/llm/heyJude.ts
+++ b/backend/src/lib/llm/heyJude.ts
@@ -1,0 +1,14 @@
+export function heyJudeEnabled(): boolean {
+    return process.env.HEY_JUDE_ENABLED === "true";
+}
+
+export function heyJudeBaseUrl(): string {
+    return (process.env.HEY_JUDE_BASE_URL || "http://localhost:4005").replace(
+        /\/$/,
+        "",
+    );
+}
+
+export function heyJudeApiKey(): string {
+    return process.env.HEY_JUDE_API_KEY || "sk-heyjude-dev";
+}

--- a/backend/src/lib/llm/openai.ts
+++ b/backend/src/lib/llm/openai.ts
@@ -6,6 +6,7 @@ import type {
     StreamChatParams,
     StreamChatResult,
 } from "./types";
+import { heyJudeApiKey, heyJudeBaseUrl, heyJudeEnabled } from "./heyJude";
 
 const OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";
 const MAX_OUTPUT_TOKENS = 16384;
@@ -36,6 +37,9 @@ type ResponseStreamEvent = {
 };
 
 function apiKey(override?: string | null): string {
+    if (heyJudeEnabled()) {
+        return heyJudeApiKey();
+    }
     const key = override?.trim() || process.env.OPENAI_API_KEY?.trim() || "";
     if (!key) {
         throw new Error(
@@ -43,6 +47,13 @@ function apiKey(override?: string | null): string {
         );
     }
     return key;
+}
+
+function responsesUrl(): string {
+    if (heyJudeEnabled()) {
+        return `${heyJudeBaseUrl()}/v1/responses`;
+    }
+    return OPENAI_RESPONSES_URL;
 }
 
 function toResponseTools(tools: OpenAIToolSchema[]): ResponseFunctionTool[] {
@@ -115,7 +126,7 @@ async function createResponse(params: {
     reasoningSummary?: boolean;
     apiKey: string;
 }): Promise<Response> {
-    const response = await fetch(OPENAI_RESPONSES_URL, {
+    const response = await fetch(responsesUrl(), {
         method: "POST",
         headers: {
             Authorization: `Bearer ${params.apiKey}`,

--- a/backend/src/lib/userSettings.ts
+++ b/backend/src/lib/userSettings.ts
@@ -19,9 +19,15 @@ export type UserModelSettings = {
 // available, otherwise OpenAI nano, otherwise Claude Haiku. With no user keys
 // set, defaults to Gemini (the dev-mode env fallback).
 function resolveTitleModel(apiKeys: UserApiKeys): string {
-    if (apiKeys.gemini?.trim()) return DEFAULT_TITLE_MODEL;
-    if (apiKeys.openai?.trim()) return OPENAI_LOW_MODELS[0];
-    if (apiKeys.claude?.trim()) return "claude-haiku-4-5";
+    if (apiKeys.gemini?.trim() || process.env.GEMINI_API_KEY?.trim()) {
+        return DEFAULT_TITLE_MODEL;
+    }
+    if (apiKeys.openai?.trim() || process.env.OPENAI_API_KEY?.trim()) {
+        return OPENAI_LOW_MODELS[0];
+    }
+    if (apiKeys.claude?.trim() || process.env.ANTHROPIC_API_KEY?.trim()) {
+        return "claude-haiku-4-5";
+    }
     return DEFAULT_TITLE_MODEL;
 }
 


### PR DESCRIPTION
## Summary
- Add optional `HEY_JUDE_ENABLED` routing for Claude, Gemini, and OpenAI model calls.
- Route OpenAI through Hey Jude's `/v1/responses` compatibility endpoint when enabled.
- Document the minimal Hey Jude environment settings for local setup.

## Notes
- Mike still stores original chat text in its database; Hey Jude pseudonymizes prompts before provider calls.
- Full `/chat` curl testing requires a configured Supabase auth environment and valid user token.

## Test Plan
- `npm run build --prefix backend`
- Live Gemini provider-adapter request through Mike -> Hey Jude -> downstream capture
- Live Anthropic provider-adapter request through Mike -> Hey Jude -> downstream capture
- Live OpenAI complete and streaming Responses requests through Mike -> Hey Jude -> downstream capture
- Capture log checked for raw test entities; downstream payloads did not contain raw `Nick Watson` or `Google`
