### PR TITLE
fix: enforce monthly message-credit limit before chat LLM calls

### DIFF
--- a/backend/src/lib/credits.ts
+++ b/backend/src/lib/credits.ts
@@ -1,0 +1,86 @@
+import { createServerSupabase } from "./supabase";
+
+/**
+ * Monthly cap on user-initiated LLM messages. Surfaced on the user
+ * profile as `creditsRemaining`. The historical default was 999999 —
+ * effectively unlimited — and we preserve that here so this module is
+ * behaviour-neutral unless the operator opts in by setting
+ * MONTHLY_MESSAGE_CREDIT_LIMIT to a smaller integer. Tier-based limits
+ * are intentionally out of scope; once a single env-driven cap exists
+ * it's straightforward to layer tier overrides on top.
+ */
+export function monthlyCreditLimit(): number {
+    const raw = process.env.MONTHLY_MESSAGE_CREDIT_LIMIT;
+    if (!raw) return 999999;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) return 999999;
+    return parsed;
+}
+
+type Db = ReturnType<typeof createServerSupabase>;
+
+export type CreditState = {
+    used: number;
+    limit: number;
+    remaining: number;
+};
+
+/**
+ * Returns the user's current message-credit balance. Caller is
+ * responsible for translating a non-positive `remaining` into a 402
+ * before the LLM call.
+ *
+ * Note: read-only. The 30-day window reset still happens in
+ * routes/user.ts → loadProfile() when the profile is fetched. We do
+ * not duplicate that here because the streaming-chat code path doesn't
+ * fetch the full profile; a small amount of staleness is acceptable
+ * for the enforcement check (a user can at most spend one extra
+ * message before their reset is observed by the next /user/profile
+ * fetch).
+ */
+export async function getCreditState(
+    userId: string,
+    db: Db,
+): Promise<CreditState> {
+    const limit = monthlyCreditLimit();
+    const { data } = await db
+        .from("user_profiles")
+        .select("message_credits_used")
+        .eq("user_id", userId)
+        .maybeSingle();
+    const used = Number((data as { message_credits_used?: number } | null)?.message_credits_used ?? 0);
+    const safeUsed = Number.isFinite(used) ? used : 0;
+    return { used: safeUsed, limit, remaining: Math.max(limit - safeUsed, 0) };
+}
+
+/**
+ * Increment the user's message-credit counter by `n` (default 1).
+ * Called exactly once per successful user-initiated LLM message — not
+ * per tool turn — so the counter reflects user-visible message volume.
+ *
+ * We do a read-then-write because postgrest doesn't expose an atomic
+ * increment expression. Two near-simultaneous requests can therefore
+ * under-count by one; that's acceptable for a soft budget. If hard
+ * accounting is needed later, swap this for an `rpc('inc_credits', ...)`
+ * stored procedure.
+ */
+export async function incrementMessageCredits(
+    userId: string,
+    db: Db,
+    n = 1,
+): Promise<void> {
+    const { data } = await db
+        .from("user_profiles")
+        .select("message_credits_used")
+        .eq("user_id", userId)
+        .maybeSingle();
+    const current = Number((data as { message_credits_used?: number } | null)?.message_credits_used ?? 0);
+    const next = (Number.isFinite(current) ? current : 0) + n;
+    await db
+        .from("user_profiles")
+        .update({
+            message_credits_used: next,
+            updated_at: new Date().toISOString(),
+        })
+        .eq("user_id", userId);
+}

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -13,6 +13,7 @@ import {
 import { completeText } from "../lib/llm";
 import { getUserApiKeys, getUserModelSettings } from "../lib/userSettings";
 import { checkProjectAccess } from "../lib/access";
+import { getCreditState, incrementMessageCredits } from "../lib/credits";
 
 export const chatRouter = Router();
 
@@ -511,6 +512,20 @@ chatRouter.post("/", requireAuth, async (req, res) => {
 
     devLog("[chat/stream] resolved chatId", chatId);
 
+    // Pre-call budget check. We reject before doing any LLM work so a
+    // user who has run out can't spend tokens; the increment after a
+    // successful stream is what bumps the counter. Default cap is
+    // 999999 (set via MONTHLY_MESSAGE_CREDIT_LIMIT) so this is a no-op
+    // unless the operator configures a smaller limit.
+    const creditState = await getCreditState(userId, db);
+    if (creditState.remaining <= 0) {
+        return void res.status(402).json({
+            detail: "Monthly message credit limit reached.",
+            creditsUsed: creditState.used,
+            creditsLimit: creditState.limit,
+        });
+    }
+
     const lastUser = [...messages].reverse().find((m) => m.role === "user");
     if (lastUser) {
         await db.from("chat_messages").insert({
@@ -586,6 +601,11 @@ chatRouter.post("/", requireAuth, async (req, res) => {
             content: events.length ? events : null,
             annotations: annotations.length ? annotations : null,
         });
+
+        // Bump the monthly counter exactly once per successful
+        // user-initiated message — not per tool turn — so the user-
+        // visible "credits remaining" reflects message volume.
+        await incrementMessageCredits(userId, db);
 
         if (!chatTitle && lastUser?.content) {
             await db

--- a/backend/src/routes/projectChat.ts
+++ b/backend/src/routes/projectChat.ts
@@ -13,6 +13,7 @@ import {
 } from "../lib/chatTools";
 import { getUserApiKeys } from "../lib/userSettings";
 import { checkProjectAccess } from "../lib/access";
+import { getCreditState, incrementMessageCredits } from "../lib/credits";
 
 const PROJECT_SYSTEM_PROMPT_EXTRA = `PROJECT CONTEXT:
 You are operating within a project folder that contains a collection of legal documents the user has organised for a single matter. The user's questions will usually refer to one or more documents in this project — your job is to find the relevant files to work on. Use list_documents to see what is available and fetch_documents / read_document to pull in any documents you need before answering.
@@ -49,6 +50,18 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
     );
     if (!projectAccess.ok)
         return void res.status(404).json({ detail: "Project not found" });
+
+    // Pre-call budget check. Default cap is 999999 (set via
+    // MONTHLY_MESSAGE_CREDIT_LIMIT) so this is a no-op unless the
+    // operator configures a smaller limit.
+    const creditState = await getCreditState(userId, db);
+    if (creditState.remaining <= 0) {
+        return void res.status(402).json({
+            detail: "Monthly message credit limit reached.",
+            creditsUsed: creditState.used,
+            creditsLimit: creditState.limit,
+        });
+    }
 
     let chatId = chat_id ?? null;
     let chatTitle: string | null = null;
@@ -178,6 +191,10 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
             content: events.length ? events : null,
             annotations: annotations.length ? annotations : null,
         });
+
+        // Bump the monthly counter exactly once per successful
+        // user-initiated message — not per tool turn.
+        await incrementMessageCredits(userId, db);
 
         if (!chatTitle && lastUser?.content) {
             await db

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -9,10 +9,9 @@ import {
   normalizeApiKeyProvider,
   saveUserApiKey,
 } from "../lib/userApiKeys";
+import { monthlyCreditLimit } from "../lib/credits";
 
 export const userRouter = Router();
-
-const MONTHLY_CREDIT_LIMIT = 999999;
 
 type UserProfileRow = {
   display_name: string | null;
@@ -33,7 +32,7 @@ function serializeProfile(
     organisation: row.organisation,
     messageCreditsUsed: creditsUsed,
     creditsResetDate: row.credits_reset_date,
-    creditsRemaining: Math.max(MONTHLY_CREDIT_LIMIT - creditsUsed, 0),
+    creditsRemaining: Math.max(monthlyCreditLimit() - creditsUsed, 0),
     tier: row.tier || "Free",
     tabularModel: resolveModel(row.tabular_model, DEFAULT_TABULAR_MODEL),
     ...(apiKeyStatus ? { apiKeyStatus } : {}),


### PR DESCRIPTION
## Summary
\`user_profiles.message_credits_used\` is exposed on \`/user/profile\` as \`creditsRemaining\`, but on \`main\` today (a) no code increments it after an LLM call, so it's always 0, and (b) no code checks it before an LLM call. The \"credits remaining\" the UI shows is therefore a no-op gauge.

## Changes
- **\`backend/src/lib/credits.ts\`** (new) —
  - \`monthlyCreditLimit()\` reads \`MONTHLY_MESSAGE_CREDIT_LIMIT\` from the env, default \`999999\` (the constant previously inline in \`routes/user.ts\`). Behaviour-neutral unless an operator opts in.
  - \`getCreditState(userId, db)\` returns \`{ used, limit, remaining }\` for the pre-call check. Read-only, doesn't fetch the full profile.
  - \`incrementMessageCredits(userId, db, n=1)\` bumps the counter once per successful user-initiated message — not per tool turn — so the gauge reflects user-visible message volume.
- **\`POST /chat\` and \`POST /projects/:projectId/chat\`** —
  - Reject with \`402\` + \`{ creditsUsed, creditsLimit }\` when \`remaining <= 0\`, **before flushing response headers**, so the client sees a clean JSON error instead of a half-streamed response.
  - Increment on the success path after the assistant-message insert. Failed streams don't count against the user.
- **\`routes/user.ts\`** now imports \`monthlyCreditLimit()\` instead of holding its own copy of the constant, so the env-driven limit is the single source of truth.

## Why
This closes the specific \"credit counter tracked but not enforced\" gap from https://insights.flank.ai/where-mikeoss-falls-short.html (gap 6). Two design choices worth flagging:

- **One increment per user message, not per tool turn.** A single chat turn can fire many tool calls; counting each would make the user-visible balance unintelligible. The user pressed Enter once, the gauge ticks once.
- **Default limit unchanged.** \`999999\` was already the historical cap; operators who want enforcement set \`MONTHLY_MESSAGE_CREDIT_LIMIT\` to a smaller integer. Tier-aware limits are intentionally not in scope — once a single env-driven cap exists, tier overrides are a small follow-up.
- **Read-then-write, not atomic.** Two near-simultaneous requests can under-count by one; acceptable for a soft monthly budget. If hard accounting is needed, swap for an \`rpc('inc_credits', ...)\` stored procedure — the call sites won't change.

Tabular and workflow LLM call sites are not touched here — the two streaming chat routes are the most user-visible entry points and wiring the rest is a wider change worth its own PR.

## Testing
- \`npm run build --prefix backend\` passes.
- Walked the four paths manually: (a) limit unset → default 999999, no behaviour change, increment still bumps the counter; (b) limit set to a small number, user at limit → 402 with detail before any LLM call; (c) successful stream → counter +1; (d) LLM error inside the try block → counter untouched.