### PR TITLE
feat(i18n): add next-intl internationalization scaffold

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -30,6 +30,7 @@
         "mammoth": "^1.11.0",
         "marked": "^17.0.1",
         "next": "^16.2.6",
+        "next-intl": "^4.13.0",
         "nextjs-toploader": "^3.9.17",
         "pdfjs-dist": "4.10.38",
         "react": "19.2.0",
@@ -328,6 +329,14 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
+    "@formatjs/fast-memoize": ["@formatjs/fast-memoize@3.1.5", "", {}, "sha512-KLi3fan6WnCHmigd9pmEEN8Hid0v4wiFBW576M/d07KMWYecf1CvyMI3n34vCmHT4AoVqG2n702kiHbXjzZX2A=="],
+
+    "@formatjs/icu-messageformat-parser": ["@formatjs/icu-messageformat-parser@3.5.10", "", { "dependencies": { "@formatjs/icu-skeleton-parser": "2.1.9" } }, "sha512-XeJihYLy1lCe19xfK1KWKG/betBOK2rB0luL8lSkjfvJj0zP+LTJvkC+RKd0jsFI8mWxN71LrarHSrEXE8xxOQ=="],
+
+    "@formatjs/icu-skeleton-parser": ["@formatjs/icu-skeleton-parser@2.1.9", "", {}, "sha512-rsxswgHMfU1zUgB2byc08fesf83wLGjFnzLCEtuf00mx2doiqc6pYrf67raI37XqdRcGUviQepk2UKGqpng74Q=="],
+
+    "@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.8.9", "", { "dependencies": { "@formatjs/fast-memoize": "3.1.5" } }, "sha512-GmB0F/gYh4Hdl4rLWjgDsgT+x4pB54fkJeRh8kAZ4XFzKeCK8dGs+SBJWXO42QZtOUni+IDWKNuCw6wiL4lTvw=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -478,6 +487,34 @@
 
     "@openrouter/sdk": ["@openrouter/sdk@0.3.16", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-WEBlrXdc5R8I7o2temkMV65tIRGkzg9ct4DMNZ/FHS/hiRscLRS5EpcuORnAgjzZAh9X2dSsBpgygM8T7KiNAw=="],
 
+    "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
+
+    "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.5.6", "", { "os": "android", "cpu": "arm64" }, "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A=="],
+
+    "@parcel/watcher-darwin-arm64": ["@parcel/watcher-darwin-arm64@2.5.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA=="],
+
+    "@parcel/watcher-darwin-x64": ["@parcel/watcher-darwin-x64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg=="],
+
+    "@parcel/watcher-freebsd-x64": ["@parcel/watcher-freebsd-x64@2.5.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng=="],
+
+    "@parcel/watcher-linux-arm-glibc": ["@parcel/watcher-linux-arm-glibc@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ=="],
+
+    "@parcel/watcher-linux-arm-musl": ["@parcel/watcher-linux-arm-musl@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg=="],
+
+    "@parcel/watcher-linux-arm64-glibc": ["@parcel/watcher-linux-arm64-glibc@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA=="],
+
+    "@parcel/watcher-linux-arm64-musl": ["@parcel/watcher-linux-arm64-musl@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA=="],
+
+    "@parcel/watcher-linux-x64-glibc": ["@parcel/watcher-linux-x64-glibc@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ=="],
+
+    "@parcel/watcher-linux-x64-musl": ["@parcel/watcher-linux-x64-musl@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg=="],
+
+    "@parcel/watcher-win32-arm64": ["@parcel/watcher-win32-arm64@2.5.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q=="],
+
+    "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g=="],
+
+    "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
+
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
     "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
@@ -541,6 +578,8 @@
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
+
+    "@schummar/icu-type-parser": ["@schummar/icu-type-parser@1.21.5", "", {}, "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 
@@ -668,7 +707,37 @@
 
     "@supabase/supabase-js": ["@supabase/supabase-js@2.91.1", "", { "dependencies": { "@supabase/auth-js": "2.91.1", "@supabase/functions-js": "2.91.1", "@supabase/postgrest-js": "2.91.1", "@supabase/realtime-js": "2.91.1", "@supabase/storage-js": "2.91.1" } }, "sha512-57Fb4s5nfLn5ed2a1rPtl+LI1Wbtms8MS4qcUa0w6luaStBlFhmSeD2TLBgJWdMIupWRF6iFTH4QTrO2+pG/ZQ=="],
 
+    "@swc/core": ["@swc/core@1.15.40", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.26" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.40", "@swc/core-darwin-x64": "1.15.40", "@swc/core-linux-arm-gnueabihf": "1.15.40", "@swc/core-linux-arm64-gnu": "1.15.40", "@swc/core-linux-arm64-musl": "1.15.40", "@swc/core-linux-ppc64-gnu": "1.15.40", "@swc/core-linux-s390x-gnu": "1.15.40", "@swc/core-linux-x64-gnu": "1.15.40", "@swc/core-linux-x64-musl": "1.15.40", "@swc/core-win32-arm64-msvc": "1.15.40", "@swc/core-win32-ia32-msvc": "1.15.40", "@swc/core-win32-x64-msvc": "1.15.40" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg=="],
+
+    "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.40", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ=="],
+
+    "@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.40", "", { "os": "darwin", "cpu": "x64" }, "sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA=="],
+
+    "@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.40", "", { "os": "linux", "cpu": "arm" }, "sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA=="],
+
+    "@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.40", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ=="],
+
+    "@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.40", "", { "os": "linux", "cpu": "arm64" }, "sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ=="],
+
+    "@swc/core-linux-ppc64-gnu": ["@swc/core-linux-ppc64-gnu@1.15.40", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA=="],
+
+    "@swc/core-linux-s390x-gnu": ["@swc/core-linux-s390x-gnu@1.15.40", "", { "os": "linux", "cpu": "s390x" }, "sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg=="],
+
+    "@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.40", "", { "os": "linux", "cpu": "x64" }, "sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg=="],
+
+    "@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.40", "", { "os": "linux", "cpu": "x64" }, "sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA=="],
+
+    "@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.40", "", { "os": "win32", "cpu": "arm64" }, "sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A=="],
+
+    "@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.40", "", { "os": "win32", "cpu": "ia32" }, "sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw=="],
+
+    "@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.40", "", { "os": "win32", "cpu": "x64" }, "sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w=="],
+
+    "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
+
+    "@swc/types": ["@swc/types@0.1.26", "", { "dependencies": { "@swc/counter": "^0.1.3" } }, "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.18", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.18" } }, "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ=="],
 
@@ -1418,6 +1487,8 @@
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
+    "icu-minify": ["icu-minify@4.13.0", "", { "dependencies": { "@formatjs/icu-messageformat-parser": "^3.4.0" } }, "sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w=="],
+
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
@@ -1439,6 +1510,8 @@
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "intl-messageformat": ["intl-messageformat@11.2.7", "", { "dependencies": { "@formatjs/fast-memoize": "3.1.5", "@formatjs/icu-messageformat-parser": "3.5.10" } }, "sha512-+q6Ktg119nULZEpZ8YTuGOst9MyEzFtjD63FTGBlN1mLz0Z/MOUYDIvnpVKwq17eezIEh+cfJIebfJoCetpiNw=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -1774,7 +1847,13 @@
 
     "next": ["next@16.2.6", "", { "dependencies": { "@next/env": "16.2.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.6", "@next/swc-darwin-x64": "16.2.6", "@next/swc-linux-arm64-gnu": "16.2.6", "@next/swc-linux-arm64-musl": "16.2.6", "@next/swc-linux-x64-gnu": "16.2.6", "@next/swc-linux-x64-musl": "16.2.6", "@next/swc-win32-arm64-msvc": "16.2.6", "@next/swc-win32-x64-msvc": "16.2.6", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw=="],
 
+    "next-intl": ["next-intl@4.13.0", "", { "dependencies": { "@formatjs/intl-localematcher": "^0.8.1", "@parcel/watcher": "^2.4.1", "@swc/core": "^1.15.2", "icu-minify": "^4.13.0", "negotiator": "^1.0.0", "next-intl-swc-plugin-extractor": "^4.13.0", "po-parser": "^2.1.1", "use-intl": "^4.13.0" }, "peerDependencies": { "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0", "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-OvNq2v5XLx4EkQOsAhVE9g+6zdb83XHusADCXXtIW4LILYnjEVaeINdr1lkVWKSjzwNUiMSlH5N4K0OQTRiv6A=="],
+
+    "next-intl-swc-plugin-extractor": ["next-intl-swc-plugin-extractor@4.13.0", "", {}, "sha512-6S/fJI0KXvLCL8nhBo9P8eGaJPzmwJBTCzX0NaUIj0VyU8U89d//T+vjMLdNIXl5MlLaYH7B9MbAjb8Mvu+tqQ=="],
+
     "nextjs-toploader": ["nextjs-toploader@3.9.17", "", { "dependencies": { "nprogress": "^0.2.0", "prop-types": "^15.8.1" }, "peerDependencies": { "next": ">= 6.0.0", "react": ">= 16.0.0", "react-dom": ">= 16.0.0" } }, "sha512-9OF0KSSLtoSAuNg2LZ3aTl4hR9mBDj5L9s9DZiFCbMlXehyICGjkIz5dVGzuATU2bheJZoBdFgq9w07AKSuQQw=="],
+
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
@@ -1863,6 +1942,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "po-parser": ["po-parser@2.1.1", "", {}, "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -2215,6 +2296,8 @@
     "urlpattern-polyfill": ["urlpattern-polyfill@10.1.0", "", {}, "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
+    "use-intl": ["use-intl@4.13.0", "", { "dependencies": { "@formatjs/fast-memoize": "^3.1.0", "@schummar/icu-type-parser": "1.21.5", "icu-minify": "^4.13.0", "intl-messageformat": "^11.1.0" }, "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0" } }, "sha512-fAFDrWaASxlhXOipcOyb5VDD+YONqj6+8O8EcG/J7RBoOUF3A8YahRWLN+mBxYMrlMQB8N6Voqk5X+YC+HSL0A=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1,0 +1,855 @@
+{
+    "Metadata": {
+        "title": "Mike - AI Legal Platform",
+        "description": "AI-powered legal document analysis and contract review platform."
+    },
+    "Errors": {
+        "title": "Something went wrong",
+        "description": "We encountered an unexpected error. This has been logged and our team will look into it.",
+        "home": "Home"
+    },
+    "GlobalError": {
+        "title": "Something went wrong",
+        "description": "We encountered an unexpected error. This has been logged and our team will look into it.",
+        "back": "Back"
+    },
+    "NotFound": {
+        "title": "Page not found",
+        "description": "The page you're looking for doesn't exist or may have been moved.",
+        "goHome": "Go home"
+    },
+    "Layout": {
+        "openSidebar": "Open sidebar"
+    },
+    "LanguageSwitcher": {
+        "label": "Language"
+    },
+    "Assistant": {
+        "AddDocButton": {
+            "addDocuments": "Add documents",
+            "documents": "{count, plural, =1 {Document} other {Documents}}",
+            "uploading": "Uploading…",
+            "uploadFiles": "Upload files",
+            "browseAll": "Browse all"
+        },
+        "AssistantMessage": {
+            "toolCall": {
+                "generate_docx": "Creating document...",
+                "edit_document": "Editing document...",
+                "read_document": "Reading document...",
+                "fetch_documents": "Reading documents...",
+                "find_in_document": "Searching document...",
+                "replicate_document": "Copying document...",
+                "read_workflow": "Loading workflow...",
+                "list_workflows": "Loading workflows...",
+                "list_documents": "Loading documents...",
+                "running": "Running {name}...",
+                "working": "Working..."
+            },
+            "thinkingPhrase": {
+                "thinking": "Thinking...",
+                "pondering": "Pondering...",
+                "analyzing": "Analyzing...",
+                "reviewing": "Reviewing...",
+                "reasoning": "Reasoning..."
+            },
+            "thoughtProcess": "Thought process",
+            "bulkEdit": {
+                "acceptAll": "Accept all",
+                "rejectAll": "Reject all",
+                "view": "View",
+                "errorAccept": "Couldn't save one or more accepts.",
+                "errorReject": "Couldn't save one or more rejects."
+            },
+            "editSection": {
+                "pendingMultiDoc": "{count} tracked changes across {docCount} documents",
+                "pendingSingleDoc": "{count, plural, =1 {1 tracked change} other {# tracked changes}}",
+                "resolvedMultiDoc": "{count} resolved tracked changes across {docCount} documents",
+                "resolvedSingleDoc": "{count, plural, =1 {1 resolved tracked change} other {# resolved tracked changes}}",
+                "collapse": "Collapse edits",
+                "expand": "Expand edits"
+            },
+            "docRead": {
+                "reading": "Reading",
+                "read": "Read"
+            },
+            "docFind": {
+                "finding": "Finding",
+                "found": "Found",
+                "matches": "{count, plural, =1 {1 match} other {# matches}}",
+                "inFile": "in {filename}"
+            },
+            "docCreated": {
+                "creating": "Creating",
+                "created": "Created"
+            },
+            "docReplicated": {
+                "replicating": "Replicating",
+                "replicated": "Replicated",
+                "times": "{count} times"
+            },
+            "workflowApplied": {
+                "label": "Applied Workflow"
+            },
+            "docEdited": {
+                "editing": "Editing",
+                "editFailed": "Edit failed",
+                "edited": "Edited"
+            },
+            "error": {
+                "default": "Sorry, something went wrong."
+            }
+        },
+        "AssistantSidePanel": {
+            "closePanel": "Close panel"
+        },
+        "AssistantWorkflowModal": {
+            "breadcrumb": {
+                "projects": "Projects",
+                "assistant": "Assistant",
+                "addWorkflow": "Add workflow"
+            },
+            "searchPlaceholder": "Search workflows…",
+            "noMatches": "No matches found",
+            "noWorkflows": "No assistant workflows found",
+            "builtIn": "Built-in",
+            "custom": "Custom",
+            "workflowPrompt": "Workflow Prompt",
+            "noPromptDefined": "_No prompt defined._",
+            "cancel": "Cancel",
+            "use": "Use"
+        },
+        "ChatInput": {
+            "placeholder": "Ask a question about your documents...",
+            "openWorkflows": "Open workflows",
+            "workflows": "Workflows",
+            "openProjects": "Open projects",
+            "projects": "Projects"
+        },
+        "ChatView": {
+            "disclaimer": "AI can make mistakes. Answers are not legal advice."
+        },
+        "EditCard": {
+            "accept": "Accept",
+            "accepted": "Accepted",
+            "reject": "Reject",
+            "rejected": "Rejected",
+            "view": "View",
+            "viewDisabledTitle": "This change has been resolved and is no longer in the document.",
+            "errorAccept": "Couldn't save accept — reverted.",
+            "errorReject": "Couldn't save reject — reverted."
+        },
+        "InitialView": {
+            "greeting": "Hi, {username}",
+            "disclaimer": "AI can make mistakes. Answers are not legal advice."
+        },
+        "ModelToggle": {
+            "titleApiKeyMissing": "API key missing for selected model",
+            "titleChooseModel": "Choose model",
+            "ariaApiKeyMissing": "API key missing"
+        },
+        "SelectAssistantProjectModal": {
+            "breadcrumbAssistant": "Assistant",
+            "breadcrumbStartChat": "Start Chat in a Project",
+            "cancel": "Cancel",
+            "continue": "Continue"
+        },
+        "ProjectChatPage": {
+            "greeting": "Hi, {username}",
+            "breadcrumbProjects": "Projects",
+            "breadcrumbAssistant": "Assistant",
+            "untitledNewChat": "Untitled New Chat",
+            "newChatTitle": "New chat",
+            "deleteChatTitle": "Delete chat",
+            "explorerLabel": "Explorer",
+            "uploadDocumentsTitle": "Upload documents",
+            "collapseExplorerTitle": "Collapse explorer",
+            "dropToUpload": "Drop to upload",
+            "expandExplorerTitle": "Expand explorer",
+            "documentViewerLabel": "Document Viewer",
+            "projectAssistantLabel": "Project Assistant",
+            "docViewerEmptyTitle": "Click on a document to display here.",
+            "docViewerEmptyTip": "Pro tip: Drag a document from the Project Explorer to the Assistant to direct it to read or edit."
+        }
+    },
+    "Auth": {
+        "Login": {
+            "heading": "Log In",
+            "tabLogin": "Log in",
+            "tabSignup": "Sign up",
+            "emailLabel": "Email",
+            "emailPlaceholder": "Enter your email",
+            "passwordLabel": "Password",
+            "passwordPlaceholder": "Enter your password",
+            "button": "Log in",
+            "buttonLoading": "Logging in...",
+            "errorDefault": "An error occurred during login",
+            "demoDisclaimer": "Mike hosted on MikeOSS.com is currently a demo service. Please do not upload, submit, or store sensitive, confidential, privileged, client, or personally identifiable documents."
+        },
+        "Signup": {
+            "heading": "Create Account",
+            "tabLogin": "Log in",
+            "tabSignup": "Sign up",
+            "nameLabel": "Name",
+            "optional": "(optional)",
+            "namePlaceholder": "Your name",
+            "organisationLabel": "Organisation",
+            "organisationPlaceholder": "Your organisation",
+            "emailLabel": "Email",
+            "emailPlaceholder": "Enter your email",
+            "passwordLabel": "Password",
+            "passwordPlaceholder": "Create a password (min. 6 characters)",
+            "confirmPasswordLabel": "Confirm Password",
+            "confirmPasswordPlaceholder": "Confirm your password",
+            "button": "Sign up",
+            "buttonLoading": "Creating account...",
+            "errorPasswordsMismatch": "Passwords do not match",
+            "errorPasswordTooShort": "Password must be at least 6 characters",
+            "errorDefault": "An error occurred during signup",
+            "successHeading": "Account created!",
+            "successRedirecting": "Redirecting you to the home page...",
+            "termsPrefix": "By signing up, you agree to our",
+            "termsLink": "Terms of Use",
+            "termsAnd": "and",
+            "privacyLink": "Privacy Policy",
+            "demoDisclaimer": "Mike hosted on MikeOSS.com is currently a demo service. Please do not upload, submit, or store sensitive, confidential, privileged, client, or personally identifiable documents."
+        },
+        "Support": {
+            "heading": "Support",
+            "typeLabel": "What can we help you with?",
+            "typeBugLabel": "Bug Report",
+            "typeBugDescription": "Report something that isn't working",
+            "typeFeatureLabel": "Feature Request",
+            "typeFeatureDescription": "Suggest a new feature or improvement",
+            "typeQuestionLabel": "Question",
+            "typeQuestionDescription": "Ask a question about using Mike",
+            "typeOtherLabel": "Other",
+            "typeOtherDescription": "General feedback or other inquiries",
+            "linkLabel": "Link to issue (optional)",
+            "linkHint": "If the bug is in a chat, mouseover the chat in the sidebar, click the dots, then click share and paste the link here.",
+            "subjectLabel": "Subject",
+            "messageLabel": "Message",
+            "messagePlaceholder": "Please describe your question, issue, or suggestion in detail...",
+            "respondTo": "We'll respond to:",
+            "button": "Submit",
+            "buttonLoading": "Sending...",
+            "errorSubmit": "Failed to submit your feedback. Please try again.",
+            "successHeading": "Thank you for helping us improve.",
+            "successBody": "We will get in touch with you soon via email.",
+            "backToHome": "Back to Home"
+        }
+    },
+    "Account": {
+        "Layout": {
+            "pageTitle": "Settings",
+            "tabGeneral": "General",
+            "tabModels": "Models & API Keys"
+        },
+        "AccountPage": {
+            "profileSectionTitle": "Profile",
+            "displayNameLabel": "Display Name",
+            "displayNamePlaceholder": "Enter your name",
+            "organisationLabel": "Organisation",
+            "organisationPlaceholder": "Enter your organisation",
+            "emailLabel": "Email",
+            "planSectionTitle": "Usage Plan",
+            "actionsSectionTitle": "Actions",
+            "signOut": "Sign Out",
+            "languageSectionTitle": "Language",
+            "dangerZoneSectionTitle": "Danger Zone",
+            "dangerZoneDescription": "Permanently delete your account and all associated data. This action cannot be undone.",
+            "deleteConfirmPrompt": "Are you sure? This will permanently delete your account.",
+            "deleteCancel": "Cancel",
+            "deleteButton": "Delete Account",
+            "deleteButtonLoading": "Deleting…",
+            "buttonSave": "Save",
+            "buttonSaving": "Saving...",
+            "buttonSaved": "Saved",
+            "errorDeleteAccount": "Failed to delete account. Please try again.",
+            "errorUpdateDisplayName": "Failed to update display name. Please try again.",
+            "errorUpdateOrganisation": "Failed to update organisation. Please try again."
+        },
+        "ModelsPage": {
+            "modelPrefSectionTitle": "Model Preferences",
+            "tabularModelLabel": "Tabular review model",
+            "tabularModelHint": "We recommend using a smaller model for tabular reviews to reduce token costs.",
+            "selectModelPlaceholder": "Select a model",
+            "modelUnavailableTitle": "Add a {provider} API key to use this model",
+            "apiKeysSectionTitle": "API Keys",
+            "apiKeysDescription": "You must provide your own API keys for the app to work or add your API keys into the .env file if you are running your own instance of Mike.",
+            "apiKeysTitleRouting": "Title generation automatically routes to the cheapest configured provider model.",
+            "serverKeyConfigured": "A server .env key is configured for this provider. Browser API-key edits are disabled.",
+            "serverKeyWillBeUsed": "The server key will be used for this provider.",
+            "apiKeySavedHint": "A key is saved. Paste a new key to replace it.",
+            "apiKeyPlaceholderServer": "Server .env key configured",
+            "apiKeyPlaceholderSaved": "Saved key hidden",
+            "apiKeyShow": "Show key",
+            "apiKeyHide": "Hide key",
+            "apiKeySaveError": "Failed to save {label}.",
+            "apiKeyRemoveError": "Failed to remove {label}.",
+            "buttonSave": "Save",
+            "buttonSaving": "Saving...",
+            "buttonSaved": "Saved",
+            "buttonRemove": "Remove"
+        }
+    },
+    "Common": {
+        "CiteButton": {
+            "copyTitle": "Copy Quote and Citation",
+            "copied": "Copied",
+            "cite": "Cite"
+        },
+        "TextSearchWidget": {
+            "placeholder": "Find",
+            "matchPosition": "{current} of {total}",
+            "noResults": "No results"
+        }
+    },
+    "Documents": {
+        "DocPanel": {
+            "citation": "Citation",
+            "trackedChange": "Tracked Change",
+            "accept": "Accept",
+            "accepted": "Accepted",
+            "reject": "Reject",
+            "rejected": "Rejected",
+            "errorAccept": "Couldn't save accept — please retry.",
+            "errorReject": "Couldn't save reject — please retry.",
+            "download": "Download"
+        },
+        "DocumentCard": {
+            "processing": "Processing…",
+            "uploadFailed": "Upload failed",
+            "removeDocument": "Remove document"
+        },
+        "DocxView": {
+            "dismissWarning": "Dismiss warning"
+        },
+        "AddDocumentsModal": {
+            "searchPlaceholder": "Search…",
+            "noMatchesFound": "No matches found",
+            "noDocumentsYet": "No documents yet",
+            "uploading": "Uploading…",
+            "upload": "Upload",
+            "selected": "{count} selected",
+            "cancel": "Cancel",
+            "saving": "Saving…",
+            "confirm": "Confirm"
+        },
+        "AddProjectDocsModal": {
+            "searchPlaceholder": "Search…",
+            "noMatchesFound": "No matches found",
+            "noDocumentsInProject": "No documents in this project",
+            "alreadyAdded": "Already added",
+            "uploading": "Uploading…",
+            "upload": "Upload",
+            "selected": "{count} selected",
+            "cancel": "Cancel",
+            "confirm": "Confirm"
+        },
+        "UploadNewVersionModal": {
+            "headerTitle": "Upload new version · {filename}",
+            "newVersionName": "New version name",
+            "versionNamePlaceholder": "Version name",
+            "currentVersion": "Current Version:",
+            "newVersionFile": "New Version File:",
+            "changeFile": "Change file",
+            "upload": "Upload",
+            "cancel": "Cancel",
+            "saving": "Saving…",
+            "save": "Save"
+        },
+        "FileDirectory": {
+            "delete": "Delete",
+            "deselectAll": "Deselect all",
+            "selectAll": "Select all",
+            "uploading": "Uploading",
+            "projects": "Projects",
+            "emptyFolder": "Empty"
+        }
+    },
+    "Projects": {
+        "NewProjectModal": {
+            "breadcrumbProjects": "Projects",
+            "breadcrumbNew": "New project",
+            "placeholderName": "Project name",
+            "placeholderCmNumber": "Add a CM number...",
+            "membersButton": "Members{count, select, 0 {} other { ({count})}}",
+            "errorSelfShare": "You cannot share a project with yourself.",
+            "placeholderEmail": "Add colleagues by email…",
+            "selectDocuments": "Select documents",
+            "noExistingDocuments": "No existing documents",
+            "errorCreate": "Failed to create project",
+            "uploadFiles": "Upload files{count, select, 0 {} other { ({count})}}",
+            "cancel": "Cancel",
+            "creating": "Creating…",
+            "createProject": "Create project"
+        },
+        "ProjectAssistantTab": {
+            "columnChats": "Chats",
+            "columnCreated": "Created",
+            "emptyHeading": "Assistant",
+            "emptyBody": "Ask questions and get answers grounded in the documents in this project.",
+            "createNew": "+ Create New",
+            "untitledChat": "Untitled Chat"
+        },
+        "ProjectExplorer": {
+            "placeholderFolderName": "Folder name",
+            "emptyState": "No documents in this project.",
+            "contextNewSubfolder": "New subfolder",
+            "contextRename": "Rename",
+            "contextDeleteFolder": "Delete folder",
+            "contextDeleteFile": "Delete file"
+        },
+        "ProjectPageParts": {
+            "loadingVersions": "Loading versions…",
+            "noVersionHistory": "No version history.",
+            "versionOriginal": "Original",
+            "renameVersion": "Rename version",
+            "breadcrumbProjects": "Projects",
+            "tabAssistant": "Assistant",
+            "tabTabularReviews": "Tabular Reviews",
+            "searchPlaceholder": "Search…",
+            "peopleWithAccess": "People with access",
+            "chatButton": "Chat",
+            "tabularReviewButton": "Tabular Review",
+            "uploadDocumentFirst": "Upload a document first"
+        },
+        "ProjectPage": {
+            "projectNotFound": "Project not found",
+            "placeholderFolderName": "Folder name",
+            "uploading": "Uploading",
+            "dropFilesHere": "Drop PDF or DOCX files here",
+            "actions": "Actions",
+            "download": "Download",
+            "removeFromSubfolder": "Remove from subfolder",
+            "delete": "Delete",
+            "addSubfolder": "Add Subfolder",
+            "addDocuments": "Add Documents",
+            "colName": "Name",
+            "colType": "Type",
+            "colSize": "Size",
+            "colVersion": "Version",
+            "colCreated": "Created",
+            "colUpdated": "Updated",
+            "tabDocuments": "Documents",
+            "tabAssistant": "Assistant",
+            "tabTabularReviews": "Tabular Reviews"
+        },
+        "ProjectReviewsTab": {
+            "colName": "Name",
+            "colColumns": "Columns",
+            "colDocuments": "Documents",
+            "colCreated": "Created",
+            "emptyHeading": "Tabular Reviews",
+            "emptyDescription": "Extract data from project documents into tables using AI.",
+            "createNew": "+ Create New",
+            "untitledReview": "Untitled Review",
+            "ownerOnlyRename": "rename this tabular review"
+        },
+        "ProjectsOverview": {
+            "tabAll": "All",
+            "tabMine": "Mine",
+            "tabSharedWithMe": "Shared with me",
+            "actions": "Actions",
+            "delete": "Delete",
+            "heading": "Projects",
+            "searchPlaceholder": "Search projects…",
+            "colName": "Name",
+            "colCm": "CM",
+            "colFiles": "Files",
+            "colChats": "Chats",
+            "colTabularReviews": "Tabular Reviews",
+            "colCreated": "Created",
+            "loadError": "Could not load projects.",
+            "emptyDescription": "Upload documents into projects and to commence chats and tabular reviews with them.",
+            "createNew": "+ Create New",
+            "noSharedProjects": "No shared projects",
+            "ownerOnlyDelete": "delete {count} of the selected projects — only the project owner can delete a project",
+            "cmPlaceholder": "CM #"
+        }
+    },
+    "Shared": {
+        "AppSidebar": {
+            "closeSidebar": "Close sidebar",
+            "openSidebar": "Open sidebar",
+            "navAssistant": "Assistant",
+            "navProjects": "Projects",
+            "navTabularReview": "Tabular Review",
+            "navWorkflows": "Workflows",
+            "recentProjects": "Recent Projects",
+            "noProjectsYet": "No projects yet",
+            "assistantHistory": "Assistant History",
+            "noChatsYet": "No chats yet",
+            "loadMore": "Load more",
+            "accountSettings": "Account Settings"
+        },
+        "SidebarChatItem": {
+            "untitledChat": "Untitled chat",
+            "rename": "Rename",
+            "delete": "Delete"
+        },
+        "HeaderSearchBtn": {
+            "searchPlaceholder": "Search…"
+        },
+        "ProjectPicker": {
+            "searchPlaceholder": "Search projects…",
+            "noMatchesFound": "No matches found",
+            "noProjectsYet": "No projects yet",
+            "projectsHeader": "Projects"
+        },
+        "RowActions": {
+            "newSubfolder": "New subfolder",
+            "rename": "Rename",
+            "delete": "Delete",
+            "editCmNo": "Edit CM No.",
+            "download": "Download",
+            "showAllVersions": "Show all versions",
+            "uploadNewVersion": "Upload new version",
+            "removeFromSubfolder": "Remove from subfolder",
+            "unhide": "Unhide",
+            "hide": "Hide"
+        },
+        "PreResponseWrapper": {
+            "working": "Working",
+            "completed": "Completed in {count, plural, one {# step} other {# steps}}"
+        },
+        "EmailPillInput": {
+            "placeholder": "Add by email…",
+            "errorInvalidEmail": "Enter a valid email address.",
+            "errorVerifyFailed": "Could not verify email. Try again.",
+            "checking": "Checking…"
+        },
+        "PeopleModal": {
+            "addByEmailPlaceholder": "Add by email…",
+            "addMemberTitle": "Add member",
+            "hintAlreadyShared": "{email} already has access.",
+            "hintIsOwner": "{email} is the owner.",
+            "hintSelf": "You cannot share this with yourself.",
+            "hintInvalidEmail": "Enter a valid email.",
+            "sectionHeading": "People with Access",
+            "emptyRoster": "No one has access yet.",
+            "tagYou": "(You)",
+            "tagOwner": "Owner",
+            "removeAccessTitle": "Remove access",
+            "removeLabel": "Remove",
+            "footerCount": "{count, plural, one {# person with access.} other {# people with access.}}",
+            "errorAdd": "Couldn't add the member. Try again.",
+            "errorRemove": "Couldn't remove the member. Try again."
+        },
+        "OwnerOnlyModal": {
+            "defaultTitle": "Owner-only action",
+            "bodyWithAction": "Only the project owner can {action}.",
+            "bodyDefault": "Only the project owner can perform this action.",
+            "askOwner": "Ask <em>{email}</em> if you need access.",
+            "ok": "OK"
+        },
+        "ApiKeyMissingModal": {
+            "thisProvider": "this provider",
+            "title": "API key required",
+            "body": "You haven't added a {providerName} API key yet. Add one in your account settings to use this model.",
+            "cancel": "Cancel",
+            "goToAccountSettings": "Go to account settings"
+        }
+    },
+    "Tabular": {
+        "AddColumnModal": {
+            "breadcrumbRoot": "Tabular Review",
+            "editColumn": "Edit column",
+            "newColumn": "New column",
+            "columnNamePlaceholder": "Column name",
+            "columnPresetsTitle": "Column presets",
+            "noPreset": "No Preset",
+            "formatLabel": "Format",
+            "tagsLabel": "Tags",
+            "addTagPlaceholder": "Add tag…",
+            "tagHint": "Press Enter or comma to add a tag.",
+            "promptLabel": "Prompt",
+            "autoGeneratePrompt": "Auto-Generate Prompt",
+            "promptPlaceholder": "Write the analysis prompt — describe what Mike should extract from each document for this column…",
+            "addAnotherColumn": "Add another column",
+            "delete": "Delete",
+            "cancel": "Cancel",
+            "saveChanges": "Save changes",
+            "addColumns": "Add columns"
+        },
+        "AddNewTRModal": {
+            "breadcrumbProjects": "Projects",
+            "breadcrumbTabularReviews": "Tabular Reviews",
+            "breadcrumbNewReview": "New review",
+            "reviewNamePlaceholder": "Review name",
+            "workflowTemplateLabel": "Workflow Template",
+            "loadingTemplates": "Loading templates…",
+            "noTemplate": "No template — start from scratch",
+            "createUnderProject": "Create under a project",
+            "selectProject": "Select project…",
+            "noProjectsFound": "No projects found",
+            "selectDocumentsLabel": "Select Documents",
+            "projectDocumentsHeading": "Project Documents",
+            "documentsHeading": "Documents",
+            "noReadyDocuments": "No ready documents in this project",
+            "noDocumentsYet": "No documents yet",
+            "uploading": "Uploading…",
+            "upload": "Upload",
+            "cancel": "Cancel",
+            "create": "Create"
+        },
+        "TabularCell": {
+            "seeDetails": "See details"
+        },
+        "TabularReviewView": {
+            "breadcrumbProjects": "Projects",
+            "breadcrumbTabularReviews": "Tabular Reviews",
+            "breadcrumbPeople": "People",
+            "untitledReview": "Untitled Review",
+            "peopleWithAccess": "People with access",
+            "exportToExcel": "Export to Excel",
+            "export": "Export",
+            "running": "Running…",
+            "run": "Run",
+            "assistantInTabularReview": "Assistant in Tabular Review",
+            "actions": "Actions",
+            "clearResults": "Clear results",
+            "delete": "Delete",
+            "addDocuments": "Add Documents",
+            "addColumns": "Add Columns"
+        },
+        "TRChatPanel": {
+            "thinkingPhrase0": "Thinking...",
+            "thinkingPhrase1": "Pondering...",
+            "thinkingPhrase2": "Analyzing...",
+            "thinkingPhrase3": "Reasoning...",
+            "thoughtProcess": "Thought process",
+            "reading": "Reading",
+            "read": "Read",
+            "chatInputPlaceholder": "Ask a question about your documents...",
+            "searchChatsPlaceholder": "Search chats…",
+            "noPreviousChats": "No previous chats.",
+            "noMatches": "No matches.",
+            "assistantTitle": "Assistant",
+            "chatHistoryTitle": "Chat history",
+            "newChatTitle": "New chat",
+            "deleteChatTitle": "Delete chat",
+            "closeTitle": "Close",
+            "emptyState": "Ask a question about this tabular review.",
+            "errorOccurred": "An error occurred. Please try again."
+        },
+        "TREditColumnMenu": {
+            "editColumn": "Edit Column",
+            "labelField": "Label",
+            "formatLabel": "Format",
+            "addTagsPlaceholder": "Add tags…",
+            "promptLabel": "Prompt",
+            "autoGenerate": "Auto-generate",
+            "delete": "Delete",
+            "saving": "Saving…",
+            "save": "Save"
+        },
+        "TRSidePanel": {
+            "flagHeading": "Flag",
+            "resultsHeading": "Results",
+            "reasoningHeading": "Reasoning"
+        },
+        "TRTable": {
+            "documentColumn": "Document",
+            "emptyTitle": "Tabular Review",
+            "emptySubtitle": "Add columns and documents to get started.",
+            "addColumns": "+ Add Columns",
+            "addDocuments": "Add Documents"
+        },
+        "TabularReviewsPage": {
+            "pageTitle": "Tabular Reviews",
+            "searchPlaceholder": "Search reviews…",
+            "tab_all": "All",
+            "tab_in-project": "In Project",
+            "tab_standalone": "Standalone",
+            "colName": "Name",
+            "colColumns": "Columns",
+            "colDocuments": "Documents",
+            "colProject": "Project",
+            "colCreated": "Created",
+            "filterByProject": "Filter by project",
+            "allProjects": "All Projects",
+            "actions": "Actions",
+            "delete": "Delete",
+            "emptyTitle": "Tabular Reviews",
+            "emptySubtitle": "Extract data from documents into tables using AI.",
+            "createNew": "+ Create New",
+            "noReviewsFound": "No reviews found",
+            "untitledReview": "Untitled Review"
+        }
+    },
+    "Workflows": {
+        "DisplayWorkflowModal": {
+            "breadcrumbWorkflows": "Workflows",
+            "breadcrumbSelect": "Select workflow",
+            "newChat": "New Chat",
+            "newReview": "New Review",
+            "searchPlaceholder": "Search…",
+            "selectProjectPlaceholder": "Select a project…",
+            "noProjectsFound": "No projects found",
+            "workflowPrompt": "Workflow Prompt",
+            "noPromptDefined": "_No prompt defined._",
+            "columns": "Columns",
+            "noColumnsDefined": "No columns defined",
+            "tags": "Tags",
+            "prompt": "Prompt",
+            "viewPage": "View Page",
+            "edit": "Edit",
+            "use": "Use",
+            "messageOptional": "Message (optional)",
+            "additionalInstructionsPlaceholder": "Add any additional instructions to the workflow prompt…",
+            "createInProject": "Create in a project",
+            "selectProject": "Select project",
+            "selectDocuments": "Select documents",
+            "noMatchesFound": "No matches found",
+            "noDocumentsYet": "No documents yet",
+            "noDocumentsInProject": "No documents in this project",
+            "selectedCount": "{count} selected",
+            "starting": "Starting…",
+            "startChat": "Start Chat",
+            "creating": "Creating…",
+            "createReview": "Create Review"
+        },
+        "NewWorkflowModal": {
+            "breadcrumbWorkflows": "Workflows",
+            "breadcrumbEdit": "Edit workflow",
+            "breadcrumbNew": "New workflow",
+            "namePlaceholder": "Workflow name",
+            "typeLabel": "Type",
+            "typeAssistant": "Assistant",
+            "typeTabular": "Tabular",
+            "practiceAreaLabel": "Practice Area",
+            "customPracticePlaceholder": "Enter practice area…",
+            "errorUpdate": "Failed to update workflow",
+            "errorCreate": "Failed to create workflow",
+            "cancel": "Cancel",
+            "saving": "Saving…",
+            "creating": "Creating…",
+            "saveChanges": "Save changes",
+            "createWorkflow": "Create workflow"
+        },
+        "ShareWorkflowModal": {
+            "breadcrumbWorkflows": "Workflows",
+            "breadcrumbPeople": "People",
+            "cannotShareWithSelf": "You cannot share a workflow with yourself.",
+            "addPeoplePlaceholder": "Add people by email…",
+            "allowEditing": "Allow editing by share recipients",
+            "peopleWithAccess": "People with access",
+            "none": "None",
+            "canEdit": "Can edit",
+            "readOnly": "Read-only",
+            "cancel": "Cancel",
+            "sharing": "Sharing…",
+            "share": "Share"
+        },
+        "WFColumnViewModal": {
+            "breadcrumbWorkflows": "Workflows",
+            "columnTitle": "Column Title",
+            "format": "Format",
+            "tags": "Tags",
+            "prompt": "Prompt",
+            "noPromptDefined": "_No prompt defined._",
+            "close": "Close"
+        },
+        "WFEditColumnModal": {
+            "breadcrumbWorkflows": "Workflows",
+            "breadcrumbEditColumn": "Edit column",
+            "columnNamePlaceholder": "Column name",
+            "columnPresetsTitle": "Column presets",
+            "noPreset": "No Preset",
+            "formatLabel": "Format",
+            "tagsLabel": "Tags",
+            "addTagPlaceholder": "Add tag…",
+            "addTagHint": "Press Enter or comma to add a tag.",
+            "promptLabel": "Prompt",
+            "autoGeneratePrompt": "Auto-Generate Prompt",
+            "promptPlaceholder": "Write the analysis prompt — describe what Mike should extract from each document for this column…",
+            "delete": "Delete",
+            "cancel": "Cancel",
+            "saveChanges": "Save changes"
+        },
+        "WorkflowList": {
+            "tabAll": "All",
+            "tabBuiltin": "Built-in",
+            "tabCustom": "Custom",
+            "tabHidden": "Hidden",
+            "pageTitle": "Workflows",
+            "searchPlaceholder": "Search workflows…",
+            "filterByType": "Filter by type",
+            "allTypes": "All Types",
+            "typeTabular": "Tabular",
+            "typeAssistant": "Assistant",
+            "filterByPractice": "Filter by practice",
+            "allPractices": "All Practices",
+            "actions": "Actions",
+            "unhide": "Unhide",
+            "delete": "Delete",
+            "colName": "Name",
+            "colType": "Type",
+            "colPractice": "Practice",
+            "colSource": "Source",
+            "sourceMike": "Mike",
+            "sourceMyself": "Myself",
+            "sourceShared": "Shared",
+            "emptyCustomTitle": "Custom Workflows",
+            "emptyCustomDescription": "Build reusable prompts and tabular review templates tailored to your practice.",
+            "createNew": "+ Create New",
+            "emptyHiddenTitle": "Hidden Workflows",
+            "emptyHiddenDescription": "Built-in workflows you've hidden will appear here. You can unhide them at any time.",
+            "emptyAllTitle": "Workflows",
+            "emptyAllDescription": "Automate document analysis with reusable prompts and tabular review templates."
+        },
+        "WorkflowPromptEditor": {
+            "heading1": "Heading 1",
+            "heading2": "Heading 2",
+            "heading3": "Heading 3",
+            "bold": "Bold",
+            "italic": "Italic",
+            "bulletList": "Bullet list",
+            "numberedList": "Numbered list"
+        },
+        "WorkflowDetailPage": {
+            "notFound": "Workflow not found.",
+            "breadcrumbWorkflows": "Workflows",
+            "saving": "Saving…",
+            "saved": "Saved",
+            "shareAriaLabel": "Open workflow people",
+            "shareTitle": "People",
+            "readOnly": "Read-only",
+            "addColumn": "Add Column",
+            "actions": "Actions",
+            "delete": "Delete",
+            "colColumnTitle": "Column Title",
+            "colFormat": "Format",
+            "colPrompt": "Prompt",
+            "emptyColumnsTitle": "Columns",
+            "emptyColumnsDescription": "Add columns to define what this tabular review workflow extracts from each document.",
+            "addColumnButton": "+ Add Column"
+        }
+    },
+    "Modals": {
+        "CreditsExhaustedModal": {
+            "title": "Message Limit Reached",
+            "limitReached": "You've reached your monthly message limit of 100 messages.",
+            "resetLabel": "Your credits will reset on:",
+            "autoResetNote": "Your message credits automatically reset on the first day of each month.",
+            "close": "Close"
+        },
+        "DeleteChatsModal": {
+            "successTitle": "All Chats Deleted",
+            "successMessage": "Your chat history has been successfully deleted.",
+            "title": "Delete All Chats",
+            "confirmMessage": "Are you sure you want to delete all {count, plural, one {# chat} other {# chats}}? This action is permanent and cannot be undone.",
+            "deleting": "Deleting...",
+            "deleteAll": "Delete All Chats",
+            "cancel": "Cancel"
+        },
+        "SimpleLinkDialog": {
+            "title": "Share Chat",
+            "shareLink": "Share Link",
+            "copied": "Copied!",
+            "copyLink": "Copy Link"
+        }
+    }
+}

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,4 +1,7 @@
 import type { NextConfig } from "next";
+import createNextIntlPlugin from "next-intl/plugin";
+
+const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
     /* config options here */
@@ -18,4 +21,4 @@ const nextConfig: NextConfig = {
     skipTrailingSlashRedirect: true,
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
         "mammoth": "^1.11.0",
         "marked": "^17.0.1",
         "next": "^16.2.6",
+        "next-intl": "^4.13.0",
         "nextjs-toploader": "^3.9.17",
         "pdfjs-dist": "4.10.38",
         "react": "19.2.0",

--- a/frontend/src/app/(pages)/account/layout.tsx
+++ b/frontend/src/app/(pages)/account/layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { usePathname, useRouter } from "next/navigation";
 import { Loader2 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
@@ -11,19 +12,20 @@ interface TabDef {
     href: string;
 }
 
-const TABS: TabDef[] = [
-    { id: "general", label: "General", href: "/account" },
-    { id: "models", label: "Models & API Keys", href: "/account/models" },
-];
-
 export default function AccountLayout({
     children,
 }: {
     children: React.ReactNode;
 }) {
+    const t = useTranslations("Account.Layout");
     const router = useRouter();
     const pathname = usePathname();
     const { isAuthenticated, authLoading } = useAuth();
+
+    const TABS: TabDef[] = [
+        { id: "general", label: t("tabGeneral"), href: "/account" },
+        { id: "models", label: t("tabModels"), href: "/account/models" },
+    ];
 
     useEffect(() => {
         if (!authLoading && !isAuthenticated) {
@@ -47,7 +49,7 @@ export default function AccountLayout({
         <div className="flex h-full flex-col overflow-y-auto">
             <header className="mx-auto flex h-16 w-full max-w-5xl shrink-0 items-end px-6 pb-2 md:h-24 md:pb-4">
                 <h1 className="text-4xl font-medium font-eb-garamond">
-                    Settings
+                    {t("pageTitle")}
                 </h1>
             </header>
 

--- a/frontend/src/app/(pages)/account/models/page.tsx
+++ b/frontend/src/app/(pages)/account/models/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { AlertCircle, Check, ChevronDown, Eye, EyeOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -40,6 +41,7 @@ const API_KEY_FIELDS = [
 ] as const;
 
 export default function ModelsAndApiKeysPage() {
+    const t = useTranslations("Account.ModelsPage");
     const { profile, updateModelPreference, updateApiKey } = useUserProfile();
 
     return (
@@ -48,17 +50,16 @@ export default function ModelsAndApiKeysPage() {
             <div className="pb-6">
                 <div className="flex items-center gap-2 mb-4">
                     <h2 className="text-2xl font-medium font-serif">
-                        Model Preferences
+                        {t("modelPrefSectionTitle")}
                     </h2>
                 </div>
                 <div className="space-y-4 max-w-md">
                     <div>
                         <label className="text-sm text-gray-600 block mb-2">
-                            Tabular review model
+                            {t("tabularModelLabel")}
                         </label>
                         <p className="text-xs text-gray-400 mb-2">
-                            We recommend using a smaller model for tabular
-                            reviews to reduce token costs.
+                            {t("tabularModelHint")}
                         </p>
                         <TabularModelDropdown
                             value={
@@ -78,17 +79,14 @@ export default function ModelsAndApiKeysPage() {
             <div className="py-6">
                 <div className="flex items-center gap-2 mb-2">
                     <h2 className="text-2xl font-medium font-serif">
-                        API Keys
+                        {t("apiKeysSectionTitle")}
                     </h2>
                 </div>
                 <p className="text-sm text-gray-500 mb-4 max-w-xl">
-                    You must provide your own API keys for the app to work or
-                    add your API keys into the .env file if you are running your
-                    own instance of Mike.
+                    {t("apiKeysDescription")}
                 </p>
                 <p className="text-xs text-gray-400 mb-4 max-w-xl">
-                    Title generation automatically routes to the cheapest
-                    configured provider model.
+                    {t("apiKeysTitleRouting")}
                 </p>
                 <div className="space-y-4 max-w-xl">
                     {API_KEY_FIELDS.map((field) => (
@@ -129,6 +127,7 @@ function TabularModelDropdown({
     onChange: (id: string) => void;
     apiKeys?: ApiKeyState;
 }) {
+    const t = useTranslations("Account.ModelsPage");
     const [isOpen, setIsOpen] = useState(false);
     const selected = MODELS.find((m) => m.id === value);
     const selectedAvailable = apiKeys ? isModelAvailable(value, apiKeys) : true;
@@ -150,7 +149,7 @@ function TabularModelDropdown({
                             <AlertCircle className="h-3.5 w-3.5 shrink-0 text-red-500" />
                         )}
                         <span className="truncate text-gray-900">
-                            {selected?.label ?? "Select a model"}
+                            {selected?.label ?? t("selectModelPlaceholder")}
                         </span>
                     </span>
                     <ChevronDown
@@ -184,7 +183,7 @@ function TabularModelDropdown({
                                         onSelect={() => onChange(m.id)}
                                         title={
                                             !available
-                                                ? `Add a ${providerLabel(provider)} API key to use this model`
+                                                ? t("modelUnavailableTitle", { provider: providerLabel(provider) })
                                                 : undefined
                                         }
                                     >
@@ -225,6 +224,7 @@ function ApiKeyField({
     onSave: (value: string) => Promise<boolean>;
     onRemove: () => Promise<boolean>;
 }) {
+    const t = useTranslations("Account.ModelsPage");
     const [value, setValue] = useState("");
     const [reveal, setReveal] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
@@ -245,7 +245,7 @@ function ApiKeyField({
             setSaved(true);
             setTimeout(() => setSaved(false), 2000);
         } else {
-            alert(`Failed to save ${label}.`);
+            alert(t("apiKeySaveError", { label }));
         }
     };
 
@@ -253,7 +253,7 @@ function ApiKeyField({
         setIsSaving(true);
         const ok = await onRemove();
         setIsSaving(false);
-        if (!ok) alert(`Failed to remove ${label}.`);
+        if (!ok) alert(t("apiKeyRemoveError", { label }));
     };
 
     return (
@@ -262,19 +262,18 @@ function ApiKeyField({
             {isServerConfigured && (
                 <div className="mb-2 rounded-md border border-blue-100 bg-blue-50 px-3 py-2">
                     <p className="text-xs text-blue-800">
-                        A server .env key is configured for this provider.
-                        Browser API-key edits are disabled.
+                        {t("serverKeyConfigured")}
                     </p>
                     {hasSavedKey && (
                         <p className="mt-1 text-xs text-blue-800">
-                            The server key will be used for this provider.
+                            {t("serverKeyWillBeUsed")}
                         </p>
                     )}
                 </div>
             )}
             {hasSavedKey && !isServerConfigured && (
                 <p className="text-xs text-gray-500 mb-2">
-                    A key is saved. Paste a new key to replace it.
+                    {t("apiKeySavedHint")}
                 </p>
             )}
             <div className="flex gap-2">
@@ -285,9 +284,9 @@ function ApiKeyField({
                         onChange={(e) => setValue(e.target.value)}
                         placeholder={
                             isServerConfigured
-                                ? "Server .env key configured"
+                                ? t("apiKeyPlaceholderServer")
                                 : hasSavedKey
-                                  ? "Saved key hidden"
+                                  ? t("apiKeyPlaceholderSaved")
                                   : placeholder
                         }
                         className="pr-10"
@@ -300,7 +299,7 @@ function ApiKeyField({
                         onClick={() => setReveal((r) => !r)}
                         disabled={isServerConfigured}
                         className="absolute inset-y-0 right-2 flex items-center text-gray-400 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-40"
-                        aria-label={reveal ? "Hide key" : "Show key"}
+                        aria-label={reveal ? t("apiKeyHide") : t("apiKeyShow")}
                     >
                         {reveal ? (
                             <EyeOff className="h-4 w-4" />
@@ -315,14 +314,14 @@ function ApiKeyField({
                     className="min-w-[80px] transition-all bg-black hover:bg-gray-900 text-white"
                 >
                     {isSaving ? (
-                        "Saving..."
+                        t("buttonSaving")
                     ) : saved ? (
                         <>
                             <Check className="h-4 w-3" />
-                            Saved
+                            {t("buttonSaved")}
                         </>
                     ) : (
-                        "Save"
+                        t("buttonSave")
                     )}
                 </Button>
                 {hasSavedKey && !isServerConfigured && (
@@ -332,7 +331,7 @@ function ApiKeyField({
                         onClick={handleRemove}
                         disabled={isSaving}
                     >
-                        Remove
+                        {t("buttonRemove")}
                     </Button>
                 )}
             </div>

--- a/frontend/src/app/(pages)/account/page.tsx
+++ b/frontend/src/app/(pages)/account/page.tsx
@@ -8,8 +8,11 @@ import { LogOut, Check } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUserProfile } from "@/contexts/UserProfileContext";
 import { deleteAccount } from "@/app/lib/mikeApi";
+import { useTranslations } from "next-intl";
+import { LanguageSwitcher } from "@/app/components/shared/LanguageSwitcher";
 
 export default function AccountPage() {
+    const t = useTranslations("Account.AccountPage");
     const router = useRouter();
     const { user, signOut } = useAuth();
     const { profile, updateDisplayName, updateOrganisation } = useUserProfile();
@@ -45,7 +48,7 @@ export default function AccountPage() {
         } catch {
             setIsDeleting(false);
             setDeleteConfirm(false);
-            alert("Failed to delete account. Please try again.");
+            alert(t("errorDeleteAccount"));
         }
     };
 
@@ -58,7 +61,7 @@ export default function AccountPage() {
             setSaved(true);
             setTimeout(() => setSaved(false), 2000);
         } else {
-            alert("Failed to update display name. Please try again.");
+            alert(t("errorUpdateDisplayName"));
         }
     };
 
@@ -71,7 +74,7 @@ export default function AccountPage() {
             setOrgSaved(true);
             setTimeout(() => setOrgSaved(false), 2000);
         } else {
-            alert("Failed to update organisation. Please try again.");
+            alert(t("errorUpdateOrganisation"));
         }
     };
 
@@ -82,19 +85,19 @@ export default function AccountPage() {
             {/* Profile Settings */}
             <div className="pb-6">
                 <div className="flex items-center gap-2 mb-4">
-                    <h2 className="text-2xl font-medium font-serif">Profile</h2>
+                    <h2 className="text-2xl font-medium font-serif">{t("profileSectionTitle")}</h2>
                 </div>
                 <div className="space-y-4">
                     <div>
                         <label className="text-sm text-gray-600 block mb-2">
-                            Display Name
+                            {t("displayNameLabel")}
                         </label>
                         <div className="flex gap-2">
                             <Input
                                 type="text"
                                 value={displayName}
                                 onChange={(e) => setDisplayName(e.target.value)}
-                                placeholder="Enter your name"
+                                placeholder={t("displayNamePlaceholder")}
                                 className="flex-1"
                             />
                             <Button
@@ -105,21 +108,21 @@ export default function AccountPage() {
                                 className="min-w-[80px] transition-all bg-black hover:bg-gray-900 text-white"
                             >
                                 {isSavingName ? (
-                                    "Saving..."
+                                    t("buttonSaving")
                                 ) : saved ? (
                                     <>
                                         <Check className="h-4 w-3" />
-                                        Saved
+                                        {t("buttonSaved")}
                                     </>
                                 ) : (
-                                    "Save"
+                                    t("buttonSave")
                                 )}
                             </Button>
                         </div>
                     </div>
                     <div>
                         <label className="text-sm text-gray-600 block mb-2">
-                            Organisation
+                            {t("organisationLabel")}
                         </label>
                         <div className="flex gap-2">
                             <Input
@@ -128,7 +131,7 @@ export default function AccountPage() {
                                 onChange={(e) =>
                                     setOrganisation(e.target.value)
                                 }
-                                placeholder="Enter your organisation"
+                                placeholder={t("organisationPlaceholder")}
                                 className="flex-1"
                             />
                             <Button
@@ -142,21 +145,21 @@ export default function AccountPage() {
                                 className="min-w-[80px] transition-all bg-black hover:bg-gray-900 text-white"
                             >
                                 {isSavingOrg ? (
-                                    "Saving..."
+                                    t("buttonSaving")
                                 ) : orgSaved ? (
                                     <>
                                         <Check className="h-4 w-3" />
-                                        Saved
+                                        {t("buttonSaved")}
                                     </>
                                 ) : (
-                                    "Save"
+                                    t("buttonSave")
                                 )}
                             </Button>
                         </div>
                     </div>
                     <div>
                         <label className="text-sm text-gray-600 block mb-2">
-                            Email
+                            {t("emailLabel")}
                         </label>
                         <p className="text-base">{user?.email}</p>
                     </div>
@@ -167,7 +170,7 @@ export default function AccountPage() {
             <div className="py-6">
                 <div className="flex items-center gap-2 mb-4">
                     <h2 className="text-2xl font-medium font-serif">
-                        Usage Plan
+                        {t("planSectionTitle")}
                     </h2>
                 </div>
                 <div>
@@ -180,7 +183,7 @@ export default function AccountPage() {
             {/* Actions */}
             <div className="py-6">
                 <h2 className="text-2xl font-medium font-serif mb-4">
-                    Actions
+                    {t("actionsSectionTitle")}
                 </h2>
                 <Button
                     variant="outline"
@@ -188,24 +191,30 @@ export default function AccountPage() {
                     className="w-full sm:w-auto"
                 >
                     <LogOut className="h-4 w-4 mr-2" />
-                    Sign Out
+                    {t("signOut")}
                 </Button>
+            </div>
+
+            {/* Language */}
+            <div className="py-6">
+                <h2 className="text-2xl font-medium font-serif mb-4">
+                    {t("languageSectionTitle")}
+                </h2>
+                <LanguageSwitcher />
             </div>
 
             {/* Danger Zone */}
             <div className="py-6">
                 <h2 className="text-2xl font-medium font-serif mb-1 text-red-600">
-                    Danger Zone
+                    {t("dangerZoneSectionTitle")}
                 </h2>
                 <p className="text-sm text-gray-500 mb-4">
-                    Permanently delete your account and all associated data.
-                    This action cannot be undone.
+                    {t("dangerZoneDescription")}
                 </p>
                 {deleteConfirm ? (
                     <div className="rounded-lg border border-red-200 bg-red-50 p-4 space-y-3 max-w-sm">
                         <p className="text-sm font-medium text-red-700">
-                            Are you sure? This will permanently delete your
-                            account.
+                            {t("deleteConfirmPrompt")}
                         </p>
                         <div className="flex gap-2">
                             <Button
@@ -214,14 +223,14 @@ export default function AccountPage() {
                                 disabled={isDeleting}
                                 className="text-sm"
                             >
-                                Cancel
+                                {t("deleteCancel")}
                             </Button>
                             <Button
                                 onClick={handleDeleteAccount}
                                 disabled={isDeleting}
                                 className="text-sm bg-red-600 hover:bg-red-700 text-white"
                             >
-                                {isDeleting ? "Deleting…" : "Delete Account"}
+                                {isDeleting ? t("deleteButtonLoading") : t("deleteButton")}
                             </Button>
                         </div>
                     </div>
@@ -231,7 +240,7 @@ export default function AccountPage() {
                         onClick={() => setDeleteConfirm(true)}
                         className="w-full sm:w-auto border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700"
                     >
-                        Delete Account
+                        {t("deleteButton")}
                     </Button>
                 )}
             </div>

--- a/frontend/src/app/(pages)/layout.tsx
+++ b/frontend/src/app/(pages)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { PanelLeft } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { ChatHistoryProvider } from "@/app/contexts/ChatHistoryContext";
@@ -13,6 +14,7 @@ export default function MikeLayout({
 }: {
     children: React.ReactNode;
 }) {
+    const t = useTranslations("Layout");
     const { isAuthenticated, authLoading } = useAuth();
     const router = useRouter();
 
@@ -96,8 +98,8 @@ export default function MikeLayout({
                                 <button
                                     onClick={handleSidebarToggle}
                                     className="flex h-8 w-8 items-center justify-center rounded-full bg-white/70 text-gray-700 shadow-[0_8px_24px_rgba(15,23,42,0.12)] ring-1 ring-white/70 backdrop-blur-md transition-all hover:bg-white/90 active:scale-95"
-                                    title="Open sidebar"
-                                    aria-label="Open sidebar"
+                                    title={t("openSidebar")}
+                                    aria-label={t("openSidebar")}
                                 >
                                     <PanelLeft className="h-4 w-4" />
                                 </button>

--- a/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.tsx
+++ b/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.tsx
@@ -9,6 +9,7 @@ import {
     useRef,
     useState,
 } from "react";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import {
     ChevronLeft,
@@ -92,6 +93,7 @@ const CHAT_MIN = 320;
 const CHAT_DEFAULT = 420;
 
 function AssistantGreeting({ username }: { username: string }) {
+    const t = useTranslations("Assistant.ProjectChatPage");
     const { profile } = useUserProfile();
     const [loaded, setLoaded] = useState(false);
     const [iconOffset, setIconOffset] = useState(0);
@@ -140,7 +142,7 @@ function AssistantGreeting({ username }: { username: string }) {
                             "transform 900ms cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity 800ms ease-in-out 300ms",
                     }}
                 >
-                    Hi, {username}
+                    {t("greeting", { username })}
                 </h1>
             </div>
         </div>
@@ -199,6 +201,7 @@ function Divider({ onDrag }: { onDrag: (dx: number) => void }) {
 export default function ProjectAssistantChatPage({ params }: Props) {
     const { id: projectId, chatId } = use(params);
     const router = useRouter();
+    const t = useTranslations("Assistant.ProjectChatPage");
 
     const { setSidebarOpen } = useSidebar();
     const { user } = useAuth();
@@ -759,7 +762,7 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                         onClick={() => router.push("/projects")}
                         className="text-gray-500 hover:text-gray-700 transition-colors"
                     >
-                        Projects
+                        {t("breadcrumbProjects")}
                     </button>
                     <span className="text-gray-300">›</span>
                     {project ? (
@@ -786,12 +789,12 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                         }
                         className="text-gray-500 hover:text-gray-700 transition-colors"
                     >
-                        Assistant
+                        {t("breadcrumbAssistant")}
                     </button>
                     <span className="text-gray-300">›</span>
                     {chatLoaded ? (
                         <span className="text-gray-900 truncate max-w-xs">
-                            {chatTitle ?? "Untitled New Chat"}
+                            {chatTitle ?? t("untitledNewChat")}
                         </span>
                     ) : (
                         <div className="h-6 w-40 rounded bg-gray-100 animate-pulse" />
@@ -801,7 +804,7 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                     <button
                         onClick={handleNewChat}
                         disabled={creatingChat}
-                        title="New chat"
+                        title={t("newChatTitle")}
                         className="flex items-center justify-center p-1.5 text-gray-500 hover:text-gray-900 transition-colors disabled:opacity-40"
                     >
                         {creatingChat ? (
@@ -813,7 +816,7 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                     <button
                         onClick={handleDeleteChat}
                         disabled={deletingChat}
-                        title="Delete chat"
+                        title={t("deleteChatTitle")}
                         className="flex items-center justify-center p-1.5 text-gray-500 hover:text-red-600 transition-colors disabled:opacity-40"
                     >
                         {deletingChat ? (
@@ -858,7 +861,7 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                             {/* Explorer header */}
                             <div className="h-10 flex items-center justify-between px-3 border-b border-gray-200 shrink-0">
                                 <span className="text-xs text-gray-700">
-                                    Explorer
+                                    {t("explorerLabel")}
                                 </span>
                                 <div className="flex items-center gap-1">
                                     <input
@@ -880,7 +883,7 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                                             fileInputRef.current?.click()
                                         }
                                         disabled={uploading}
-                                        title="Upload documents"
+                                        title={t("uploadDocumentsTitle")}
                                         className="p-1 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors disabled:opacity-40"
                                     >
                                         {uploading ? (
@@ -893,7 +896,7 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                                         onClick={() =>
                                             setExplorerCollapsed(true)
                                         }
-                                        title="Collapse explorer"
+                                        title={t("collapseExplorerTitle")}
                                         className="p-1 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
                                     >
                                         <ChevronLeft className="h-3.5 w-3.5" />
@@ -928,7 +931,7 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                                 {explorerDragOver && (
                                     <div className="absolute inset-0 z-10 flex items-center justify-center pointer-events-none">
                                         <p className="text-xs text-blue-500 font-medium">
-                                            Drop to upload
+                                            {t("dropToUpload")}
                                         </p>
                                     </div>
                                 )}
@@ -957,7 +960,7 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                         <div className="h-10 flex items-center justify-center border-b border-gray-200 shrink-0 px-1">
                             <button
                                 onClick={() => setExplorerCollapsed(false)}
-                                title="Expand explorer"
+                                title={t("expandExplorerTitle")}
                                 className="p-1 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
                             >
                                 <ChevronRight className="h-3.5 w-3.5" />
@@ -975,7 +978,7 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                     >
                         {tabs.length === 0 ? (
                             <span className="px-4 self-center text-xs text-gray-700">
-                                Document Viewer
+                                {t("documentViewerLabel")}
                             </span>
                         ) : (
                             tabs.map((tab) => {
@@ -1102,12 +1105,10 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                             <div className="flex items-center justify-center h-full px-8 bg-gray-100">
                                 <div className="text-center space-y-3">
                                     <p className="font-serif text-gray-700 text-xl">
-                                        Click on a document to display here.
+                                        {t("docViewerEmptyTitle")}
                                     </p>
                                     <p className="font-serif text-base text-gray-500">
-                                        Pro tip: Drag a document from the
-                                        Project Explorer to the Assistant to
-                                        direct it to read or edit.
+                                        {t("docViewerEmptyTip")}
                                     </p>
                                 </div>
                             </div>
@@ -1127,7 +1128,7 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                     <div className="h-10 flex items-center gap-2 px-4 border-b border-gray-200 shrink-0">
                         <MikeIcon size={16} />
                         <span className="text-xs text-gray-700">
-                            Project Assistant
+                            {t("projectAssistantLabel")}
                         </span>
                     </div>
 

--- a/frontend/src/app/(pages)/tabular-reviews/page.tsx
+++ b/frontend/src/app/(pages)/tabular-reviews/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Plus, Loader2, ChevronDown, Check, Table2 } from "lucide-react";
@@ -23,11 +24,8 @@ type Tab = "all" | "in-project" | "standalone";
 const CHECK_W = "w-8 shrink-0";
 const NAME_COL_W = "w-[300px] shrink-0";
 
-const TABS: { id: Tab; label: string }[] = [
-    { id: "all", label: "All" },
-    { id: "in-project", label: "In Project" },
-    { id: "standalone", label: "Standalone" },
-];
+// Tab labels are resolved inside the component via t()
+const TAB_IDS: Tab[] = ["all", "in-project", "standalone"];
 
 function formatDate(iso: string) {
     return new Date(iso).toLocaleDateString(undefined, {
@@ -38,6 +36,7 @@ function formatDate(iso: string) {
 }
 
 export default function TabularReviewsPage() {
+    const t = useTranslations("Tabular.TabularReviewsPage");
     const [reviews, setReviews] = useState<TabularReview[]>([]);
     const [projects, setProjects] = useState<MikeProject[]>([]);
     const [loading, setLoading] = useState(true);
@@ -198,7 +197,7 @@ export default function TabularReviewsPage() {
                         : "text-gray-500 hover:text-gray-700"
                 }`}
             >
-                {selectedProject ? selectedProject.name : "Filter by project"}
+                {selectedProject ? selectedProject.name : t("filterByProject")}
                 <ChevronDown className="h-3 w-3" />
             </button>
             {filterOpen && (
@@ -210,7 +209,7 @@ export default function TabularReviewsPage() {
                         }}
                         className="flex items-center justify-between w-full px-3 py-2 text-xs text-gray-600 hover:bg-gray-50 transition-colors"
                     >
-                        All Projects
+                        {t("allProjects")}
                         {!projectFilter && (
                             <Check className="h-3.5 w-3.5 text-gray-400" />
                         )}
@@ -246,7 +245,7 @@ export default function TabularReviewsPage() {
                         onClick={() => setActionsOpen((v) => !v)}
                         className="flex items-center gap-1 text-xs font-medium text-gray-700 hover:text-gray-900 transition-colors"
                     >
-                        Actions
+                        {t("actions")}
                         <ChevronDown className="h-3.5 w-3.5" />
                     </button>
                     {actionsOpen && (
@@ -255,7 +254,7 @@ export default function TabularReviewsPage() {
                                 onClick={handleDeleteSelected}
                                 className="w-full px-3 py-1.5 text-left text-xs text-red-600 hover:bg-red-50 transition-colors"
                             >
-                                Delete
+                                {t("delete")}
                             </button>
                         </div>
                     )}
@@ -270,10 +269,10 @@ export default function TabularReviewsPage() {
             {/* Page header */}
             <div className="mb-1 flex items-center justify-between px-4 py-3 md:px-10">
                 <h1 className="text-2xl font-medium font-serif text-gray-900">
-                    Tabular Reviews
+                    {t("pageTitle")}
                 </h1>
                 <div className="flex items-center gap-2">
-                    <HeaderSearchBtn value={search} onChange={setSearch} placeholder="Search reviews…" />
+                    <HeaderSearchBtn value={search} onChange={setSearch} placeholder={t("searchPlaceholder")} />
                     <button
                         onClick={() => setNewTROpen(true)}
                         disabled={creating}
@@ -289,7 +288,7 @@ export default function TabularReviewsPage() {
             </div>
 
             <ToolbarTabs
-                tabs={TABS}
+                tabs={TAB_IDS.map((id) => ({ id, label: t(`tab_${id}`) }))}
                 active={activeTab}
                 onChange={setActiveTab}
                 actions={toolbarActions}
@@ -313,12 +312,12 @@ export default function TabularReviewsPage() {
                         )}
                     </div>
                     <div className={`sticky left-8 z-[60] ${NAME_COL_W} bg-white pl-2 text-left`}>
-                        Name
+                        {t("colName")}
                     </div>
-                    <div className="ml-auto w-24 shrink-0">Columns</div>
-                    <div className="w-24 shrink-0">Documents</div>
-                    <div className="w-40 shrink-0">Project</div>
-                    <div className="w-32 shrink-0">Created</div>
+                    <div className="ml-auto w-24 shrink-0">{t("colColumns")}</div>
+                    <div className="w-24 shrink-0">{t("colDocuments")}</div>
+                    <div className="w-40 shrink-0">{t("colProject")}</div>
+                    <div className="w-32 shrink-0">{t("colCreated")}</div>
                     <div className="w-8 shrink-0" />
                 </div>
 
@@ -355,23 +354,22 @@ export default function TabularReviewsPage() {
                             <>
                                 <Table2 className="h-8 w-8 text-gray-300 mb-4" />
                                 <p className="text-2xl font-medium font-serif text-gray-900">
-                                    Tabular Reviews
+                                    {t("emptyTitle")}
                                 </p>
                                 <p className="mt-1 text-xs text-gray-400 max-w-xs text-left">
-                                    Extract data from documents into tables
-                                    using AI.
+                                    {t("emptySubtitle")}
                                 </p>
                                 <button
                                     onClick={() => setNewTROpen(true)}
                                     disabled={creating}
                                     className="mt-4 inline-flex items-center gap-1 rounded-full bg-gray-900 px-3 py-1 text-xs font-medium text-white hover:bg-gray-700 transition-colors shadow-md disabled:opacity-40"
                                 >
-                                    + Create New
+                                    {t("createNew")}
                                 </button>
                             </>
                         ) : (
                             <p className="text-sm text-gray-400">
-                                No reviews found
+                                {t("noReviewsFound")}
                             </p>
                         )}
                     </div>
@@ -443,7 +441,7 @@ export default function TabularReviewsPage() {
                                         ) : (
                                             <span className="text-sm text-gray-800 truncate block">
                                                 {review.title ??
-                                                    "Untitled Review"}
+                                                    t("untitledReview")}
                                             </span>
                                         )}
                                     </div>
@@ -488,7 +486,7 @@ export default function TabularReviewsPage() {
                                                 }
                                                 setRenameValue(
                                                     review.title ??
-                                                        "Untitled Review",
+                                                        t("untitledReview"),
                                                 );
                                                 setRenamingId(review.id);
                                             }}

--- a/frontend/src/app/(pages)/workflows/[id]/page.tsx
+++ b/frontend/src/app/(pages)/workflows/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/app/components/workflows/builtinWorkflows";
 import { formatIcon, formatLabel } from "@/app/components/tabular/columnFormat";
 import { RenameableTitle } from "@/app/components/shared/RenameableTitle";
+import { useTranslations } from "next-intl";
 // dynamic import keeps Tiptap (browser-only) out of the SSR bundle
 const WorkflowPromptEditor = dynamic(
     () =>
@@ -38,6 +39,7 @@ const NAME_COL_W = "w-[300px] shrink-0";
 // Page
 // ---------------------------------------------------------------------------
 export default function WorkflowDetailPage({ params }: Props) {
+    const t = useTranslations("Workflows.WorkflowDetailPage");
     const { id } = use(params);
     const router = useRouter();
 
@@ -244,7 +246,7 @@ export default function WorkflowDetailPage({ params }: Props) {
     if (notFound || !workflow) {
         return (
             <div className="flex-1 flex items-center justify-center">
-                <p className="text-gray-400 font-serif">Workflow not found.</p>
+                <p className="text-gray-400 font-serif">{t("notFound")}</p>
             </div>
         );
     }
@@ -258,7 +260,7 @@ export default function WorkflowDetailPage({ params }: Props) {
                         onClick={() => router.push("/workflows")}
                         className="text-gray-500 hover:text-gray-700 transition-colors"
                     >
-                        Workflows
+                        {t("breadcrumbWorkflows")}
                     </button>
                     <span className="text-gray-300">›</span>
                     {readOnly ? (
@@ -272,9 +274,9 @@ export default function WorkflowDetailPage({ params }: Props) {
                     {/* Save status */}
                     <span className="text-xs text-gray-400">
                         {saveStatus === "saving"
-                            ? "Saving…"
+                            ? t("saving")
                             : saveStatus === "saved"
-                              ? "Saved"
+                              ? t("saved")
                               : ""}
                     </span>
 
@@ -282,8 +284,8 @@ export default function WorkflowDetailPage({ params }: Props) {
                     {canShare && (
                         <button
                             onClick={() => setShareOpen(true)}
-                            aria-label="Open workflow people"
-                            title="People"
+                            aria-label={t("shareAriaLabel")}
+                            title={t("shareTitle")}
                             className="flex items-center text-gray-500 hover:text-gray-900 transition-colors"
                         >
                             <Users className="h-4 w-4" />
@@ -302,7 +304,7 @@ export default function WorkflowDetailPage({ params }: Props) {
             {/* Read-only badge for built-in workflows */}
             {readOnly && (
                 <div className="flex items-center h-10 px-8 border-b border-gray-200">
-                    <span className="text-xs text-gray-400">Read-only</span>
+                    <span className="text-xs text-gray-400">{t("readOnly")}</span>
                 </div>
             )}
 
@@ -328,7 +330,7 @@ export default function WorkflowDetailPage({ params }: Props) {
                                     className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700 transition-colors"
                                 >
                                     <Plus className="h-3.5 w-3.5" />
-                                    Add Column
+                                    {t("addColumn")}
                                 </button>
                                 {selectedColIndices.length > 0 && (
                                     <div ref={colActionsRef} className="relative">
@@ -336,7 +338,7 @@ export default function WorkflowDetailPage({ params }: Props) {
                                             onClick={() => setColActionsOpen((v) => !v)}
                                             className="flex items-center gap-1 text-xs font-medium text-gray-700 hover:text-gray-900 transition-colors"
                                         >
-                                            Actions
+                                            {t("actions")}
                                             <ChevronDown className="h-3.5 w-3.5" />
                                         </button>
                                         {colActionsOpen && (
@@ -353,7 +355,7 @@ export default function WorkflowDetailPage({ params }: Props) {
                                                     }}
                                                     className="w-full px-3 py-1.5 text-left text-xs text-red-600 hover:bg-red-50 transition-colors"
                                                 >
-                                                    Delete
+                                                    {t("delete")}
                                                 </button>
                                             </div>
                                         )}
@@ -378,10 +380,10 @@ export default function WorkflowDetailPage({ params }: Props) {
                                 )}
                             </div>
                             <div className={`sticky left-8 z-[60] ${NAME_COL_W} bg-white pl-2 text-left`}>
-                                Column Title
+                                {t("colColumnTitle")}
                             </div>
-                            <div className="ml-auto w-36 shrink-0">Format</div>
-                            <div className="flex-1 min-w-0">Prompt</div>
+                            <div className="ml-auto w-36 shrink-0">{t("colFormat")}</div>
+                            <div className="flex-1 min-w-0">{t("colPrompt")}</div>
                             {!readOnly && <div className="w-8 shrink-0" />}
                         </div>
 
@@ -391,17 +393,17 @@ export default function WorkflowDetailPage({ params }: Props) {
                                 <div className="flex flex-col items-start py-24 w-full max-w-xs mx-auto">
                                     <Plus className="h-8 w-8 text-gray-300 mb-4" />
                                     <p className="text-2xl font-medium font-serif text-gray-900">
-                                        Columns
+                                        {t("emptyColumnsTitle")}
                                     </p>
                                     <p className="mt-1 text-xs text-gray-400 text-left">
-                                        Add columns to define what this tabular review workflow extracts from each document.
+                                        {t("emptyColumnsDescription")}
                                     </p>
                                     {!readOnly && (
                                         <button
                                             onClick={() => setAddColumnOpen(true)}
                                             className="mt-4 inline-flex items-center gap-1 rounded-full bg-gray-900 px-3 py-1 text-xs font-medium text-white hover:bg-gray-700 transition-colors shadow-md"
                                         >
-                                            + Add Column
+                                            {t("addColumnButton")}
                                         </button>
                                     )}
                                 </div>

--- a/frontend/src/app/components/assistant/AddDocButton.tsx
+++ b/frontend/src/app/components/assistant/AddDocButton.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { uploadStandaloneDocument } from "@/app/lib/mikeApi";
 import type { MikeDocument } from "../shared/types";
+import { useTranslations } from "next-intl";
 
 interface Props {
     onSelectDoc: (doc: MikeDocument) => void;
@@ -18,6 +19,7 @@ interface Props {
 }
 
 export function AddDocButton({ onSelectDoc, onBrowseAll, selectedDocIds = [] }: Props) {
+    const t = useTranslations("Assistant.AddDocButton");
     const [isOpen, setIsOpen] = useState(false);
     const [uploading, setUploading] = useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -57,8 +59,8 @@ export function AddDocButton({ onSelectDoc, onBrowseAll, selectedDocIds = [] }: 
                                 ? "text-black hover:bg-gray-100"
                                 : "text-gray-400 hover:text-gray-700 hover:bg-gray-100"
                         } ${isOpen ? "bg-gray-100" : ""}`}
-                        title="Add documents"
-                        aria-label="Add documents"
+                        title={t("addDocuments")}
+                        aria-label={t("addDocuments")}
                     >
                         {selectedDocIds.length > 0 ? (
                             <span className="font-medium tabular-nums">{selectedDocIds.length}</span>
@@ -68,9 +70,7 @@ export function AddDocButton({ onSelectDoc, onBrowseAll, selectedDocIds = [] }: 
                             />
                         )}
                         <span className="hidden sm:inline">
-                            {selectedDocIds.length === 1
-                                ? "Document"
-                                : "Documents"}
+                            {t("documents", { count: selectedDocIds.length })}
                         </span>
                     </button>
                 </DropdownMenuTrigger>
@@ -93,7 +93,7 @@ export function AddDocButton({ onSelectDoc, onBrowseAll, selectedDocIds = [] }: 
                             <Upload className="h-4 w-4 mr-2 text-gray-500" />
                         )}
                         <span className="text-sm">
-                            {uploading ? "Uploading…" : "Upload files"}
+                            {uploading ? t("uploading") : t("uploadFiles")}
                         </span>
                     </DropdownMenuItem>
                     <DropdownMenuItem
@@ -101,7 +101,7 @@ export function AddDocButton({ onSelectDoc, onBrowseAll, selectedDocIds = [] }: 
                         onClick={onBrowseAll}
                     >
                         <LayoutGridIcon className="h-4 w-4 mr-2 text-gray-500" />
-                        <span className="text-sm">Browse all</span>
+                        <span className="text-sm">{t("browseAll")}</span>
                     </DropdownMenuItem>
                 </DropdownMenuContent>
             </DropdownMenu>

--- a/frontend/src/app/components/assistant/AssistantMessage.tsx
+++ b/frontend/src/app/components/assistant/AssistantMessage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useId, useRef, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import ReactMarkdown from "react-markdown";
 import remarkMath from "remark-math";
 import remarkGfm from "remark-gfm";
@@ -18,17 +19,17 @@ import { EditCard, applyOptimisticResolution } from "./EditCard";
 import { PreResponseWrapper } from "../shared/PreResponseWrapper";
 import { supabase } from "@/lib/supabase";
 
-function toolCallLabel(name: string): string {
-    if (name === "generate_docx") return "Creating document...";
-    if (name === "edit_document") return "Editing document...";
-    if (name === "read_document") return "Reading document...";
-    if (name === "fetch_documents") return "Reading documents...";
-    if (name === "find_in_document") return "Searching document...";
-    if (name === "replicate_document") return "Copying document...";
-    if (name === "read_workflow") return "Loading workflow...";
-    if (name === "list_workflows") return "Loading workflows...";
-    if (name === "list_documents") return "Loading documents...";
-    return name ? `Running ${name}...` : "Working...";
+function toolCallLabel(name: string, t: ReturnType<typeof useTranslations<"Assistant.AssistantMessage">>): string {
+    if (name === "generate_docx") return t("toolCall.generate_docx");
+    if (name === "edit_document") return t("toolCall.edit_document");
+    if (name === "read_document") return t("toolCall.read_document");
+    if (name === "fetch_documents") return t("toolCall.fetch_documents");
+    if (name === "find_in_document") return t("toolCall.find_in_document");
+    if (name === "replicate_document") return t("toolCall.replicate_document");
+    if (name === "read_workflow") return t("toolCall.read_workflow");
+    if (name === "list_workflows") return t("toolCall.list_workflows");
+    if (name === "list_documents") return t("toolCall.list_documents");
+    return name ? t("toolCall.running", { name }) : t("toolCall.working");
 }
 
 /**
@@ -75,6 +76,7 @@ function BulkEditActions({
         message: string;
     }) => void;
 }) {
+    const t = useTranslations("Assistant.AssistantMessage");
     const [busy, setBusy] = useState<"accept" | "reject" | null>(null);
     const [progress, setProgress] = useState<{
         done: number;
@@ -158,8 +160,8 @@ function BulkEditActions({
                         versionId: annotation.version_id ?? null,
                         message:
                             verb === "accept"
-                                ? "Couldn't save one or more accepts."
-                                : "Couldn't save one or more rejects.",
+                                ? t("bulkEdit.errorAccept")
+                                : t("bulkEdit.errorReject"),
                     });
                 }
                 done++;
@@ -185,7 +187,7 @@ function BulkEditActions({
                 {busy === "accept" && (
                     <Loader2 className="h-3 w-3 animate-spin" />
                 )}
-                Accept all
+                {t("bulkEdit.acceptAll")}
             </button>
             <button
                 onClick={() => handleAll("reject")}
@@ -195,7 +197,7 @@ function BulkEditActions({
                 {busy === "reject" && (
                     <Loader2 className="h-3 w-3 animate-spin" />
                 )}
-                Reject all
+                {t("bulkEdit.rejectAll")}
             </button>
             {progress && (
                 <span className="text-xs font-serif text-gray-500">
@@ -210,7 +212,7 @@ function BulkEditActions({
                     disabled={!!busy}
                     className="ml-auto px-2 py-1 text-xs rounded border border-gray-200 bg-white text-gray-700 hover:bg-gray-100 disabled:opacity-50"
                 >
-                    View
+                    {t("bulkEdit.view")}
                 </button>
             )}
         </div>
@@ -259,6 +261,7 @@ function EditCardsSection({
         message: string;
     }) => void;
 }) {
+    const t = useTranslations("Assistant.AssistantMessage");
     const [isOpen, setIsOpen] = useState(true);
     if (cards.length === 0) return null;
 
@@ -266,11 +269,11 @@ function EditCardsSection({
     const summary =
         pending.length > 0
             ? docCount > 1
-                ? `${pending.length} tracked changes across ${docCount} documents`
-                : `${pending.length} tracked ${pending.length === 1 ? "change" : "changes"}`
+                ? t("editSection.pendingMultiDoc", { count: pending.length, docCount })
+                : t("editSection.pendingSingleDoc", { count: pending.length })
             : docCount > 1
-              ? `${resolvedCount} resolved tracked changes across ${docCount} documents`
-              : `${resolvedCount} resolved tracked ${resolvedCount === 1 ? "change" : "changes"}`;
+              ? t("editSection.resolvedMultiDoc", { count: resolvedCount, docCount })
+              : t("editSection.resolvedSingleDoc", { count: resolvedCount });
 
     return (
         <div className="border border-gray-200 rounded-lg bg-white overflow-hidden">
@@ -281,7 +284,7 @@ function EditCardsSection({
                 </p>
                 <button
                     onClick={() => setIsOpen((v) => !v)}
-                    aria-label={isOpen ? "Collapse edits" : "Expand edits"}
+                    aria-label={isOpen ? t("editSection.collapse") : t("editSection.expand")}
                     className="shrink-0 rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-800 transition-colors"
                 >
                     <ChevronDown
@@ -357,13 +360,13 @@ function ResponseStatus({ status }: { status: StatusState }) {
 // Event block components
 // ---------------------------------------------------------------------------
 
-const THINKING_PHRASES = [
-    "Thinking...",
-    "Pondering...",
-    "Analyzing...",
-    "Reviewing...",
-    "Reasoning...",
-];
+const THINKING_PHRASE_KEYS = [
+    "thinkingPhrase.thinking",
+    "thinkingPhrase.pondering",
+    "thinkingPhrase.analyzing",
+    "thinkingPhrase.reviewing",
+    "thinkingPhrase.reasoning",
+] as const;
 
 function ReasoningBlock({
     text,
@@ -374,13 +377,14 @@ function ReasoningBlock({
     isStreaming: boolean;
     showConnector?: boolean;
 }) {
+    const t = useTranslations("Assistant.AssistantMessage");
     const [isOpen, setIsOpen] = useState(false);
     const [thinkingIndex, setThinkingIndex] = useState(0);
 
     useEffect(() => {
         if (!isStreaming) return;
         const interval = setInterval(() => {
-            setThinkingIndex((i) => (i + 1) % THINKING_PHRASES.length);
+            setThinkingIndex((i) => (i + 1) % THINKING_PHRASE_KEYS.length);
         }, 2000);
         return () => clearInterval(interval);
     }, [isStreaming]);
@@ -403,8 +407,8 @@ function ReasoningBlock({
                 )}
                 <span className="font-medium ml-2">
                     {isStreaming
-                        ? THINKING_PHRASES[thinkingIndex]
-                        : "Thought process"}
+                        ? t(THINKING_PHRASE_KEYS[thinkingIndex])
+                        : t("thoughtProcess")}
                 </span>
                 {!isStreaming && (
                     <ChevronDown
@@ -445,6 +449,7 @@ function DocReadBlock({
     showConnector?: boolean;
     isStreaming?: boolean;
 }) {
+    const t = useTranslations("Assistant.AssistantMessage");
     return (
         <div className="flex items-start text-sm font-serif text-gray-500 relative">
             {showConnector && (
@@ -457,7 +462,7 @@ function DocReadBlock({
             )}
             <div className="ml-2 min-w-0 flex-1 whitespace-normal break-words">
                 <span className="font-medium">
-                    {isStreaming ? "Reading" : "Read"}
+                    {isStreaming ? t("docRead.reading") : t("docRead.read")}
                 </span>{" "}
                 {isStreaming ? (
                     <span>{filename}...</span>
@@ -489,10 +494,11 @@ function DocFindBlock({
     isStreaming?: boolean;
     showConnector?: boolean;
 }) {
-    const label = isStreaming ? "Finding" : "Found";
+    const t = useTranslations("Assistant.AssistantMessage");
+    const label = isStreaming ? t("docFind.finding") : t("docFind.found");
     const matchSuffix = isStreaming
         ? ""
-        : ` (${totalMatches} ${totalMatches === 1 ? "match" : "matches"})`;
+        : ` (${t("docFind.matches", { count: totalMatches })})`;
     return (
         <div className="flex items-start text-sm font-serif text-gray-500 relative">
             {showConnector && (
@@ -509,7 +515,7 @@ function DocFindBlock({
                 <span className="font-medium">{label}</span>{" "}
                 <span>
                     &ldquo;{query}&rdquo;{matchSuffix}
-                    <span className="ml-1 text-gray-400">in {filename}</span>
+                    <span className="ml-1 text-gray-400">{t("docFind.inFile", { filename })}</span>
                     {isStreaming && "..."}
                 </span>
             </div>
@@ -526,6 +532,7 @@ function DocCreatedBlock({
     showConnector?: boolean;
     isStreaming?: boolean;
 }) {
+    const t = useTranslations("Assistant.AssistantMessage");
     return (
         <div className="flex items-start text-sm font-serif text-gray-500 relative">
             {showConnector && (
@@ -538,7 +545,7 @@ function DocCreatedBlock({
             )}
             <div className="ml-2 min-w-0 flex-1 whitespace-normal break-words">
                 <span className="font-medium">
-                    {isStreaming ? "Creating" : "Created"}
+                    {isStreaming ? t("docCreated.creating") : t("docCreated.created")}
                 </span>{" "}
                 <span>{isStreaming ? `${filename}...` : filename}</span>
             </div>
@@ -563,9 +570,10 @@ function DocReplicatedBlock({
     isStreaming?: boolean;
     hasError?: boolean;
 }) {
-    const label = isStreaming ? "Replicating" : "Replicated";
+    const t = useTranslations("Assistant.AssistantMessage");
+    const label = isStreaming ? t("docReplicated.replicating") : t("docReplicated.replicated");
     const suffix =
-        !isStreaming && count > 1 ? ` ${count} times` : isStreaming ? "..." : "";
+        !isStreaming && count > 1 ? ` ${t("docReplicated.times", { count })}` : isStreaming ? "..." : "";
     return (
         <div className="flex items-start text-sm font-serif text-gray-500 relative">
             {showConnector && (
@@ -739,6 +747,7 @@ function WorkflowAppliedBlock({
     showConnector?: boolean;
     onClick?: () => void;
 }) {
+    const t = useTranslations("Assistant.AssistantMessage");
     return (
         <div className="flex items-start text-sm font-serif text-gray-500 relative">
             {showConnector && (
@@ -746,7 +755,7 @@ function WorkflowAppliedBlock({
             )}
             <div className="mt-2 w-1.5 h-1.5 rounded-full bg-green-400 shrink-0" />
             <div className="ml-2 min-w-0 flex-1 whitespace-normal break-words">
-                <span className="font-medium">Applied Workflow</span>{" "}
+                <span className="font-medium">{t("workflowApplied.label")}</span>{" "}
                 {onClick ? (
                     <button
                         onClick={onClick}
@@ -773,6 +782,7 @@ function DocEditedBlock({
     isStreaming?: boolean;
     hasError?: boolean;
 }) {
+    const t = useTranslations("Assistant.AssistantMessage");
     return (
         <div className="flex items-start text-sm font-serif text-gray-500 relative">
             {showConnector && (
@@ -788,10 +798,10 @@ function DocEditedBlock({
             <div className="ml-2 min-w-0 flex-1 whitespace-normal break-words">
                 <span className="font-medium">
                     {isStreaming
-                        ? "Editing"
+                        ? t("docEdited.editing")
                         : hasError
-                          ? "Edit failed"
-                          : "Edited"}
+                          ? t("docEdited.editFailed")
+                          : t("docEdited.edited")}
                 </span>{" "}
                 <span>{isStreaming ? `${filename}...` : filename}</span>
             </div>
@@ -1086,6 +1096,7 @@ export function AssistantMessage({
     isEditReloading,
     resolvedEditStatuses,
 }: Props) {
+    const t = useTranslations("Assistant.AssistantMessage");
     const messageKey = useId();
     const contentDivRef = useRef<HTMLDivElement | null>(null);
     const [isCopied, setIsCopied] = useState(false);
@@ -1251,7 +1262,7 @@ export function AssistantMessage({
                     )}
                     <div className="w-1.5 h-1.5 rounded-full border border-gray-400 border-t-transparent animate-spin shrink-0" />
                     <span className="font-medium ml-2">
-                        {toolCallLabel(event.name)}
+                        {toolCallLabel(event.name, t)}
                     </span>
                 </div>
             );
@@ -1266,7 +1277,7 @@ export function AssistantMessage({
                         <div className="absolute bottom-0 w-[1px] bg-gray-300 top-[13px] left-[2.5px] h-[calc(100%+11px)]" />
                     )}
                     <div className="w-1.5 h-1.5 rounded-full border border-gray-400 border-t-transparent animate-spin shrink-0" />
-                    <span className="ml-2">Thinking...</span>
+                    <span className="ml-2">{t("thinkingPhrase.thinking")}</span>
                 </div>
             );
         }
@@ -1497,7 +1508,7 @@ export function AssistantMessage({
                 {isError && (
                     <div className="mt-2 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm font-serif text-red-700">
                         <span className="leading-snug">
-                            {errorMessage ?? "Sorry, something went wrong."}
+                            {errorMessage ?? t("error.default")}
                         </span>
                     </div>
                 )}

--- a/frontend/src/app/components/assistant/AssistantSidePanel.tsx
+++ b/frontend/src/app/components/assistant/AssistantSidePanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { X } from "lucide-react";
 import { DocPanel, type DocPanelMode } from "../shared/DocPanel";
 import type {
@@ -101,6 +102,7 @@ export function AssistantSidePanel({
     onWarningDismiss,
     onScrollChange,
 }: Props) {
+    const t = useTranslations("Assistant.AssistantSidePanel");
     const panelRef = useRef<HTMLDivElement>(null);
     const [panelWidth, setPanelWidth] = useState(() =>
         typeof window !== "undefined"
@@ -211,7 +213,7 @@ export function AssistantSidePanel({
                 <button
                     onClick={onCloseAll}
                     className="shrink-0 mb-1 ml-1 rounded-lg p-1.5 text-gray-400 hover:bg-gray-200 hover:text-gray-700"
-                    title="Close panel"
+                    title={t("closePanel")}
                 >
                     <X className="h-4 w-4" />
                 </button>

--- a/frontend/src/app/components/assistant/AssistantWorkflowModal.tsx
+++ b/frontend/src/app/components/assistant/AssistantWorkflowModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { createPortal } from "react-dom";
 import { ChevronLeft, Search, X } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -26,6 +27,7 @@ export function AssistantWorkflowModal({
     projectCmNumber,
     initialWorkflowId,
 }: Props) {
+    const t = useTranslations("Assistant.AssistantWorkflowModal");
     const [workflows, setWorkflows] = useState<MikeWorkflow[]>([]);
     const [loading, setLoading] = useState(false);
     const [selected, setSelected] = useState<MikeWorkflow | null>(null);
@@ -97,7 +99,7 @@ export function AssistantWorkflowModal({
                     <div className="flex items-center gap-1.5 text-xs text-gray-400">
                         {projectName ? (
                             <>
-                                <span>Projects</span>
+                                <span>{t("breadcrumb.projects")}</span>
                                 <span>›</span>
                                 <span>
                                     {projectName}
@@ -106,15 +108,15 @@ export function AssistantWorkflowModal({
                                         : ""}
                                 </span>
                                 <span>›</span>
-                                <span>Assistant</span>
+                                <span>{t("breadcrumb.assistant")}</span>
                                 <span>›</span>
-                                <span>Add workflow</span>
+                                <span>{t("breadcrumb.addWorkflow")}</span>
                             </>
                         ) : (
                             <>
-                                <span>Assistant</span>
+                                <span>{t("breadcrumb.assistant")}</span>
                                 <span>›</span>
-                                <span>Add workflow</span>
+                                <span>{t("breadcrumb.addWorkflow")}</span>
                             </>
                         )}
                     </div>
@@ -138,7 +140,7 @@ export function AssistantWorkflowModal({
                                 <Search className="h-3 w-3 text-gray-400 shrink-0" />
                                 <input
                                     type="text"
-                                    placeholder="Search workflows…"
+                                    placeholder={t("searchPlaceholder")}
                                     value={search}
                                     onChange={(e) => setSearch(e.target.value)}
                                     className="flex-1 bg-transparent text-xs text-gray-700 placeholder:text-gray-400 outline-none"
@@ -168,7 +170,7 @@ export function AssistantWorkflowModal({
                             </div>
                         ) : filteredWorkflows.length === 0 ? (
                             <p className="px-4 py-8 text-sm text-center text-gray-400">
-                                {search ? "No matches found" : "No assistant workflows found"}
+                                {search ? t("noMatches") : t("noWorkflows")}
                             </p>
                         ) : (
                             filteredWorkflows.map((wf) => (
@@ -190,7 +192,7 @@ export function AssistantWorkflowModal({
                                         {wf.title}
                                     </span>
                                     <span className="shrink-0 text-xs text-gray-400">
-                                        {wf.is_system ? "Built-in" : "Custom"}
+                                        {wf.is_system ? t("builtIn") : t("custom")}
                                     </span>
                                 </button>
                             ))
@@ -202,7 +204,7 @@ export function AssistantWorkflowModal({
                         <div className={`flex-1 border-l border-gray-100 flex flex-col overflow-hidden px-3 pb-3 transition-opacity duration-200 ${rightVisible ? "opacity-100" : "opacity-0"}`}>
                             <div className="flex items-center justify-between py-3 shrink-0">
                                 <p className="text-xs font-medium text-gray-700">
-                                    Workflow Prompt
+                                    {t("workflowPrompt")}
                                 </p>
                                 <button
                                     onClick={() => setSelected(null)}
@@ -261,7 +263,7 @@ export function AssistantWorkflowModal({
                                     }}
                                 >
                                     {selected.prompt_md ??
-                                        "_No prompt defined._"}
+                                        t("noPromptDefined")}
                                 </ReactMarkdown>
                             </div>
                         </div>
@@ -275,7 +277,7 @@ export function AssistantWorkflowModal({
                         onClick={onClose}
                         className="rounded-lg px-3 py-1.5 text-sm text-gray-500 hover:bg-gray-100 transition-colors"
                     >
-                        Cancel
+                        {t("cancel")}
                     </button>
                     <button
                         type="button"
@@ -283,7 +285,7 @@ export function AssistantWorkflowModal({
                         disabled={!selected}
                         className="rounded-lg bg-gray-900 px-4 py-1.5 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-40 transition-colors"
                     >
-                        Use
+                        {t("use")}
                     </button>
                 </div>
             </div>

--- a/frontend/src/app/components/assistant/ChatInput.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.tsx
@@ -23,6 +23,7 @@ import { AssistantWorkflowModal } from "./AssistantWorkflowModal";
 import { ApiKeyMissingModal } from "../shared/ApiKeyMissingModal";
 import { ModelToggle } from "./ModelToggle";
 import { useSelectedModel } from "@/app/hooks/useSelectedModel";
+import { useTranslations } from "next-intl";
 import { useUserProfile } from "@/contexts/UserProfileContext";
 import {
     getModelProvider,
@@ -59,6 +60,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
     }: Props,
     ref,
 ) {
+    const t = useTranslations("Assistant.ChatInput");
     const [value, setValue] = useState("");
     const [attachedDocs, setAttachedDocs] = useState<MikeDocument[]>([]);
     const [selectedWorkflow, setSelectedWorkflow] = useState<{
@@ -218,7 +220,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                         <textarea
                             ref={textareaRef}
                             rows={1}
-                            placeholder="Ask a question about your documents..."
+                            placeholder={t("placeholder")}
                             value={value}
                             onChange={handleChange}
                             onKeyDown={handleKeyDown}
@@ -242,7 +244,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                                 <button
                                     type="button"
                                     onClick={() => setWorkflowModalOpen(true)}
-                                    aria-label="Open workflows"
+                                    aria-label={t("openWorkflows")}
                                     className={`flex items-center gap-1.5 rounded-lg px-2 h-8 text-sm transition-colors ${selectedWorkflow ? "text-blue-600 hover:bg-blue-50" : "text-gray-400 hover:bg-gray-100 hover:text-gray-700"}`}
                                 >
                                     {selectedWorkflow ? (
@@ -251,7 +253,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                                         <Library className="h-3.5 w-3.5" />
                                     )}
                                     <span className="hidden sm:inline">
-                                        Workflows
+                                        {t("workflows")}
                                     </span>
                                 </button>
                             )}
@@ -259,12 +261,12 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                                 <button
                                     type="button"
                                     onClick={onProjectsClick}
-                                    aria-label="Open projects"
+                                    aria-label={t("openProjects")}
                                     className="flex items-center gap-1.5 rounded-lg px-2 h-8 text-sm text-gray-400 hover:bg-gray-100 hover:text-gray-700 transition-colors"
                                 >
                                     <FolderOpen className="h-3.5 w-3.5" />
                                     <span className="hidden sm:inline">
-                                        Projects
+                                        {t("projects")}
                                     </span>
                                 </button>
                             )}

--- a/frontend/src/app/components/assistant/ChatView.tsx
+++ b/frontend/src/app/components/assistant/ChatView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState, useRef, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { ArrowDown } from "lucide-react";
 import { UserMessage } from "./UserMessage";
 import { AssistantMessage } from "./AssistantMessage";
@@ -31,6 +32,7 @@ export function ChatView({
     handleChat,
     cancel,
 }: Props) {
+    const t = useTranslations("Assistant.ChatView");
     const [tabs, setTabs] = useState<AssistantSidePanelTab[]>([]);
     const [activeTabId, setActiveTabId] = useState<string | null>(null);
     const [panelMounted, setPanelMounted] = useState(false);
@@ -582,8 +584,7 @@ export function ChatView({
                             />
                             <div className="py-3 text-center">
                                 <p className="text-xs text-gray-500">
-                                    AI can make mistakes. Answers are not legal
-                                    advice.
+                                    {t("disclaimer")}
                                 </p>
                             </div>
                         </div>

--- a/frontend/src/app/components/assistant/EditCard.tsx
+++ b/frontend/src/app/components/assistant/EditCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { supabase } from "@/lib/supabase";
 import type { MikeEditAnnotation } from "../shared/types";
 
@@ -210,6 +211,7 @@ export function EditCard({
     onResolved,
     onError,
 }: Props) {
+    const t = useTranslations("Assistant.EditCard");
     const [busy, setBusy] = useState(false);
     const [localStatus, setLocalStatus] = useState<
         "pending" | "accepted" | "rejected"
@@ -286,8 +288,8 @@ export function EditCard({
                 versionId: annotation.version_id ?? null,
                 message:
                     verb === "accept"
-                        ? "Couldn't save accept — reverted."
-                        : "Couldn't save reject — reverted.",
+                        ? t("errorAccept")
+                        : t("errorReject"),
             });
         } finally {
             setBusy(false);
@@ -319,14 +321,14 @@ export function EditCard({
                     disabled={inFlight || resolved}
                     className="px-2 py-1 text-xs rounded border border-gray-900 bg-gray-900 text-white hover:bg-gray-800 disabled:opacity-50"
                 >
-                    {status === "accepted" ? "Accepted" : "Accept"}
+                    {status === "accepted" ? t("accepted") : t("accept")}
                 </button>
                 <button
                     onClick={() => handle("reject")}
                     disabled={inFlight || resolved}
                     className="px-2 py-1 text-xs rounded border border-gray-200 bg-white text-gray-700 hover:bg-gray-100 disabled:opacity-50"
                 >
-                    {status === "rejected" ? "Rejected" : "Reject"}
+                    {status === "rejected" ? t("rejected") : t("reject")}
                 </button>
                 {onViewClick && (
                     <button
@@ -334,12 +336,12 @@ export function EditCard({
                         disabled={resolved}
                         title={
                             resolved
-                                ? "This change has been resolved and is no longer in the document."
+                                ? t("viewDisabledTitle")
                                 : undefined
                         }
                         className="ml-auto px-2 py-1 text-xs rounded border border-gray-200 bg-white text-gray-700 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-white"
                     >
-                        View
+                        {t("view")}
                     </button>
                 )}
             </div>

--- a/frontend/src/app/components/assistant/InitialView.tsx
+++ b/frontend/src/app/components/assistant/InitialView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUserProfile } from "@/contexts/UserProfileContext";
 import { MikeIcon } from "@/components/chat/mike-icon";
@@ -16,6 +17,7 @@ const ICON_SIZE = 35;
 const GAP = 16; // gap-4 = 1rem = 16px
 
 export function InitialView({ onSubmit }: InitialViewProps) {
+    const t = useTranslations("Assistant.InitialView");
     const { user } = useAuth();
     const { profile } = useUserProfile();
     const [loaded, setLoaded] = useState(false);
@@ -71,7 +73,7 @@ export function InitialView({ onSubmit }: InitialViewProps) {
                                     "transform 900ms cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity 800ms ease-in-out 300ms",
                             }}
                         >
-                            Hi, {username}
+                            {t("greeting", { username })}
                         </h1>
                     </div>
 
@@ -84,7 +86,7 @@ export function InitialView({ onSubmit }: InitialViewProps) {
 
                     <div className="text-center">
                         <p className="text-xs py-3 mb-3 text-gray-500">
-                            AI can make mistakes. Answers are not legal advice.
+                            {t("disclaimer")}
                         </p>
                     </div>
                 </div>

--- a/frontend/src/app/components/assistant/ModelToggle.tsx
+++ b/frontend/src/app/components/assistant/ModelToggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { ChevronDown, Check, AlertCircle } from "lucide-react";
 import {
     DropdownMenu,
@@ -41,6 +42,7 @@ interface Props {
 }
 
 export function ModelToggle({ value, onChange, apiKeys }: Props) {
+    const t = useTranslations("Assistant.ModelToggle");
     const [isOpen, setIsOpen] = useState(false);
     const selected = MODELS.find((m) => m.id === value);
     const selectedLabel = selected?.label ?? "Model";
@@ -56,8 +58,8 @@ export function ModelToggle({ value, onChange, apiKeys }: Props) {
                     className={`flex items-center gap-1.5 rounded-lg px-2 h-8 text-sm transition-colors cursor-pointer text-gray-400 hover:bg-gray-100 hover:text-gray-700 ${isOpen ? "bg-gray-100 text-gray-700" : ""}`}
                     title={
                         !selectedAvailable
-                            ? "API key missing for selected model"
-                            : "Choose model"
+                            ? t("titleApiKeyMissing")
+                            : t("titleChooseModel")
                     }
                 >
                     {!selectedAvailable && (
@@ -97,7 +99,7 @@ export function ModelToggle({ value, onChange, apiKeys }: Props) {
                                         {!available && (
                                             <AlertCircle
                                                 className="h-3.5 w-3.5 text-red-500 ml-1"
-                                                aria-label="API key missing"
+                                                aria-label={t("ariaApiKeyMissing")}
                                             />
                                         )}
                                         {m.id === value && available && (

--- a/frontend/src/app/components/assistant/SelectAssistantProjectModal.tsx
+++ b/frontend/src/app/components/assistant/SelectAssistantProjectModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { createPortal } from "react-dom";
 import { X, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -14,6 +15,7 @@ interface Props {
 }
 
 export function SelectAssistantProjectModal({ open, onClose }: Props) {
+    const t = useTranslations("Assistant.SelectAssistantProjectModal");
     const [selectedId, setSelectedId] = useState<string | null>(null);
     const [creating, setCreating] = useState(false);
     const router = useRouter();
@@ -46,9 +48,9 @@ export function SelectAssistantProjectModal({ open, onClose }: Props) {
                 {/* Header */}
                 <div className="flex items-center justify-between px-5 py-4">
                     <div className="flex items-center gap-1.5 text-xs text-gray-400">
-                        <span>Assistant</span>
+                        <span>{t("breadcrumbAssistant")}</span>
                         <span>›</span>
-                        <span>Start Chat in a Project</span>
+                        <span>{t("breadcrumbStartChat")}</span>
                     </div>
                     <button
                         onClick={onClose}
@@ -71,7 +73,7 @@ export function SelectAssistantProjectModal({ open, onClose }: Props) {
                         onClick={onClose}
                         className="rounded-lg px-3 py-1.5 text-sm text-gray-500 hover:bg-gray-100"
                     >
-                        Cancel
+                        {t("cancel")}
                     </button>
                     <button
                         onClick={handleContinue}
@@ -81,7 +83,7 @@ export function SelectAssistantProjectModal({ open, onClose }: Props) {
                         {creating ? (
                             <Loader2 className="h-3.5 w-3.5 animate-spin" />
                         ) : (
-                            "Continue"
+                            t("continue")
                         )}
                     </button>
                 </div>

--- a/frontend/src/app/components/modals/credits-exhausted-modal.tsx
+++ b/frontend/src/app/components/modals/credits-exhausted-modal.tsx
@@ -1,5 +1,6 @@
 import { X } from "lucide-react";
 import { createPortal } from "react-dom";
+import { useTranslations } from "next-intl";
 
 interface CreditsExhaustedModalProps {
     isOpen: boolean;
@@ -12,6 +13,7 @@ export function CreditsExhaustedModal({
     onClose,
     resetDate,
 }: CreditsExhaustedModalProps) {
+    const t = useTranslations("Modals.CreditsExhaustedModal");
     if (!isOpen) return null;
 
     // Format the reset date
@@ -38,20 +40,19 @@ export function CreditsExhaustedModal({
                     {/* Header */}
                     <div className="flex items-start justify-between mb-4">
                         <h2 className="text-3xl font-light font-eb-garamond text-gray-900">
-                            Message Limit Reached
+                            {t("title")}
                         </h2>
                     </div>
 
                     {/* Content */}
                     <div className="space-y-4">
                         <p className="text-gray-600">
-                            You've reached your monthly message limit of 100
-                            messages.
+                            {t("limitReached")}
                         </p>
 
                         <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
                             <p className="text-sm text-blue-900 font-medium mb-1">
-                                Your credits will reset on:
+                                {t("resetLabel")}
                             </p>
                             <p className="text-lg font-semibold text-blue-700">
                                 {formatResetDate(resetDate)}
@@ -59,8 +60,7 @@ export function CreditsExhaustedModal({
                         </div>
 
                         <p className="text-sm text-gray-500">
-                            Your message credits automatically reset on the
-                            first day of each month.
+                            {t("autoResetNote")}
                         </p>
                     </div>
 
@@ -70,7 +70,7 @@ export function CreditsExhaustedModal({
                             onClick={onClose}
                             className="flex-1 px-4 py-2.5 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg font-medium transition-colors"
                         >
-                            Close
+                            {t("close")}
                         </button>
                     </div>
                 </div>

--- a/frontend/src/app/components/modals/delete-chats-modal.tsx
+++ b/frontend/src/app/components/modals/delete-chats-modal.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { X, Check } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 interface DeleteChatsModalProps {
     isOpen: boolean;
@@ -20,6 +21,7 @@ export function DeleteChatsModal({
     isDeleting,
     isSuccess = false,
 }: DeleteChatsModalProps) {
+    const t = useTranslations("Modals.DeleteChatsModal");
     if (!isOpen) return null;
 
     return (
@@ -41,11 +43,10 @@ export function DeleteChatsModal({
                                     <Check className="h-8 w-8 text-green-600" />
                                 </div>
                                 <h2 className="text-3xl font-light font-eb-garamond text-gray-900 mb-2">
-                                    All Chats Deleted
+                                    {t("successTitle")}
                                 </h2>
                                 <p className="text-gray-600 text-sm">
-                                    Your chat history has been successfully
-                                    deleted.
+                                    {t("successMessage")}
                                 </p>
                             </div>
                         </>
@@ -54,17 +55,14 @@ export function DeleteChatsModal({
                             {/* Header */}
                             <div className="flex items-center justify-between mb-6">
                                 <h2 className="text-4xl font-light font-eb-garamond text-red-700">
-                                    Delete All Chats
+                                    {t("title")}
                                 </h2>
                             </div>
 
                             {/* Content */}
                             <div className="space-y-4">
                                 <p className="text-gray-600 text-sm leading-relaxed">
-                                    Are you sure you want to delete all{" "}
-                                    {chatCount} chat
-                                    {chatCount !== 1 ? "s" : ""}? This action is
-                                    permanent and cannot be undone.
+                                    {t("confirmMessage", { count: chatCount })}
                                 </p>
 
                                 <div className="space-y-3 pt-4">
@@ -75,8 +73,8 @@ export function DeleteChatsModal({
                                         className="w-full bg-red-600 hover:bg-red-700 text-white"
                                     >
                                         {isDeleting
-                                            ? "Deleting..."
-                                            : "Delete All Chats"}
+                                            ? t("deleting")
+                                            : t("deleteAll")}
                                     </Button>
                                     <Button
                                         onClick={onClose}
@@ -84,7 +82,7 @@ export function DeleteChatsModal({
                                         disabled={isDeleting}
                                         className="w-full border-gray-300 text-gray-700 hover:bg-gray-50"
                                     >
-                                        Cancel
+                                        {t("cancel")}
                                     </Button>
                                 </div>
                             </div>

--- a/frontend/src/app/components/modals/simple-link-dialog.tsx
+++ b/frontend/src/app/components/modals/simple-link-dialog.tsx
@@ -1,6 +1,7 @@
 import { X, Link2, Check } from "lucide-react";
 import { useState } from "react";
 import { createPortal } from "react-dom";
+import { useTranslations } from "next-intl";
 
 interface SimpleLinkDialogProps {
     isOpen: boolean;
@@ -13,6 +14,7 @@ export function SimpleLinkDialog({
     onClose,
     shareUrl,
 }: SimpleLinkDialogProps) {
+    const t = useTranslations("Modals.SimpleLinkDialog");
     const [linkCopied, setLinkCopied] = useState(false);
 
     if (!isOpen) return null;
@@ -48,7 +50,7 @@ export function SimpleLinkDialog({
                     {/* Header */}
                     <div className="flex items-center justify-between mb-6">
                         <h2 className="text-3xl font-light font-eb-garamond text-gray-900">
-                            Share Chat
+                            {t("title")}
                         </h2>
                     </div>
 
@@ -57,7 +59,7 @@ export function SimpleLinkDialog({
                         {/* Link display */}
                         <div className="bg-gray-50 rounded-lg p-3 border border-gray-200">
                             <p className="text-sm text-gray-600 mb-2 font-medium">
-                                Share Link
+                                {t("shareLink")}
                             </p>
                             <p className="text-sm text-gray-800 break-all font-mono">
                                 {shareUrl}
@@ -72,12 +74,12 @@ export function SimpleLinkDialog({
                             {linkCopied ? (
                                 <>
                                     <Check className="h-5 w-5" />
-                                    Copied!
+                                    {t("copied")}
                                 </>
                             ) : (
                                 <>
                                     <Link2 className="h-5 w-5" />
-                                    Copy Link
+                                    {t("copyLink")}
                                 </>
                             )}
                         </button>

--- a/frontend/src/app/components/projects/NewProjectModal.tsx
+++ b/frontend/src/app/components/projects/NewProjectModal.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from "react";
 import { X, Users, Upload } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
     addDocumentToProject,
     createProject,
@@ -20,6 +21,7 @@ interface Props {
 }
 
 export function NewProjectModal({ open, onClose, onCreated }: Props) {
+    const t = useTranslations("Projects.NewProjectModal");
     const [name, setName] = useState("");
     const [cmNumber, setCmNumber] = useState("");
     const [sharedEmails, setSharedEmails] = useState<string[]>([]);
@@ -64,7 +66,7 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
             resetForm();
             onClose();
         } catch (err: unknown) {
-            setError((err as Error).message || "Failed to create project");
+            setError((err as Error).message || t("errorCreate"));
         } finally {
             setLoading(false);
         }
@@ -91,9 +93,9 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                 {/* Header */}
                 <div className="flex items-center justify-between px-6 pt-5 pb-2">
                     <div className="flex items-center gap-1.5 text-xs text-gray-400">
-                        <span>Projects</span>
+                        <span>{t("breadcrumbProjects")}</span>
                         <span>›</span>
-                        <span>New project</span>
+                        <span>{t("breadcrumbNew")}</span>
                     </div>
                     <button
                         onClick={handleClose}
@@ -110,7 +112,7 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                             type="text"
                             value={name}
                             onChange={(e) => setName(e.target.value)}
-                            placeholder="Project name"
+                            placeholder={t("placeholderName")}
                             className="w-full text-2xl font-serif text-gray-800 placeholder-gray-300 focus:outline-none bg-transparent"
                             autoFocus
                         />
@@ -120,7 +122,7 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                             type="text"
                             value={cmNumber}
                             onChange={(e) => setCmNumber(e.target.value)}
-                            placeholder="Add a CM number..."
+                            placeholder={t("placeholderCmNumber")}
                             className="mt-1.5 w-full text-sm text-gray-500 placeholder-gray-300 focus:outline-none bg-transparent"
                         />
 
@@ -132,7 +134,7 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                                 className="flex items-center gap-1.5 rounded-full border border-gray-200 px-3 py-1 text-xs text-gray-600 hover:bg-gray-50 transition-colors"
                             >
                                 <Users className="h-3 w-3 text-gray-400" />
-                                Members{sharedEmails.length > 0 ? ` (${sharedEmails.length})` : ""}
+                                {t("membersButton", { count: sharedEmails.length })}
                             </button>
                         </div>
 
@@ -144,24 +146,24 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                                     onChange={setSharedEmails}
                                     validate={async (email) =>
                                         ownEmail && email === ownEmail
-                                            ? "You cannot share a project with yourself."
+                                            ? t("errorSelfShare")
                                             : null
                                     }
-                                    placeholder="Add colleagues by email…"
+                                    placeholder={t("placeholderEmail")}
                                 />
                             </div>
                         )}
 
                         {/* Documents */}
                         <div className="mt-4 space-y-2">
-                            <p className="text-xs font-medium text-gray-700">Select documents</p>
+                            <p className="text-xs font-medium text-gray-700">{t("selectDocuments")}</p>
                                 <FileDirectory
                                     standaloneDocs={standaloneDocuments}
                                     directoryProjects={dirProjects}
                                     loading={dirLoading}
                                     selectedIds={selectedDocIds}
                                     onChange={setSelectedDocIds}
-                                    emptyMessage="No existing documents"
+                                    emptyMessage={t("noExistingDocuments")}
                                 />
 
                         </div>
@@ -187,7 +189,7 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                                 className="flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs text-gray-500 hover:bg-gray-50 transition-colors"
                             >
                                 <Upload className="h-3.5 w-3.5" />
-                                Upload files{pendingFiles.length > 0 ? ` (${pendingFiles.length})` : ""}
+                                {t("uploadFiles", { count: pendingFiles.length })}
                             </button>
                         </div>
                         <div className="flex items-center gap-2">
@@ -196,14 +198,14 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
                                 onClick={handleClose}
                                 className="rounded-lg px-4 py-2 text-sm text-gray-500 hover:bg-gray-100 transition-colors"
                             >
-                                Cancel
+                                {t("cancel")}
                             </button>
                             <button
                                 type="submit"
                                 disabled={!name.trim() || loading}
                                 className="rounded-lg bg-gray-900 px-5 py-2 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-40 transition-colors"
                             >
-                                {loading ? "Creating…" : "Create project"}
+                                {loading ? t("creating") : t("createProject")}
                             </button>
                         </div>
                     </div>

--- a/frontend/src/app/components/projects/ProjectAssistantTab.tsx
+++ b/frontend/src/app/components/projects/ProjectAssistantTab.tsx
@@ -2,6 +2,7 @@
 
 import { type Dispatch, type SetStateAction } from "react";
 import { MessageSquare } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { RowActions } from "@/app/components/shared/RowActions";
 import type { MikeChat } from "@/app/components/shared/types";
 import { CHECK_W, formatDate, NAME_COL_W } from "./ProjectPageParts";
@@ -41,6 +42,7 @@ export function ProjectAssistantTab({
     setRenamingChatId: Dispatch<SetStateAction<string | null>>;
     setRenameChatValue: Dispatch<SetStateAction<string>>;
 }) {
+    const t = useTranslations("Projects.ProjectAssistantTab");
     return (
         <>
             <div className="flex items-center h-8 pr-8 border-b border-gray-200 text-xs text-gray-500 font-medium select-none">
@@ -63,26 +65,25 @@ export function ProjectAssistantTab({
                 <div
                     className={`sticky left-8 z-[60] ${NAME_COL_W} bg-white pl-2 text-left`}
                 >
-                    Chats
+                    {t("columnChats")}
                 </div>
-                <div className="ml-auto w-32 shrink-0 text-left">Created</div>
+                <div className="ml-auto w-32 shrink-0 text-left">{t("columnCreated")}</div>
                 <div className="w-8 shrink-0" />
             </div>
             {chats.length === 0 ? (
                 <div className="flex flex-col items-start py-24 w-full max-w-xs mx-auto">
                     <MessageSquare className="h-8 w-8 text-gray-300 mb-4" />
                     <p className="text-2xl font-medium font-serif text-gray-900">
-                        Assistant
+                        {t("emptyHeading")}
                     </p>
                     <p className="mt-1 text-xs text-gray-400 max-w-xs">
-                        Ask questions and get answers grounded in the documents
-                        in this project.
+                        {t("emptyBody")}
                     </p>
                     <button
                         onClick={onCreateChat}
                         className="mt-4 inline-flex items-center gap-1 rounded-full bg-gray-900 px-3 py-1 text-xs font-medium text-white hover:bg-gray-700 transition-colors shadow-md"
                     >
-                        + Create New
+                        {t("createNew")}
                     </button>
                 </div>
             ) : (
@@ -139,7 +140,7 @@ export function ProjectAssistantTab({
                                     />
                                 ) : (
                                     <span className="text-sm text-gray-800 truncate block">
-                                        {chat.title ?? "Untitled Chat"}
+                                        {chat.title ?? t("untitledChat")}
                                     </span>
                                 )}
                             </div>
@@ -160,7 +161,7 @@ export function ProjectAssistantTab({
                                             return;
                                         }
                                         setRenameChatValue(
-                                            chat.title ?? "Untitled Chat",
+                                            chat.title ?? t("untitledChat"),
                                         );
                                         setRenamingChatId(chat.id);
                                     }}

--- a/frontend/src/app/components/projects/ProjectExplorer.tsx
+++ b/frontend/src/app/components/projects/ProjectExplorer.tsx
@@ -11,6 +11,7 @@ import {
     FolderPlus,
     Trash2,
 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { MikeDocument, MikeFolder } from "@/app/components/shared/types";
 import { VersionChip } from "@/app/components/shared/VersionChip";
 
@@ -57,6 +58,7 @@ export function ProjectExplorer({
     onMoveDoc,
     onMoveFolder,
 }: Props) {
+    const t = useTranslations("Projects.ProjectExplorer");
     const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
     const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
     const [creatingIn, setCreatingIn] = useState<string | null | undefined>(undefined);
@@ -184,7 +186,7 @@ export function ProjectExplorer({
                             ref={newFolderInputRef}
                             autoFocus
                             className="flex-1 min-w-0 text-xs bg-transparent outline-none border-b border-gray-300 text-gray-800"
-                            placeholder="Folder name"
+                            placeholder={t("placeholderFolderName")}
                             value={newFolderName}
                             onChange={(e) => setNewFolderName(e.target.value)}
                             onKeyDown={(e) => {
@@ -353,7 +355,7 @@ export function ProjectExplorer({
 
             {/* Empty state */}
             {documents.length === 0 && folders.length === 0 && creatingIn === undefined && (
-                <li className="px-4 py-2 text-xs text-gray-400">No documents in this project.</li>
+                <li className="px-4 py-2 text-xs text-gray-400">{t("emptyState")}</li>
             )}
 
             {/* Context menu */}
@@ -378,7 +380,7 @@ export function ProjectExplorer({
                             }}
                         >
                             <FolderPlus className="h-3.5 w-3.5 text-gray-400" />
-                            New subfolder
+                            {t("contextNewSubfolder")}
                         </button>
                     )}
                     {contextMenu.folderId && onRenameFolder && (
@@ -391,7 +393,7 @@ export function ProjectExplorer({
                                 setContextMenu(null);
                             }}
                         >
-                            Rename
+                            {t("contextRename")}
                         </button>
                     )}
                     {contextMenu.folderId && onDeleteFolder && (
@@ -403,7 +405,7 @@ export function ProjectExplorer({
                             }}
                         >
                             <Trash2 className="h-3.5 w-3.5 shrink-0" />
-                            Delete folder
+                            {t("contextDeleteFolder")}
                         </button>
                     )}
                     {contextMenu.docId && onDeleteDoc && (
@@ -415,7 +417,7 @@ export function ProjectExplorer({
                             }}
                         >
                             <Trash2 className="h-3.5 w-3.5 shrink-0" />
-                            Delete file
+                            {t("contextDeleteFile")}
                         </button>
                     )}
                 </div>

--- a/frontend/src/app/components/projects/ProjectPage.tsx
+++ b/frontend/src/app/components/projects/ProjectPage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 import {
     Upload,
     Loader2,
@@ -85,6 +86,7 @@ interface Props {
 }
 
 export function ProjectPage({ projectId, initialTab = "documents" }: Props) {
+    const t = useTranslations("Projects.ProjectPage");
     const [project, setProject] = useState<MikeProject | null>(null);
     const [folders, setFolders] = useState<MikeFolder[]>([]);
     const [chats, setChats] = useState<MikeChat[]>([]);
@@ -786,7 +788,7 @@ export function ProjectPage({ projectId, initialTab = "documents" }: Props) {
                         <input
                             autoFocus
                             className="flex-1 min-w-0 text-sm text-gray-800 bg-transparent outline-none border-b border-gray-300"
-                            placeholder="Folder name"
+                            placeholder={t("placeholderFolderName")}
                             value={newFolderName}
                             onChange={(e) => setNewFolderName(e.target.value)}
                             onKeyDown={(e) => {
@@ -838,7 +840,7 @@ export function ProjectPage({ projectId, initialTab = "documents" }: Props) {
                     {filename.includes(".") ? filename.split(".").pop() : "file"}
                 </div>
                 <div className="w-24 shrink-0 text-sm text-gray-300">
-                    Uploading
+                    {t("uploading")}
                 </div>
                 <div className="w-20 shrink-0 text-sm text-gray-300">—</div>
                 <div className="w-32 shrink-0 text-sm text-gray-300">—</div>
@@ -1154,7 +1156,7 @@ export function ProjectPage({ projectId, initialTab = "documents" }: Props) {
     if (!project) {
         return (
             <div className="flex h-full items-center justify-center">
-                <p className="text-gray-400">Project not found</p>
+                <p className="text-gray-400">{t("projectNotFound")}</p>
             </div>
         );
     }
@@ -1188,7 +1190,7 @@ export function ProjectPage({ projectId, initialTab = "documents" }: Props) {
                 onClick={() => setActionsOpen((v) => !v)}
                 className="flex items-center gap-1 text-xs font-medium text-gray-700 hover:text-gray-900 transition-colors"
             >
-                Actions
+                {t("actions")}
                 <ChevronDown className="h-3.5 w-3.5" />
             </button>
             {actionsOpen && (
@@ -1198,7 +1200,7 @@ export function ProjectPage({ projectId, initialTab = "documents" }: Props) {
                             onClick={handleDownloadSelectedDocs}
                             className="w-full px-3 py-1.5 text-left text-xs text-gray-600 hover:bg-gray-50 transition-colors"
                         >
-                            Download
+                            {t("download")}
                         </button>
                     )}
                     {tab === "documents" && selectedDocIds.some((id) => docs.find((d) => d.id === id)?.folder_id != null) && (
@@ -1206,14 +1208,14 @@ export function ProjectPage({ projectId, initialTab = "documents" }: Props) {
                             onClick={handleRemoveSelectedFromFolder}
                             className="w-full px-3 py-1.5 text-left text-xs text-gray-600 hover:bg-gray-50 transition-colors"
                         >
-                            Remove from subfolder
+                            {t("removeFromSubfolder")}
                         </button>
                     )}
                     <button
                         onClick={handleDeleteSelected}
                         className="w-full px-3 py-1.5 text-left text-xs text-red-600 hover:bg-red-50 transition-colors"
                     >
-                        Delete
+                        {t("delete")}
                     </button>
                 </div>
             )}
@@ -1230,14 +1232,14 @@ export function ProjectPage({ projectId, initialTab = "documents" }: Props) {
                         className="flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-gray-700 transition-colors"
                     >
                         <FolderPlus className="h-3.5 w-3.5" />
-                        Add Subfolder
+                        {t("addSubfolder")}
                     </button>
                     <button
                         onClick={() => setAddDocsOpen(true)}
                         className="flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-gray-700 transition-colors"
                     >
                         <Upload className="h-3.5 w-3.5" />
-                        Add Documents
+                        {t("addDocuments")}
                     </button>
                 </>
             )}
@@ -1264,9 +1266,9 @@ export function ProjectPage({ projectId, initialTab = "documents" }: Props) {
 
             <ToolbarTabs
                 tabs={[
-                    { id: "documents", label: "Documents" },
-                    { id: "assistant", label: "Assistant" },
-                    { id: "reviews", label: "Tabular Reviews" },
+                    { id: "documents", label: t("tabDocuments") },
+                    { id: "assistant", label: t("tabAssistant") },
+                    { id: "reviews", label: t("tabTabularReviews") },
                 ]}
                 active={tab}
                 onChange={handleTabChange}
@@ -1299,13 +1301,13 @@ export function ProjectPage({ projectId, initialTab = "documents" }: Props) {
                                 />
                             </div>
                             <div className={`sticky left-8 z-[60] ${DOC_NAME_COL_W} bg-white pl-2 text-left`}>
-                                Name
+                                {t("colName")}
                             </div>
-                            <div className="ml-auto w-20 shrink-0 text-left">Type</div>
-                            <div className="w-24 shrink-0 text-left">Size</div>
-                            <div className="w-20 shrink-0 text-left">Version</div>
-                            <div className="w-32 shrink-0 text-left">Created</div>
-                            <div className="w-32 shrink-0 text-left">Updated</div>
+                            <div className="ml-auto w-20 shrink-0 text-left">{t("colType")}</div>
+                            <div className="w-24 shrink-0 text-left">{t("colSize")}</div>
+                            <div className="w-20 shrink-0 text-left">{t("colVersion")}</div>
+                            <div className="w-32 shrink-0 text-left">{t("colCreated")}</div>
+                            <div className="w-32 shrink-0 text-left">{t("colUpdated")}</div>
                             <div className="w-8 shrink-0" />
                         </div>
 
@@ -1351,7 +1353,7 @@ export function ProjectPage({ projectId, initialTab = "documents" }: Props) {
                                 className="flex-1 flex cursor-pointer flex-col items-center justify-center py-24 text-center"
                             >
                                 <Upload className="h-8 w-8 text-gray-200 mb-3" />
-                                <p className="text-sm text-gray-400">Drop PDF or DOCX files here</p>
+                                <p className="text-sm text-gray-400">{t("dropFilesHere")}</p>
                             </div>
                         ) : (
                             <div

--- a/frontend/src/app/components/projects/ProjectPageParts.tsx
+++ b/frontend/src/app/components/projects/ProjectPageParts.tsx
@@ -10,6 +10,7 @@ import {
     Plus,
     Users,
 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { HeaderSearchBtn } from "@/app/components/shared/HeaderSearchBtn";
 import { RenameableTitle } from "@/app/components/shared/RenameableTitle";
 import type { MikeProject } from "@/app/components/shared/types";
@@ -101,6 +102,7 @@ export function DocVersionHistory({
         displayName: string | null,
     ) => Promise<void> | void;
 }) {
+    const t = useTranslations("Projects.ProjectPageParts");
     const [editingVersionId, setEditingVersionId] = useState<string | null>(
         null,
     );
@@ -126,7 +128,7 @@ export function DocVersionHistory({
                 >
                     <div className="flex items-center gap-2">
                         <Loader2 className="h-3 w-3 animate-spin text-gray-400" />
-                        <span>Loading versions…</span>
+                        <span>{t("loadingVersions")}</span>
                     </div>
                 </div>
             </div>
@@ -144,7 +146,7 @@ export function DocVersionHistory({
                     className={`sticky left-8 z-[60] ${DOC_NAME_COL_W} bg-gray-50/60 p-2`}
                     style={treeNameCellStyle(depth)}
                 >
-                    <div>No version history.</div>
+                    <div>{t("noVersionHistory")}</div>
                 </div>
             </div>
         );
@@ -159,7 +161,7 @@ export function DocVersionHistory({
                     v.version_number >= 1
                         ? `${v.version_number}`
                         : v.source === "upload"
-                          ? "Original"
+                          ? t("versionOriginal")
                           : "—";
                 const displayLabel = v.display_name?.trim() || numberLabel;
                 const dt = new Date(v.created_at);
@@ -228,7 +230,7 @@ export function DocVersionHistory({
                                                 v.display_name ?? "",
                                             );
                                         }}
-                                        title="Rename version"
+                                        title={t("renameVersion")}
                                         className="shrink-0 rounded p-0.5 text-gray-400 opacity-0 group-hover:opacity-100 hover:text-gray-700 hover:bg-gray-200 transition"
                                     >
                                         <Pencil className="h-3 w-3" />
@@ -356,6 +358,7 @@ export function ProjectPageHeader({
     onNewChat: () => void;
     onNewReview: () => void;
 }) {
+    const t = useTranslations("Projects.ProjectPageParts");
     return (
         <div className="mb-1 flex items-start justify-between px-4 py-3 md:px-10">
             <div>
@@ -364,7 +367,7 @@ export function ProjectPageHeader({
                         onClick={onBackToProjects}
                         className="text-gray-400 hover:text-gray-600 transition-colors"
                     >
-                        Projects
+                        {t("breadcrumbProjects")}
                     </button>
                     <span className="text-gray-300">›</span>
                     {tab !== "documents" ? (
@@ -397,8 +400,8 @@ export function ProjectPageHeader({
                             <span className="text-gray-300">›</span>
                             <span className="text-gray-900">
                                 {tab === "assistant"
-                                    ? "Assistant"
-                                    : "Tabular Reviews"}
+                                    ? t("tabAssistant")
+                                    : t("tabTabularReviews")}
                             </span>
                         </>
                     )}
@@ -408,13 +411,13 @@ export function ProjectPageHeader({
                 <HeaderSearchBtn
                     value={search}
                     onChange={onSearchChange}
-                    placeholder="Search…"
+                    placeholder={t("searchPlaceholder")}
                 />
                 <button
                     onClick={onOpenPeople}
                     className="flex h-8 w-8 items-center justify-center text-sm text-gray-500 transition-colors hover:text-gray-900 cursor-pointer"
-                    title="People with access"
-                    aria-label="People with access"
+                    title={t("peopleWithAccess")}
+                    aria-label={t("peopleWithAccess")}
                 >
                     <Users className="h-4 w-4" />
                 </button>
@@ -432,7 +435,7 @@ export function ProjectPageHeader({
                         ) : (
                             <Plus className="h-4 w-4" />
                         )}
-                        Chat
+                        {t("chatButton")}
                     </button>
                 </div>
                 <div className="relative group">
@@ -451,11 +454,11 @@ export function ProjectPageHeader({
                         ) : (
                             <Plus className="h-4 w-4" />
                         )}
-                        Tabular Review
+                        {t("tabularReviewButton")}
                     </button>
                     {docsCount === 0 && (
                         <div className="pointer-events-none absolute right-0 top-full mt-1.5 z-10 hidden group-hover:flex items-center whitespace-nowrap rounded-lg bg-gray-900 px-2.5 py-1.5 text-xs text-white shadow-lg">
-                            Upload a document first
+                            {t("uploadDocumentFirst")}
                         </div>
                     )}
                 </div>

--- a/frontend/src/app/components/projects/ProjectReviewsTab.tsx
+++ b/frontend/src/app/components/projects/ProjectReviewsTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type Dispatch, type SetStateAction } from "react";
+import { useTranslations } from "next-intl";
 import { Table2 } from "lucide-react";
 import { RowActions } from "@/app/components/shared/RowActions";
 import type { MikeDocument, TabularReview } from "@/app/components/shared/types";
@@ -45,6 +46,7 @@ export function ProjectReviewsTab({
     setRenamingReviewId: Dispatch<SetStateAction<string | null>>;
     setRenameReviewValue: Dispatch<SetStateAction<string>>;
 }) {
+    const t = useTranslations("Projects.ProjectReviewsTab");
     return (
         <>
             <div className="flex items-center h-8 pr-8 border-b border-gray-200 text-xs text-gray-500 font-medium select-none">
@@ -70,28 +72,28 @@ export function ProjectReviewsTab({
                 <div
                     className={`sticky left-8 z-[60] ${NAME_COL_W} bg-white pl-2 text-left`}
                 >
-                    Name
+                    {t("colName")}
                 </div>
-                <div className="ml-auto w-24 shrink-0 text-left">Columns</div>
-                <div className="w-24 shrink-0 text-left">Documents</div>
-                <div className="w-32 shrink-0 text-left">Created</div>
+                <div className="ml-auto w-24 shrink-0 text-left">{t("colColumns")}</div>
+                <div className="w-24 shrink-0 text-left">{t("colDocuments")}</div>
+                <div className="w-32 shrink-0 text-left">{t("colCreated")}</div>
                 <div className="w-8 shrink-0" />
             </div>
             {reviews.length === 0 ? (
                 <div className="flex flex-col items-start py-24 w-full max-w-xs mx-auto">
                     <Table2 className="h-8 w-8 text-gray-300 mb-4" />
                     <p className="text-2xl font-medium font-serif text-gray-900">
-                        Tabular Reviews
+                        {t("emptyHeading")}
                     </p>
                     <p className="mt-1 text-xs text-gray-400 max-w-xs">
-                        Extract data from project documents into tables using AI.
+                        {t("emptyDescription")}
                     </p>
                     <button
                         onClick={onCreateReview}
                         disabled={creatingReview || docs.length === 0}
                         className="mt-4 inline-flex items-center gap-1 rounded-full bg-gray-900 px-3 py-1 text-xs font-medium text-white hover:bg-gray-700 transition-colors shadow-md disabled:opacity-40"
                     >
-                        + Create New
+                        {t("createNew")}
                     </button>
                 </div>
             ) : (
@@ -152,7 +154,7 @@ export function ProjectReviewsTab({
                                     />
                                 ) : (
                                     <span className="text-sm text-gray-800 truncate block">
-                                        {review.title ?? "Untitled Review"}
+                                        {review.title ?? t("untitledReview")}
                                     </span>
                                 )}
                             </div>
@@ -180,12 +182,12 @@ export function ProjectReviewsTab({
                                             review.user_id !== currentUserId
                                         ) {
                                             onOwnerOnlyAction(
-                                                "rename this tabular review",
+                                                t("ownerOnlyRename"),
                                             );
                                             return;
                                         }
                                         setRenameReviewValue(
-                                            review.title ?? "Untitled Review",
+                                            review.title ?? t("untitledReview"),
                                         );
                                         setRenamingReviewId(review.id);
                                     }}

--- a/frontend/src/app/components/projects/ProjectsOverview.tsx
+++ b/frontend/src/app/components/projects/ProjectsOverview.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { Plus, FolderOpen, ChevronDown } from "lucide-react";
 import { HeaderSearchBtn } from "@/app/components/shared/HeaderSearchBtn";
 import { listProjects, updateProject, deleteProject } from "@/app/lib/mikeApi";
@@ -42,6 +43,7 @@ export function ProjectsOverview() {
     const actionsRef = useRef<HTMLDivElement>(null);
     const router = useRouter();
     const { user, isAuthenticated, authLoading } = useAuth();
+    const t = useTranslations("Projects.ProjectsOverview");
 
     useEffect(() => {
         if (authLoading) {
@@ -66,7 +68,7 @@ export function ProjectsOverview() {
                 console.error("[projects] failed to load projects", err);
                 if (!cancelled) {
                     setProjects([]);
-                    setLoadError("Could not load projects.");
+                    setLoadError(t("loadError"));
                 }
             })
             .finally(() => {
@@ -129,9 +131,9 @@ export function ProjectsOverview() {
     }
 
     const tabs: { id: Tab; label: string }[] = [
-        { id: "all", label: "All" },
-        { id: "mine", label: "Mine" },
-        { id: "shared-with-me", label: "Shared with me" },
+        { id: "all", label: t("tabAll") },
+        { id: "mine", label: t("tabMine") },
+        { id: "shared-with-me", label: t("tabSharedWithMe") },
     ];
 
     async function handleRenameSubmit(projectId: string) {
@@ -170,9 +172,7 @@ export function ProjectsOverview() {
         await Promise.all(owned.map((id) => deleteProject(id).catch(() => {})));
         setProjects((prev) => prev.filter((p) => !owned.includes(p.id)));
         if (blocked > 0) {
-            setOwnerOnlyAction(
-                `delete ${blocked} of the selected projects — only the project owner can delete a project`,
-            );
+            setOwnerOnlyAction(t("ownerOnlyDelete", { count: blocked }));
         }
     }
 
@@ -184,7 +184,7 @@ export function ProjectsOverview() {
                         onClick={() => setActionsOpen((v) => !v)}
                         className="flex items-center gap-1 text-xs font-medium text-gray-700 hover:text-gray-900 transition-colors"
                     >
-                        Actions
+                        {t("actions")}
                         <ChevronDown className="h-3.5 w-3.5" />
                     </button>
                     {actionsOpen && (
@@ -193,7 +193,7 @@ export function ProjectsOverview() {
                                 onClick={handleDeleteSelected}
                                 className="w-full px-3 py-1.5 text-left text-xs text-red-600 hover:bg-red-50 transition-colors"
                             >
-                                Delete
+                                {t("delete")}
                             </button>
                         </div>
                     )}
@@ -207,13 +207,13 @@ export function ProjectsOverview() {
             {/* Page header */}
             <div className="mb-1 flex items-center justify-between px-4 py-3 md:px-10">
                 <h1 className="text-2xl font-medium font-serif text-gray-900">
-                    Projects
+                    {t("heading")}
                 </h1>
                 <div className="flex items-center gap-2">
                     <HeaderSearchBtn
                         value={search}
                         onChange={setSearch}
-                        placeholder="Search projects…"
+                        placeholder={t("searchPlaceholder")}
                     />
                     <button
                         onClick={() => setModalOpen(true)}
@@ -250,15 +250,15 @@ export function ProjectsOverview() {
                         )}
                     </div>
                     <div className={`sticky left-8 z-[60] ${NAME_COL_W} bg-white pl-2 text-left`}>
-                        Name
+                        {t("colName")}
                     </div>
-                    <div className="ml-auto w-32 shrink-0 text-left">CM</div>
-                    <div className="w-24 shrink-0 text-left">Files</div>
-                    <div className="w-24 shrink-0 text-left">Chats</div>
+                    <div className="ml-auto w-32 shrink-0 text-left">{t("colCm")}</div>
+                    <div className="w-24 shrink-0 text-left">{t("colFiles")}</div>
+                    <div className="w-24 shrink-0 text-left">{t("colChats")}</div>
                     <div className="w-36 shrink-0 text-left">
-                        Tabular Reviews
+                        {t("colTabularReviews")}
                     </div>
-                    <div className="w-32 shrink-0 text-left">Created</div>
+                    <div className="w-32 shrink-0 text-left">{t("colCreated")}</div>
                     <div className="w-8 shrink-0" />
                 </div>
 
@@ -296,7 +296,7 @@ export function ProjectsOverview() {
                     <div className="flex flex-col items-start py-24 w-full max-w-xs mx-auto">
                         <FolderOpen className="h-8 w-8 text-gray-300 mb-4" />
                         <p className="text-2xl font-medium font-serif text-gray-900">
-                            Projects
+                            {t("heading")}
                         </p>
                         <p className="mt-1 text-xs text-red-500 max-w-xs">
                             {loadError}
@@ -308,23 +308,21 @@ export function ProjectsOverview() {
                             <>
                                 <FolderOpen className="h-8 w-8 text-gray-300 mb-4" />
                                 <p className="text-2xl font-medium font-serif text-gray-900">
-                                    Projects
+                                    {t("heading")}
                                 </p>
                                 <p className="mt-1 text-xs text-gray-400 max-w-xs">
-                                    Upload documents into projects and to
-                                    commence chats and tabular reviews with
-                                    them.
+                                    {t("emptyDescription")}
                                 </p>
                                 <button
                                     onClick={() => setModalOpen(true)}
                                     className="mt-4 inline-flex items-center gap-1 rounded-full bg-gray-900 px-3 py-1 text-xs font-medium text-white hover:bg-gray-700 transition-colors shadow-md"
                                 >
-                                    + Create New
+                                    {t("createNew")}
                                 </button>
                             </>
                         ) : (
                             <p className="text-sm text-gray-400">
-                                No {activeTab} projects
+                                {t("noSharedProjects")}
                             </p>
                         )}
                     </div>
@@ -407,7 +405,7 @@ export function ProjectsOverview() {
                                             onBlur={() =>
                                                 handleCmSubmit(project.id)
                                             }
-                                            placeholder="CM #"
+                                            placeholder={t("cmPlaceholder")}
                                             className="w-full text-sm text-gray-800 bg-transparent outline-none"
                                         />
                                     ) : (

--- a/frontend/src/app/components/shared/AddDocumentsModal.tsx
+++ b/frontend/src/app/components/shared/AddDocumentsModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { X, Upload, Search, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
     uploadStandaloneDocument,
     uploadProjectDocument,
@@ -34,6 +35,7 @@ export function AddDocumentsModal({
     allowMultiple = true,
     projectId,
 }: Props) {
+    const t = useTranslations("Documents.AddDocumentsModal");
     const { loading, standaloneDocuments, projects } = useDirectoryData(open);
     const { user } = useAuth();
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -228,7 +230,7 @@ export function AddDocumentsModal({
                         <Search className="h-3.5 w-3.5 text-gray-400 shrink-0" />
                         <input
                             type="text"
-                            placeholder="Search…"
+                            placeholder={t("searchPlaceholder")}
                             value={search}
                             onChange={(e) => setSearch(e.target.value)}
                             className="flex-1 bg-transparent text-sm text-gray-700 placeholder:text-gray-400 outline-none"
@@ -256,7 +258,7 @@ export function AddDocumentsModal({
                         allowMultiple={allowMultiple}
                         forceExpanded={!!q}
                         emptyMessage={
-                            q ? "No matches found" : "No documents yet"
+                            q ? t("noMatchesFound") : t("noDocumentsYet")
                         }
                         onDelete={handleDelete}
                         uploadingFilenames={uploadingFilenames}
@@ -284,27 +286,27 @@ export function AddDocumentsModal({
                             ) : (
                                 <Upload className="h-3.5 w-3.5" />
                             )}
-                            {uploading ? "Uploading…" : "Upload"}
+                            {uploading ? t("uploading") : t("upload")}
                         </button>
                     </div>
                     <div className="flex items-center gap-2">
                         {selectedIds.size > 0 && (
                             <span className="text-xs text-gray-400">
-                                {selectedIds.size} selected
+                                {t("selected", { count: selectedIds.size })}
                             </span>
                         )}
                         <button
                             onClick={onClose}
                             className="rounded-lg px-3 py-1.5 text-sm text-gray-500 hover:bg-gray-100"
                         >
-                            Cancel
+                            {t("cancel")}
                         </button>
                         <button
                             onClick={handleConfirm}
                             disabled={selectedIds.size === 0 || uploading}
                             className="rounded-lg bg-gray-900 px-4 py-1.5 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-40"
                         >
-                            {uploading ? "Saving…" : "Confirm"}
+                            {uploading ? t("saving") : t("confirm")}
                         </button>
                     </div>
                 </div>

--- a/frontend/src/app/components/shared/AddProjectDocsModal.tsx
+++ b/frontend/src/app/components/shared/AddProjectDocsModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Check, Loader2, Search, Upload, X } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { getProject, uploadProjectDocument } from "@/app/lib/mikeApi";
 import type { MikeDocument } from "./types";
 import { DocFileIcon } from "./FileDirectory";
@@ -37,6 +38,7 @@ export function AddProjectDocsModal({
     excludeDocIds,
     allowMultiple = true,
 }: Props) {
+    const t = useTranslations("Documents.AddProjectDocsModal");
     const [docs, setDocs] = useState<MikeDocument[]>([]);
     const [loading, setLoading] = useState(false);
     const [search, setSearch] = useState("");
@@ -145,7 +147,7 @@ export function AddProjectDocsModal({
                         <Search className="h-3.5 w-3.5 text-gray-400 shrink-0" />
                         <input
                             type="text"
-                            placeholder="Search…"
+                            placeholder={t("searchPlaceholder")}
                             value={search}
                             onChange={(e) => setSearch(e.target.value)}
                             className="flex-1 bg-transparent text-sm text-gray-700 placeholder:text-gray-400 outline-none"
@@ -182,7 +184,7 @@ export function AddProjectDocsModal({
                         </div>
                     ) : filtered.length === 0 ? (
                         <p className="text-center text-sm text-gray-400 py-8">
-                            {q ? "No matches found" : "No documents in this project"}
+                            {q ? t("noMatchesFound") : t("noDocumentsInProject")}
                         </p>
                     ) : (
                         <div className="rounded-sm border border-gray-100 overflow-hidden">
@@ -229,7 +231,7 @@ export function AddProjectDocsModal({
                                         </span>
                                         {excluded && (
                                             <span className="text-[10px] text-gray-400 shrink-0">
-                                                Already added
+                                                {t("alreadyAdded")}
                                             </span>
                                         )}
                                         <VersionChip
@@ -268,27 +270,27 @@ export function AddProjectDocsModal({
                             ) : (
                                 <Upload className="h-3.5 w-3.5" />
                             )}
-                            {uploading ? "Uploading…" : "Upload"}
+                            {uploading ? t("uploading") : t("upload")}
                         </button>
                     </div>
                     <div className="flex items-center gap-2">
                         {selectedIds.size > 0 && (
                             <span className="text-xs text-gray-400">
-                                {selectedIds.size} selected
+                                {t("selected", { count: selectedIds.size })}
                             </span>
                         )}
                         <button
                             onClick={onClose}
                             className="rounded-lg px-3 py-1.5 text-sm text-gray-500 hover:bg-gray-100"
                         >
-                            Cancel
+                            {t("cancel")}
                         </button>
                         <button
                             onClick={handleConfirm}
                             disabled={selectedIds.size === 0 || uploading}
                             className="rounded-lg bg-gray-900 px-4 py-1.5 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-40"
                         >
-                            Confirm
+                            {t("confirm")}
                         </button>
                     </div>
                 </div>

--- a/frontend/src/app/components/shared/ApiKeyMissingModal.tsx
+++ b/frontend/src/app/components/shared/ApiKeyMissingModal.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 import { AlertTriangle, X } from "lucide-react";
 import { providerLabel, type ModelProvider } from "@/app/lib/modelAvailability";
+import { useTranslations } from "next-intl";
 
 interface Props {
     open: boolean;
@@ -15,12 +16,14 @@ interface Props {
 
 export function ApiKeyMissingModal({ open, onClose, provider, message }: Props) {
     const router = useRouter();
+    const t = useTranslations("Shared.ApiKeyMissingModal");
+
     if (!open) return null;
 
-    const providerName = provider ? providerLabel(provider) : "this provider";
+    const providerName = provider ? providerLabel(provider) : t("thisProvider");
     const body =
         message ??
-        `You haven't added a ${providerName} API key yet. Add one in your account settings to use this model.`;
+        t("body", { providerName });
 
     const handleGoToAccount = () => {
         onClose();
@@ -40,7 +43,7 @@ export function ApiKeyMissingModal({ open, onClose, provider, message }: Props) 
                     <div className="flex items-center gap-2">
                         <AlertTriangle className="h-4 w-4 text-amber-600" />
                         <h2 className="text-base font-medium text-gray-900">
-                            API key required
+                            {t("title")}
                         </h2>
                     </div>
                     <button
@@ -62,13 +65,13 @@ export function ApiKeyMissingModal({ open, onClose, provider, message }: Props) 
                         onClick={onClose}
                         className="rounded-lg px-4 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100"
                     >
-                        Cancel
+                        {t("cancel")}
                     </button>
                     <button
                         onClick={handleGoToAccount}
                         className="rounded-lg bg-gray-900 px-4 py-1.5 text-sm font-medium text-white hover:bg-gray-700"
                     >
-                        Go to account settings
+                        {t("goToAccountSettings")}
                     </button>
                 </div>
             </div>

--- a/frontend/src/app/components/shared/AppSidebar.tsx
+++ b/frontend/src/app/components/shared/AppSidebar.tsx
@@ -11,6 +11,7 @@ import {
     ChevronsUpDown,
     ChevronDown,
 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUserProfile } from "@/contexts/UserProfileContext";
 import { useChatHistoryContext } from "@/app/contexts/ChatHistoryContext";
@@ -21,11 +22,11 @@ import { SidebarChatItem } from "@/app/components/shared/SidebarChatItem";
 import { listProjects } from "@/app/lib/mikeApi";
 import type { MikeProject } from "@/app/components/shared/types";
 
-const NAV_ITEMS = [
-    { href: "/assistant", label: "Assistant", icon: MessageSquare },
-    { href: "/projects", label: "Projects", icon: FolderOpen },
-    { href: "/tabular-reviews", label: "Tabular Review", icon: Table2 },
-    { href: "/workflows", label: "Workflows", icon: Library },
+const NAV_ITEM_KEYS = [
+    { href: "/assistant", labelKey: "navAssistant" as const, icon: MessageSquare },
+    { href: "/projects", labelKey: "navProjects" as const, icon: FolderOpen },
+    { href: "/tabular-reviews", labelKey: "navTabularReview" as const, icon: Table2 },
+    { href: "/workflows", labelKey: "navWorkflows" as const, icon: Library },
 ];
 
 interface AppSidebarProps {
@@ -128,6 +129,8 @@ export function AppSidebar({ isOpen, onToggle }: AppSidebarProps) {
         return profile.tier || "Free";
     };
 
+    const t = useTranslations("Shared.AppSidebar");
+
     if (!user) return null;
 
     return (
@@ -164,14 +167,15 @@ export function AppSidebar({ isOpen, onToggle }: AppSidebarProps) {
                 <button
                     onClick={onToggle}
                     className="h-9 w-9 p-2.5 items-center flex hover:bg-gray-100 rounded-md transition-colors"
-                    title={isOpen ? "Close sidebar" : "Open sidebar"}
+                    title={isOpen ? t("closeSidebar") : t("openSidebar")}
                 >
                     <PanelLeft className="h-4 w-4" />
                 </button>
             </div>
 
             {/* Nav items */}
-            {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+            {NAV_ITEM_KEYS.map(({ href, labelKey, icon: Icon }) => {
+                const label = t(labelKey);
                 const isActive =
                     pathname === href || pathname.startsWith(href + "/");
                 return (
@@ -214,7 +218,7 @@ export function AppSidebar({ isOpen, onToggle }: AppSidebarProps) {
                                 shouldAnimate ? "sidebar-fade-in" : ""
                             }`}
                         >
-                            <span>Recent Projects</span>
+                            <span>{t("recentProjects")}</span>
                             <ChevronDown
                                 className={`h-3.5 w-3.5 transition-transform ${
                                     projectsCollapsed ? "-rotate-90" : ""
@@ -245,7 +249,7 @@ export function AppSidebar({ isOpen, onToggle }: AppSidebarProps) {
                                                 : ""
                                         }`}
                                     >
-                                        No projects yet
+                                        {t("noProjectsYet")}
                                     </div>
                                 ) : (
                                     <div
@@ -298,7 +302,7 @@ export function AppSidebar({ isOpen, onToggle }: AppSidebarProps) {
                                 shouldAnimate ? "sidebar-fade-in" : ""
                             }`}
                         >
-                            <span>Assistant History</span>
+                            <span>{t("assistantHistory")}</span>
                             <ChevronDown
                                 className={`h-3.5 w-3.5 transition-transform ${
                                     historyCollapsed ? "-rotate-90" : ""
@@ -330,7 +334,7 @@ export function AppSidebar({ isOpen, onToggle }: AppSidebarProps) {
                                         shouldAnimate ? "sidebar-fade-in-2" : ""
                                     }`}
                                 >
-                                    No chats yet
+                                    {t("noChatsYet")}
                                 </div>
                             ) : (
                                 <>
@@ -372,7 +376,7 @@ export function AppSidebar({ isOpen, onToggle }: AppSidebarProps) {
                                                 onClick={loadMoreChats}
                                                 className="flex h-8 w-full items-center justify-start rounded-md px-3 text-left text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
                                             >
-                                                Load more
+                                                {t("loadMore")}
                                             </button>
                                         </div>
                                     )}
@@ -430,7 +434,7 @@ export function AppSidebar({ isOpen, onToggle }: AppSidebarProps) {
                                     className="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2 rounded-md"
                                 >
                                     <User className="h-4 w-4" />
-                                    Account Settings
+                                    {t("accountSettings")}
                                 </button>
                             </div>
                         )}

--- a/frontend/src/app/components/shared/DocPanel.tsx
+++ b/frontend/src/app/components/shared/DocPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Download, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { supabase } from "@/lib/supabase";
 import { applyOptimisticResolution } from "../assistant/EditCard";
 import { DocView } from "./DocView";
@@ -199,12 +200,13 @@ function CitationHeader({
     filename: string;
     isReloading: boolean;
 }) {
+    const t = useTranslations("Documents.DocPanel");
     const displayQuote = displayCitationQuote(citation);
     const pagesLabel = formatCitationPage(citation);
     return (
         <div className="pt-2 pb-3">
             <div className="flex items-center gap-2 mb-2">
-                <SectionLabel>Citation</SectionLabel>
+                <SectionLabel>{t("citation")}</SectionLabel>
                 <div className="ml-auto shrink-0">
                     <DownloadButton
                         documentId={documentId}
@@ -241,11 +243,12 @@ function TrackedChangeHeader({
     filename: string;
     isReloading: boolean;
 }) {
+    const t = useTranslations("Documents.DocPanel");
     const { edit, isEditReloading, onResolveStart, onResolved, onError } = mode;
     return (
         <div className="pt-2 pb-3">
             <div className="flex items-center gap-2 mb-2">
-                <SectionLabel>Tracked Change</SectionLabel>
+                <SectionLabel>{t("trackedChange")}</SectionLabel>
                 <div className="ml-auto flex items-center gap-2 shrink-0">
                     <EditResolveButtons
                         edit={edit}
@@ -321,6 +324,7 @@ function EditResolveButtons({
         message: string;
     }) => void;
 }) {
+    const t = useTranslations("Documents.DocPanel");
     const [busy, setBusy] = useState(false);
     const [status, setStatus] = useState<"pending" | "accepted" | "rejected">(
         edit.status,
@@ -405,8 +409,8 @@ function EditResolveButtons({
                     versionId: edit.version_id ?? null,
                     message:
                         verb === "accept"
-                            ? "Couldn't save accept — please retry."
-                            : "Couldn't save reject — please retry.",
+                            ? t("errorAccept")
+                            : t("errorReject"),
                 });
             } finally {
                 setBusy(false);
@@ -423,14 +427,14 @@ function EditResolveButtons({
                 disabled={inFlight || resolved}
                 className="inline-flex items-center gap-1 rounded-lg border border-gray-900 bg-gray-900 px-2 py-1.5 text-xs font-medium text-white hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-                {status === "accepted" ? "Accepted" : "Accept"}
+                {status === "accepted" ? t("accepted") : t("accept")}
             </button>
             <button
                 onClick={() => handle("reject")}
                 disabled={inFlight || resolved}
                 className="inline-flex items-center gap-1 rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-                {status === "rejected" ? "Rejected" : "Reject"}
+                {status === "rejected" ? t("rejected") : t("reject")}
             </button>
         </div>
     );
@@ -451,6 +455,7 @@ function DownloadButton({
     filename: string;
     isReloading?: boolean;
 }) {
+    const t = useTranslations("Documents.DocPanel");
     const [busy, setBusy] = useState(false);
 
     const handleClick = async () => {
@@ -499,7 +504,7 @@ function DownloadButton({
             ) : (
                 <Download className="h-3.5 w-3.5" />
             )}
-            Download
+            {t("download")}
         </button>
     );
 }

--- a/frontend/src/app/components/shared/DocumentCard.tsx
+++ b/frontend/src/app/components/shared/DocumentCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FileText, File, X, AlertCircle, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { MikeDocument } from "./types";
 
 interface Props {
@@ -27,6 +28,7 @@ function formatBytes(bytes: number): string {
 }
 
 export function DocumentCard({ document, onRemove, onClick, selected }: Props) {
+  const t = useTranslations("Documents.DocumentCard");
   const isError = document.status === "error";
   const isProcessing = document.status === "pending" || document.status === "processing";
 
@@ -57,9 +59,9 @@ export function DocumentCard({ document, onRemove, onClick, selected }: Props) {
         </p>
         <p className="text-xs text-gray-400">
           {isProcessing
-            ? "Processing…"
+            ? t("processing")
             : isError
-            ? "Upload failed"
+            ? t("uploadFailed")
             : [
                 document.size_bytes != null ? formatBytes(document.size_bytes) : null,
                 document.page_count ? `${document.page_count}p` : null,
@@ -76,7 +78,7 @@ export function DocumentCard({ document, onRemove, onClick, selected }: Props) {
             onRemove(document.id);
           }}
           className="shrink-0 rounded p-0.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-          aria-label="Remove document"
+          aria-label={t("removeDocument")}
         >
           <X className="h-3.5 w-3.5" />
         </button>

--- a/frontend/src/app/components/shared/DocxView.tsx
+++ b/frontend/src/app/components/shared/DocxView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { MikeIcon } from "@/components/chat/mike-icon";
 import { useFetchDocxBytes } from "@/app/hooks/useFetchDocxBytes";
 import { supabase } from "@/lib/supabase";
@@ -208,6 +209,7 @@ export function DocxView({
     rounded = true,
     bordered = true,
 }: Props) {
+    const t = useTranslations("Documents.DocxView");
     const scrollRef = useRef<HTMLDivElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const lastScrollTopRef = useRef(0);
@@ -480,7 +482,7 @@ export function DocxView({
                         type="button"
                         onClick={() => onWarningDismiss?.()}
                         className="text-amber-600 hover:text-amber-900"
-                        aria-label="Dismiss warning"
+                        aria-label={t("dismissWarning")}
                     >
                         ×
                     </button>

--- a/frontend/src/app/components/shared/EmailPillInput.tsx
+++ b/frontend/src/app/components/shared/EmailPillInput.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { X } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -19,9 +20,11 @@ export function EmailPillInput({
     onChange,
     validate,
     onValidatingChange,
-    placeholder = "Add by email…",
+    placeholder,
     autoFocus = false,
 }: Props) {
+    const t = useTranslations("Shared.EmailPillInput");
+    const resolvedPlaceholder = placeholder ?? t("placeholder");
     const [input, setInput] = useState("");
     const [validating, setValidating] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -48,7 +51,7 @@ export function EmailPillInput({
             return;
         }
         if (!EMAIL_RE.test(email)) {
-            setError("Enter a valid email address.");
+            setError(t("errorInvalidEmail"));
             return;
         }
         if (validate) {
@@ -61,7 +64,7 @@ export function EmailPillInput({
                     return;
                 }
             } catch {
-                setError("Could not verify email. Try again.");
+                setError(t("errorVerifyFailed"));
                 return;
             } finally {
                 setValidatingState(false);
@@ -105,13 +108,13 @@ export function EmailPillInput({
                     }}
                     onKeyDown={handleKeyDown}
                     onBlur={addEmail}
-                    placeholder={emails.length === 0 ? placeholder : ""}
+                    placeholder={emails.length === 0 ? resolvedPlaceholder : ""}
                     className="flex-1 min-w-[160px] bg-transparent text-sm text-gray-700 placeholder:text-gray-400 outline-none"
                     autoFocus={autoFocus}
                 />
             </div>
             {error && <p className="mt-1.5 text-xs text-red-500">{error}</p>}
-            {validating && <p className="mt-1.5 text-xs text-gray-400">Checking…</p>}
+            {validating && <p className="mt-1.5 text-xs text-gray-400">{t("checking")}</p>}
         </div>
     );
 }

--- a/frontend/src/app/components/shared/FileDirectory.tsx
+++ b/frontend/src/app/components/shared/FileDirectory.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import {
     Check,
     ChevronDown,
@@ -56,6 +57,7 @@ export function FileDirectory({
     onDelete,
     uploadingFilenames = [],
 }: FileDirectoryProps) {
+    const t = useTranslations("Documents.FileDirectory");
     const [expandedProjects, setExpandedProjects] = useState<Set<string>>(
         new Set(),
     );
@@ -176,7 +178,7 @@ export function FileDirectory({
                                     className="inline-flex items-center gap-1 text-xs text-red-500 hover:text-red-700 transition-colors disabled:opacity-50"
                                 >
                                     <Trash2 className="h-3 w-3" />
-                                    Delete
+                                    {t("delete")}
                                 </button>
                             )}
                             {standaloneDocs.length > 0 && (
@@ -186,8 +188,8 @@ export function FileDirectory({
                                     className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
                                 >
                                     {allStandaloneSelected
-                                        ? "Deselect all"
-                                        : "Select all"}
+                                        ? t("deselectAll")
+                                        : t("selectAll")}
                                 </button>
                             )}
                         </div>
@@ -204,7 +206,7 @@ export function FileDirectory({
                             {filename}
                         </span>
                         <span className="shrink-0 text-gray-300">
-                            Uploading
+                            {t("uploading")}
                         </span>
                     </div>
                 ))}
@@ -251,7 +253,7 @@ export function FileDirectory({
                 {standaloneDocs.length > 0 && directoryProjects.length > 0 && (
                     <div className="border-t border-gray-100 py-2 px-2">
                         <p className="text-xs font-medium text-gray-400">
-                            Projects
+                            {t("projects")}
                         </p>
                     </div>
                 )}
@@ -289,7 +291,7 @@ export function FileDirectory({
                                 <div>
                                     {docs.length === 0 ? (
                                         <p className="pl-7 py-1 text-xs text-gray-400">
-                                            Empty
+                                            {t("emptyFolder")}
                                         </p>
                                     ) : (
                                         docs.map((doc) => {

--- a/frontend/src/app/components/shared/HeaderSearchBtn.tsx
+++ b/frontend/src/app/components/shared/HeaderSearchBtn.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { Search, X } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 interface Props {
     value: string;
@@ -9,7 +10,9 @@ interface Props {
     placeholder?: string;
 }
 
-export function HeaderSearchBtn({ value, onChange, placeholder = "Search…" }: Props) {
+export function HeaderSearchBtn({ value, onChange, placeholder }: Props) {
+    const t = useTranslations("Shared.HeaderSearchBtn");
+    const resolvedPlaceholder = placeholder ?? t("searchPlaceholder");
     const [open, setOpen] = useState(false);
     const ref = useRef<HTMLDivElement>(null);
 
@@ -32,7 +35,7 @@ export function HeaderSearchBtn({ value, onChange, placeholder = "Search…" }: 
                     <input
                         autoFocus
                         type="text"
-                        placeholder={placeholder}
+                        placeholder={resolvedPlaceholder}
                         value={value}
                         onChange={(e) => onChange(e.target.value)}
                         className="flex-1 text-sm text-gray-700 placeholder:text-gray-400 outline-none bg-transparent"

--- a/frontend/src/app/components/shared/LanguageSwitcher.tsx
+++ b/frontend/src/app/components/shared/LanguageSwitcher.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import { Check, ChevronDown, Globe } from "lucide-react";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { setLocale } from "@/i18n/actions";
+import { locales, localeLabels, type Locale } from "@/i18n/config";
+import { cn } from "@/lib/utils";
+
+/**
+ * Lets the user switch the UI language. Persists the choice via the `setLocale`
+ * server action (writes the `NEXT_LOCALE` cookie) and refreshes the router so
+ * server components re-render in the new locale.
+ */
+export function LanguageSwitcher() {
+    const t = useTranslations("LanguageSwitcher");
+    const activeLocale = useLocale() as Locale;
+    const router = useRouter();
+    const [isPending, startTransition] = useTransition();
+
+    const handleSelect = (next: string) => {
+        if (next === activeLocale) return;
+        startTransition(async () => {
+            await setLocale(next as Locale);
+            router.refresh();
+        });
+    };
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger
+                disabled={isPending}
+                aria-label={t("label")}
+                className={cn(
+                    "inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                )}
+            >
+                <Globe className="h-4 w-4 text-gray-500" />
+                {localeLabels[activeLocale]}
+                <ChevronDown className="h-4 w-4 text-gray-400" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="min-w-[10rem]">
+                <DropdownMenuRadioGroup
+                    value={activeLocale}
+                    onValueChange={handleSelect}
+                >
+                    {locales.map((locale) => (
+                        <DropdownMenuRadioItem key={locale} value={locale}>
+                            <span className="flex-1">
+                                {localeLabels[locale]}
+                            </span>
+                            {locale === activeLocale && (
+                                <Check className="h-4 w-4 text-gray-600" />
+                            )}
+                        </DropdownMenuRadioItem>
+                    ))}
+                </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/frontend/src/app/components/shared/OwnerOnlyModal.tsx
+++ b/frontend/src/app/components/shared/OwnerOnlyModal.tsx
@@ -2,6 +2,7 @@
 
 import { createPortal } from "react-dom";
 import { Lock, X } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 interface Props {
     open: boolean;
@@ -25,18 +26,21 @@ interface Props {
 export function OwnerOnlyModal({
     open,
     onClose,
-    title = "Owner-only action",
+    title,
     action,
     ownerEmail,
     message,
 }: Props) {
+    const t = useTranslations("Shared.OwnerOnlyModal");
+
     if (!open) return null;
 
+    const resolvedTitle = title ?? t("defaultTitle");
     const body =
         message ??
         (action
-            ? `Only the project owner can ${action}.`
-            : "Only the project owner can perform this action.");
+            ? t("bodyWithAction", { action })
+            : t("bodyDefault"));
 
     return createPortal(
         <div
@@ -52,7 +56,7 @@ export function OwnerOnlyModal({
                     <div className="flex items-center gap-2">
                         <Lock className="h-4 w-4 text-amber-600" />
                         <h2 className="text-base font-medium text-gray-900">
-                            {title}
+                            {resolvedTitle}
                         </h2>
                     </div>
                     <button
@@ -70,9 +74,10 @@ export function OwnerOnlyModal({
                     </p>
                     {ownerEmail && (
                         <p className="mt-2 text-xs text-gray-400">
-                            Ask{" "}
-                            <span className="text-gray-600">{ownerEmail}</span>{" "}
-                            if you need access.
+                            {t.rich("askOwner", {
+                                email: ownerEmail,
+                                em: (chunks) => <span className="text-gray-600">{chunks}</span>,
+                            })}
                         </p>
                     )}
                 </div>
@@ -83,7 +88,7 @@ export function OwnerOnlyModal({
                         onClick={onClose}
                         className="rounded-lg bg-gray-900 px-4 py-1.5 text-sm font-medium text-white hover:bg-gray-700"
                     >
-                        OK
+                        {t("ok")}
                     </button>
                 </div>
             </div>

--- a/frontend/src/app/components/shared/PeopleModal.tsx
+++ b/frontend/src/app/components/shared/PeopleModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { X, User, UserPlus, Loader2, Plus } from "lucide-react";
 import type { ProjectPeople } from "@/app/lib/mikeApi";
+import { useTranslations } from "next-intl";
 
 /**
  * Any resource the modal can manage members for — projects today, tabular
@@ -57,6 +58,7 @@ export function PeopleModal({
     breadcrumb,
     onSharedWithChange,
 }: Props) {
+    const t = useTranslations("Shared.PeopleModal");
     const [newEmail, setNewEmail] = useState("");
     const [busy, setBusy] = useState<"add" | "remove" | null>(null);
     const [removingEmail, setRemovingEmail] = useState<string | null>(null);
@@ -165,7 +167,7 @@ export function PeopleModal({
             setError(
                 e instanceof Error
                     ? e.message
-                    : "Couldn't add the member. Try again.",
+                    : t("errorAdd"),
             );
         } finally {
             setBusy(null);
@@ -186,7 +188,7 @@ export function PeopleModal({
             setError(
                 e instanceof Error
                     ? e.message
-                    : "Couldn't remove the member. Try again.",
+                    : t("errorRemove"),
             );
         } finally {
             setBusy(null);
@@ -223,7 +225,7 @@ export function PeopleModal({
                                 <UserPlus className="h-3.5 w-3.5 text-gray-400 shrink-0" />
                                 <input
                                     type="email"
-                                    placeholder="Add by email…"
+                                    placeholder={t("addByEmailPlaceholder")}
                                     value={newEmail}
                                     onChange={(e) =>
                                         setNewEmail(e.target.value)
@@ -238,7 +240,7 @@ export function PeopleModal({
                             <button
                                 onClick={() => void handleAdd()}
                                 disabled={!canAdd}
-                                title="Add member"
+                                title={t("addMemberTitle")}
                                 className="inline-flex items-center justify-center rounded-lg border border-gray-900 bg-gray-900 p-2 text-white hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                                 {busy === "add" ? (
@@ -250,17 +252,17 @@ export function PeopleModal({
                         </div>
                         {alreadyShared && trimmedNewEmail && (
                             <p className="mt-1.5 text-xs text-gray-400">
-                                {trimmedNewEmail} already has access.
+                                {t("hintAlreadyShared", { email: trimmedNewEmail })}
                             </p>
                         )}
                         {isOwnerEmail && trimmedNewEmail && (
                             <p className="mt-1.5 text-xs text-gray-400">
-                                {trimmedNewEmail} is the owner.
+                                {t("hintIsOwner", { email: trimmedNewEmail })}
                             </p>
                         )}
                         {isSelfEmail && !isOwnerEmail && trimmedNewEmail && (
                             <p className="mt-1.5 text-xs text-gray-400">
-                                You cannot share this with yourself.
+                                {t("hintSelf")}
                             </p>
                         )}
                         {trimmedNewEmail &&
@@ -269,7 +271,7 @@ export function PeopleModal({
                             !isOwnerEmail &&
                             !isSelfEmail && (
                                 <p className="mt-1.5 text-xs text-gray-400">
-                                    Enter a valid email.
+                                    {t("hintInvalidEmail")}
                                 </p>
                             )}
                         {error && (
@@ -283,7 +285,7 @@ export function PeopleModal({
                 {/* Section heading */}
                 <div className="px-4 pt-3 pb-1 flex items-center gap-2">
                     <h3 className="text-xs font-medium text-gray-500">
-                        People with Access
+                        {t("sectionHeading")}
                     </h3>
                     {peopleLoading && (
                         <Loader2 className="h-3 w-3 animate-spin text-gray-400" />
@@ -294,7 +296,7 @@ export function PeopleModal({
                 <div className="flex-1 overflow-y-auto px-4 pb-2">
                     {roster.length === 0 ? (
                         <div className="flex h-full items-center justify-center text-sm text-gray-400">
-                            No one has access yet.
+                            {t("emptyRoster")}
                         </div>
                     ) : (
                         <ul className="divide-y divide-gray-100 [&>li:nth-child(2)]:border-t-0">
@@ -324,12 +326,12 @@ export function PeopleModal({
                                                 {primary}
                                                 {isYou && (
                                                     <span className="ml-1.5 text-xs text-gray-400">
-                                                        (You)
+                                                        {t("tagYou")}
                                                     </span>
                                                 )}
                                                 {entry.role === "owner" && (
                                                     <span className="ml-1.5 text-[10px] text-gray-400">
-                                                        Owner
+                                                        {t("tagOwner")}
                                                     </span>
                                                 )}
                                             </p>
@@ -348,13 +350,13 @@ export function PeopleModal({
                                                         )
                                                     }
                                                     disabled={busy !== null}
-                                                    title="Remove access"
+                                                    title={t("removeAccessTitle")}
                                                     className="self-center inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-gray-500 hover:bg-red-50 hover:text-red-600 disabled:opacity-50"
                                                 >
                                                     {isRemoving && (
                                                         <Loader2 className="h-3 w-3 animate-spin" />
                                                     )}
-                                                    Remove
+                                                    {t("removeLabel")}
                                                 </button>
                                             )}
                                     </li>
@@ -367,10 +369,8 @@ export function PeopleModal({
                 {/* Footer */}
                 <div className="px-5 py-3 text-[11px] text-gray-400">
                     {roster.length === 0
-                        ? "No one has access yet."
-                        : `${roster.length} ${
-                              roster.length === 1 ? "person" : "people"
-                          } with access.`}
+                        ? t("emptyRoster")
+                        : t("footerCount", { count: roster.length })}
                 </div>
             </div>
         </div>,

--- a/frontend/src/app/components/shared/PreResponseWrapper.tsx
+++ b/frontend/src/app/components/shared/PreResponseWrapper.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { ChevronDown } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 export function PreResponseWrapper({
     children,
@@ -17,6 +18,7 @@ export function PreResponseWrapper({
     /** Tighter typography + child gap for narrow side panels (e.g. TR chat). */
     compact?: boolean;
 }) {
+    const t = useTranslations("Shared.PreResponseWrapper");
     const [userToggled, setUserToggled] = useState(false);
     const [isOpen, setIsOpen] = useState(!shouldMinimize);
     // Once content has streamed in (shouldMinimize=true even once), stay
@@ -31,10 +33,9 @@ export function PreResponseWrapper({
         setIsOpen(!shouldMinimize && !hasMinimizedRef.current);
     }, [shouldMinimize, userToggled]);
 
-    const stepWord = `step${stepCount === 1 ? "" : "s"}`;
     const label = isStreaming
-        ? "Working"
-        : `Completed in ${stepCount} ${stepWord}`;
+        ? t("working")
+        : t("completed", { count: stepCount });
 
     const buttonTextClass = compact ? "text-xs" : "text-sm";
     const childrenGapClass = compact ? "gap-2.5" : "gap-4";

--- a/frontend/src/app/components/shared/ProjectPicker.tsx
+++ b/frontend/src/app/components/shared/ProjectPicker.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Folder, Search, X } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { MikeProject } from "./types";
 
 interface Props {
@@ -12,6 +13,7 @@ interface Props {
 }
 
 export function ProjectPicker({ projects, loading, selectedId, onSelect }: Props) {
+    const t = useTranslations("Shared.ProjectPicker");
     const [search, setSearch] = useState("");
     const q = search.toLowerCase().trim();
     const filtered = q ? projects.filter((p) => p.name.toLowerCase().includes(q)) : projects;
@@ -23,7 +25,7 @@ export function ProjectPicker({ projects, loading, selectedId, onSelect }: Props
                     <Search className="h-3.5 w-3.5 text-gray-400 shrink-0" />
                     <input
                         type="text"
-                        placeholder="Search projects…"
+                        placeholder={t("searchPlaceholder")}
                         value={search}
                         onChange={(e) => setSearch(e.target.value)}
                         className="flex-1 bg-transparent text-sm text-gray-700 placeholder:text-gray-400 outline-none"
@@ -52,12 +54,12 @@ export function ProjectPicker({ projects, loading, selectedId, onSelect }: Props
                     </div>
                 ) : filtered.length === 0 ? (
                     <p className="text-center text-sm text-gray-400 py-8">
-                        {q ? "No matches found" : "No projects yet"}
+                        {q ? t("noMatchesFound") : t("noProjectsYet")}
                     </p>
                 ) : (
                     <div className="rounded-sm border border-gray-100 overflow-hidden">
                         <div className="flex items-center justify-between px-2 py-2">
-                            <p className="text-xs font-medium text-gray-400">Projects</p>
+                            <p className="text-xs font-medium text-gray-400">{t("projectsHeader")}</p>
                         </div>
                         <div className="space-y-px">
                             {filtered.map((project) => {

--- a/frontend/src/app/components/shared/RowActions.tsx
+++ b/frontend/src/app/components/shared/RowActions.tsx
@@ -13,6 +13,7 @@ import {
     Trash2,
     Upload,
 } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 const CLOSE_ROW_ACTIONS_EVENT = "mike:close-row-actions";
 
@@ -49,11 +50,15 @@ export function RowActionMenuItems({
     deleting,
     onRename,
     onUpdateCmNumber,
-    newSubfolderLabel = "New subfolder",
-    renameLabel = "Rename",
-    deleteLabel = "Delete",
+    newSubfolderLabel,
+    renameLabel,
+    deleteLabel,
     onClose,
 }: Props & { onClose: () => void }) {
+    const t = useTranslations("Shared.RowActions");
+    const resolvedNewSubfolderLabel = newSubfolderLabel ?? t("newSubfolder");
+    const resolvedRenameLabel = renameLabel ?? t("rename");
+    const resolvedDeleteLabel = deleteLabel ?? t("delete");
     return (
         <>
             {onNewSubfolder && (
@@ -62,7 +67,7 @@ export function RowActionMenuItems({
                     className="flex items-center gap-2 w-full px-3 py-2 text-xs text-left text-gray-600 hover:bg-gray-50 transition-colors"
                 >
                     <FolderPlus className="h-3.5 w-3.5 shrink-0" />
-                    {newSubfolderLabel}
+                    {resolvedNewSubfolderLabel}
                 </button>
             )}
             {onRename && (
@@ -71,7 +76,7 @@ export function RowActionMenuItems({
                     className="flex items-center gap-2 w-full px-3 py-2 text-xs text-gray-600 hover:bg-gray-50 transition-colors"
                 >
                     <Pencil className="h-3.5 w-3.5" />
-                    {renameLabel}
+                    {resolvedRenameLabel}
                 </button>
             )}
             {onUpdateCmNumber && (
@@ -80,7 +85,7 @@ export function RowActionMenuItems({
                     className="flex items-center gap-2 w-full px-3 py-2 text-xs text-gray-600 hover:bg-gray-50 transition-colors"
                 >
                     <Hash className="h-3.5 w-3.5" />
-                    Edit CM No.
+                    {t("editCmNo")}
                 </button>
             )}
             {onDownload && (
@@ -89,7 +94,7 @@ export function RowActionMenuItems({
                     className="flex items-center gap-2 w-full px-3 py-2 text-xs text-gray-600 hover:bg-gray-50 transition-colors"
                 >
                     <Download className="h-3.5 w-3.5" />
-                    Download
+                    {t("download")}
                 </button>
             )}
             {onShowAllVersions && (
@@ -98,7 +103,7 @@ export function RowActionMenuItems({
                     className="flex items-center gap-2 w-full px-3 py-2 text-xs text-left text-gray-600 hover:bg-gray-50 transition-colors"
                 >
                     <History className="h-3.5 w-3.5 shrink-0" />
-                    Show all versions
+                    {t("showAllVersions")}
                 </button>
             )}
             {onUploadNewVersion && (
@@ -107,7 +112,7 @@ export function RowActionMenuItems({
                     className="flex items-center gap-2 w-full px-3 py-2 text-xs text-left text-gray-600 hover:bg-gray-50 transition-colors"
                 >
                     <Upload className="h-3.5 w-3.5 shrink-0" />
-                    Upload new version
+                    {t("uploadNewVersion")}
                 </button>
             )}
             {onRemoveFromFolder && (
@@ -116,7 +121,7 @@ export function RowActionMenuItems({
                     className="flex items-center gap-2 w-full px-3 py-2 text-xs text-left text-gray-600 hover:bg-gray-50 transition-colors"
                 >
                     <FolderMinus className="h-3.5 w-3.5 shrink-0" />
-                    Remove from subfolder
+                    {t("removeFromSubfolder")}
                 </button>
             )}
             {onUnhide && (
@@ -125,7 +130,7 @@ export function RowActionMenuItems({
                     className="flex items-center gap-2 w-full px-3 py-2 text-xs text-gray-600 hover:bg-gray-50 transition-colors"
                 >
                     <Eye className="h-3.5 w-3.5" />
-                    Unhide
+                    {t("unhide")}
                 </button>
             )}
             {onHide && (
@@ -134,7 +139,7 @@ export function RowActionMenuItems({
                     className="flex items-center gap-2 w-full px-3 py-2 text-xs text-gray-600 hover:bg-gray-50 transition-colors"
                 >
                     <EyeOff className="h-3.5 w-3.5" />
-                    Hide
+                    {t("hide")}
                 </button>
             )}
             {onDelete && (
@@ -144,7 +149,7 @@ export function RowActionMenuItems({
                     className="flex items-center gap-2 w-full px-3 py-2 text-xs text-red-500 hover:bg-red-50 transition-colors disabled:opacity-40"
                 >
                     <Trash2 className="h-3.5 w-3.5" />
-                    {deleteLabel}
+                    {resolvedDeleteLabel}
                 </button>
             )}
         </>

--- a/frontend/src/app/components/shared/SidebarChatItem.tsx
+++ b/frontend/src/app/components/shared/SidebarChatItem.tsx
@@ -8,6 +8,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useTranslations } from "next-intl";
 import { useChatHistoryContext } from "@/app/contexts/ChatHistoryContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { OwnerOnlyModal } from "@/app/components/shared/OwnerOnlyModal";
@@ -21,6 +22,7 @@ interface Props {
 }
 
 export function SidebarChatItem({ chat, isActive, onSelect, projectName }: Props) {
+    const t = useTranslations("Shared.SidebarChatItem");
     const { renameChat, deleteChat } = useChatHistoryContext();
     const { user } = useAuth();
     const [isRenaming, setIsRenaming] = useState(false);
@@ -93,12 +95,12 @@ export function SidebarChatItem({ chat, isActive, onSelect, projectName }: Props
                         className={`flex-1 min-w-0 text-left px-3 py-2 text-xs overflow-x-hidden whitespace-nowrap scrollbar-none ${
                             isActive ? "text-gray-900" : "text-gray-700"
                         }`}
-                        title={projectName ? `${projectName}: ${chat.title ?? "Untitled chat"}` : (chat.title ?? "Untitled chat")}
+                        title={projectName ? `${projectName}: ${chat.title ?? t("untitledChat")}` : (chat.title ?? t("untitledChat"))}
                     >
                         {projectName && (
                             <span className="text-gray-400 font-normal">{projectName}: </span>
                         )}
-                        {chat.title ?? "Untitled chat"}
+                        {chat.title ?? t("untitledChat")}
                     </button>
 
                     <DropdownMenu>
@@ -125,7 +127,7 @@ export function SidebarChatItem({ chat, isActive, onSelect, projectName }: Props
                                 }}
                             >
                                 <Pencil className="mr-2 h-4 w-4" />
-                                Rename
+                                {t("rename")}
                             </DropdownMenuItem>
                             <DropdownMenuItem
                                 onClick={() => {
@@ -138,7 +140,7 @@ export function SidebarChatItem({ chat, isActive, onSelect, projectName }: Props
                                 className="text-red-600 focus:text-red-600"
                             >
                                 <Trash2 className="mr-2 h-4 w-4" />
-                                Delete
+                                {t("delete")}
                             </DropdownMenuItem>
                         </DropdownMenuContent>
                     </DropdownMenu>

--- a/frontend/src/app/components/shared/UploadNewVersionModal.tsx
+++ b/frontend/src/app/components/shared/UploadNewVersionModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { X, Upload } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { listDocumentVersions } from "@/app/lib/mikeApi";
 import type { MikeDocument } from "./types";
 
@@ -14,6 +15,7 @@ interface Props {
 }
 
 export function UploadNewVersionModal({ open, onClose, doc, onSubmit }: Props) {
+    const t = useTranslations("Documents.UploadNewVersionModal");
     const [name, setName] = useState("");
     const [stagedFile, setStagedFile] = useState<File | null>(null);
     const [submitting, setSubmitting] = useState(false);
@@ -78,7 +80,7 @@ export function UploadNewVersionModal({ open, onClose, doc, onSubmit }: Props) {
                 {/* Header */}
                 <div className="flex items-center justify-between px-5 py-4">
                     <div className="text-xs text-gray-400">
-                        Upload new version · {doc.filename}
+                        {t("headerTitle", { filename: doc.filename })}
                     </div>
                     <button
                         onClick={onClose}
@@ -91,24 +93,24 @@ export function UploadNewVersionModal({ open, onClose, doc, onSubmit }: Props) {
                 {/* Name input */}
                 <div className="px-5 pb-4">
                     <label className="block text-xs font-medium text-gray-500 mb-1">
-                        New version name
+                        {t("newVersionName")}
                     </label>
                     <input
                         type="text"
                         value={name}
                         onChange={(e) => setName(e.target.value)}
-                        placeholder="Version name"
+                        placeholder={t("versionNamePlaceholder")}
                         className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-gray-400"
                     />
                     <div className="mt-2 text-xs text-gray-500">
-                        Current Version:{" "}
+                        {t("currentVersion")}{" "}
                         <span className="text-gray-700 font-medium">
                             {currentVersion ?? "—"}
                         </span>
                     </div>
                     {stagedFile && (
                         <div className="mt-2 text-xs text-gray-500 truncate">
-                            New Version File:{" "}
+                            {t("newVersionFile")}{" "}
                             <span className="text-gray-700">
                                 {stagedFile.name}
                             </span>
@@ -132,7 +134,7 @@ export function UploadNewVersionModal({ open, onClose, doc, onSubmit }: Props) {
                             className="flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-50"
                         >
                             <Upload className="h-3.5 w-3.5" />
-                            {stagedFile ? "Change file" : "Upload"}
+                            {stagedFile ? t("changeFile") : t("upload")}
                         </button>
                     </div>
                     <div className="flex items-center gap-2">
@@ -140,14 +142,14 @@ export function UploadNewVersionModal({ open, onClose, doc, onSubmit }: Props) {
                             onClick={onClose}
                             className="rounded-lg px-3 py-1.5 text-sm text-gray-500 hover:bg-gray-100"
                         >
-                            Cancel
+                            {t("cancel")}
                         </button>
                         <button
                             onClick={handleSubmit}
                             disabled={!stagedFile || submitting}
                             className="rounded-lg bg-gray-900 px-4 py-1.5 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-40"
                         >
-                            {submitting ? "Saving…" : "Save"}
+                            {submitting ? t("saving") : t("save")}
                         </button>
                     </div>
                 </div>

--- a/frontend/src/app/components/tabular/AddColumnModal.tsx
+++ b/frontend/src/app/components/tabular/AddColumnModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { ChevronDown, Plus, X } from "lucide-react";
@@ -43,6 +44,7 @@ interface Props {
 }
 
 export function AddColumnModal({ open, existingCount, onClose, onAdd, editingColumn, onSave, onDelete }: Props) {
+    const t = useTranslations("Tabular.AddColumnModal");
     const isEditing = !!editingColumn;
     const [columns, setColumns] = useState<ColumnDraft[]>([{ ...EMPTY_DRAFT }]);
     const [generatingIndices, setGeneratingIndices] = useState<number[]>([]);
@@ -196,9 +198,9 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                 {/* Header */}
                 <div className="flex items-center justify-between px-6 pt-5 pb-2">
                     <div className="flex items-center gap-1.5 text-xs text-gray-400">
-                        <span>Tabular Review</span>
+                        <span>{t("breadcrumbRoot")}</span>
                         <span>›</span>
-                        <span>{isEditing ? "Edit column" : "New column"}</span>
+                        <span>{isEditing ? t("editColumn") : t("newColumn")}</span>
                     </div>
                     <button
                         onClick={handleClose}
@@ -251,7 +253,7 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                                                         : {}),
                                                 });
                                             }}
-                                            placeholder="Column name"
+                                            placeholder={t("columnNamePlaceholder")}
                                             className="flex-1 text-2xl font-serif text-gray-800 placeholder-gray-400 focus:outline-none bg-transparent"
                                             autoFocus={index === 0}
                                         />
@@ -264,7 +266,7 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                                                         : index,
                                                 )
                                             }
-                                            title="Column presets"
+                                            title={t("columnPresetsTitle")}
                                             className="mt-1.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
                                         >
                                             <ChevronDown
@@ -281,7 +283,7 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                                                     }}
                                                     className="w-full px-3 py-2 text-left text-sm text-gray-400 hover:bg-gray-50 transition-colors border-b border-gray-100"
                                                 >
-                                                    No Preset
+                                                    {t("noPreset")}
                                                 </button>
                                                 {PROMPT_PRESETS.map(
                                                     (preset) => (
@@ -329,7 +331,7 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                                 {/* Format */}
                                 <div className="mt-4">
                                     <label className="text-sm font-medium text-gray-500">
-                                        Format
+                                        {t("formatLabel")}
                                     </label>
                                     <DropdownMenu>
                                         <DropdownMenuTrigger asChild>
@@ -380,7 +382,7 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                                 {column.format === "tag" && (
                                     <div className="mt-3">
                                         <label className="text-sm font-medium text-gray-500">
-                                            Tags
+                                            {t("tagsLabel")}
                                         </label>
                                         <div className="mt-1 flex flex-wrap gap-1.5 rounded-md border border-gray-200 px-2 py-1.5 focus-within:border-gray-400">
                                             {column.tags.map((tag, tagIdx) => (
@@ -422,12 +424,12 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                                                     handleTagKeyDown(e, index)
                                                 }
                                                 onBlur={() => commitTag(index)}
-                                                placeholder="Add tag…"
+                                                placeholder={t("addTagPlaceholder")}
                                                 className="min-w-[80px] flex-1 bg-transparent text-sm text-gray-700 placeholder-gray-400 focus:outline-none"
                                             />
                                         </div>
                                         <p className="mt-1 text-xs text-gray-400">
-                                            Press Enter or comma to add a tag.
+                                            {t("tagHint")}
                                         </p>
                                     </div>
                                 )}
@@ -435,7 +437,7 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                                 {/* Prompt */}
                                 <div className="mt-4 flex items-center justify-between">
                                     <label className="text-sm font-medium text-gray-500">
-                                        Prompt
+                                        {t("promptLabel")}
                                     </label>
                                     <button
                                         type="button"
@@ -453,7 +455,7 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                                         ) : (
                                             <Plus className="h-4 w-4" />
                                         )}
-                                        Auto-Generate Prompt
+                                        {t("autoGeneratePrompt")}
                                     </button>
                                 </div>
                                 <textarea
@@ -464,7 +466,7 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                                             prompt: e.target.value,
                                         })
                                     }
-                                    placeholder="Write the analysis prompt — describe what Mike should extract from each document for this column…"
+                                    placeholder={t("promptPlaceholder")}
                                     className="mt-2 w-full rounded-md border border-gray-200 px-3 py-2 text-sm text-gray-700 placeholder-gray-400 focus:border-gray-400 focus:outline-none bg-transparent resize-none leading-relaxed"
                                 />
                             </div>
@@ -477,7 +479,7 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                                 className="inline-flex items-center gap-1.5 text-sm text-gray-500 transition-colors hover:text-gray-900"
                             >
                                 <Plus className="h-4 w-4" />
-                                Add another column
+                                {t("addAnotherColumn")}
                             </button>
                         )}
                     </div>
@@ -491,7 +493,7 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                                     onClick={onDelete}
                                     className="rounded-lg px-4 py-2 text-sm text-red-500 hover:bg-red-50 transition-colors"
                                 >
-                                    Delete
+                                    {t("delete")}
                                 </button>
                             )}
                         </div>
@@ -501,7 +503,7 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                                 onClick={handleClose}
                                 className="rounded-lg px-4 py-2 text-sm text-gray-500 hover:bg-gray-100 transition-colors"
                             >
-                                Cancel
+                                {t("cancel")}
                             </button>
                             <button
                                 type="submit"
@@ -510,7 +512,7 @@ export function AddColumnModal({ open, existingCount, onClose, onAdd, editingCol
                                 )}
                                 className="rounded-lg bg-gray-900 px-5 py-2 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-40 transition-colors"
                             >
-                                {isEditing ? "Save changes" : "Add columns"}
+                                {isEditing ? t("saveChanges") : t("addColumns")}
                             </button>
                         </div>
                     </div>

--- a/frontend/src/app/components/tabular/AddNewTRModal.tsx
+++ b/frontend/src/app/components/tabular/AddNewTRModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Check, ChevronDown, Loader2, Upload, X } from "lucide-react";
@@ -40,6 +41,7 @@ export function AddNewTRModal({
     projectName,
     projectCmNumber,
 }: Props) {
+    const t = useTranslations("Tabular.AddNewTRModal");
     const isProjectMode = fixedProjectDocs !== undefined;
     const [title, setTitle] = useState("");
     const [underProject, setUnderProject] = useState(false);
@@ -222,22 +224,22 @@ export function AddNewTRModal({
                     <div className="flex items-center gap-1.5 text-xs text-gray-400">
                         {isProjectMode && projectName ? (
                             <>
-                                <span>Projects</span>
+                                <span>{t("breadcrumbProjects")}</span>
                                 <span>›</span>
                                 <span>
                                     {projectName}
                                     {projectCmNumber ? ` (#${projectCmNumber})` : ""}
                                 </span>
                                 <span>›</span>
-                                <span>Tabular Reviews</span>
+                                <span>{t("breadcrumbTabularReviews")}</span>
                                 <span>›</span>
-                                <span>New review</span>
+                                <span>{t("breadcrumbNewReview")}</span>
                             </>
                         ) : (
                             <>
-                                <span>Tabular Reviews</span>
+                                <span>{t("breadcrumbTabularReviews")}</span>
                                 <span>›</span>
-                                <span>New review</span>
+                                <span>{t("breadcrumbNewReview")}</span>
                             </>
                         )}
                     </div>
@@ -259,7 +261,7 @@ export function AddNewTRModal({
                             type="text"
                             value={title}
                             onChange={(e) => setTitle(e.target.value)}
-                            placeholder="Review name"
+                            placeholder={t("reviewNamePlaceholder")}
                             className="w-full text-2xl font-serif text-gray-800 placeholder-gray-400 focus:outline-none bg-transparent"
                             autoFocus
                         />
@@ -267,7 +269,7 @@ export function AddNewTRModal({
                         {/* Workflow template */}
                         <div className="space-y-2">
                             <p className="text-xs font-medium text-gray-700">
-                                Workflow Template
+                                {t("workflowTemplateLabel")}
                             </p>
                             <div className="relative">
                                 <button
@@ -290,10 +292,10 @@ export function AddNewTRModal({
                                             }
                                         >
                                             {loadingWorkflows
-                                                ? "Loading templates…"
+                                                ? t("loadingTemplates")
                                                 : selectedWorkflow
                                                   ? selectedWorkflow.title
-                                                  : "No template — start from scratch"}
+                                                  : t("noTemplate")}
                                         </span>
                                     </div>
                                     <ChevronDown className="h-3.5 w-3.5 text-gray-400 shrink-0 ml-2" />
@@ -309,7 +311,7 @@ export function AddNewTRModal({
                                             className={`w-full text-left flex items-center gap-2 px-3 py-2 text-sm transition-colors hover:bg-gray-50 ${!selectedWorkflowId ? "bg-gray-50 text-gray-900" : "text-gray-500"}`}
                                         >
                                             <span className="flex-1">
-                                                No template — start from scratch
+                                                {t("noTemplate")}
                                             </span>
                                             {!selectedWorkflowId && (
                                                 <Check className="h-3.5 w-3.5 text-gray-500 shrink-0" />
@@ -370,7 +372,7 @@ export function AddNewTRModal({
                                     />
                                 </span>
                                 <span className="text-sm text-gray-600">
-                                    Create under a project
+                                    {t("createUnderProject")}
                                 </span>
                             </button>
 
@@ -395,7 +397,7 @@ export function AddNewTRModal({
                                                   (selectedProject.cm_number
                                                       ? ` (#${selectedProject.cm_number})`
                                                       : "")
-                                                : "Select project…"}
+                                                : t("selectProject")}
                                         </span>
                                         <ChevronDown className="h-3.5 w-3.5 text-gray-400 shrink-0" />
                                     </button>
@@ -403,7 +405,7 @@ export function AddNewTRModal({
                                         <div className="absolute left-0 top-full z-20 mt-1 w-full rounded-xl border border-gray-100 bg-white shadow-lg overflow-y-auto max-h-48">
                                             {projects.length === 0 ? (
                                                 <p className="px-3 py-2 text-xs text-gray-400">
-                                                    No projects found
+                                                    {t("noProjectsFound")}
                                                 </p>
                                             ) : (
                                                 projects.map((p) => (
@@ -446,7 +448,7 @@ export function AddNewTRModal({
                         {showDirectory && (
                             <div className="space-y-2">
                                 <p className="text-xs font-medium text-gray-700">
-                                    Select Documents
+                                    {t("selectDocumentsLabel")}
                                 </p>
                                 <div>
                                     <FileDirectory
@@ -467,11 +469,11 @@ export function AddNewTRModal({
                                         loading={directoryLoading}
                                         selectedIds={selectedDocIds}
                                         onChange={setSelectedDocIds}
-                                        heading={isProjectMode ? "Project Documents" : "Documents"}
+                                        heading={isProjectMode ? t("projectDocumentsHeading") : t("documentsHeading")}
                                         emptyMessage={
                                             isProjectMode || underProject
-                                                ? "No ready documents in this project"
-                                                : "No documents yet"
+                                                ? t("noReadyDocuments")
+                                                : t("noDocumentsYet")
                                         }
                                     />
                                 </div>
@@ -501,7 +503,7 @@ export function AddNewTRModal({
                                 ) : (
                                     <Upload className="h-3.5 w-3.5" />
                                 )}
-                                {uploading ? "Uploading…" : "Upload"}
+                                {uploading ? t("uploading") : t("upload")}
                             </button>
                         </div>
                         <div className="flex items-center gap-2">
@@ -510,7 +512,7 @@ export function AddNewTRModal({
                                 onClick={handleClose}
                                 className="rounded-lg px-4 py-2 text-sm text-gray-500 hover:bg-gray-100 transition-colors"
                             >
-                                Cancel
+                                {t("cancel")}
                             </button>
                             <button
                                 type="submit"
@@ -520,7 +522,7 @@ export function AddNewTRModal({
                                 }
                                 className="rounded-lg bg-gray-900 px-5 py-2 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-40 transition-colors"
                             >
-                                Create
+                                {t("create")}
                             </button>
                         </div>
                     </div>

--- a/frontend/src/app/components/tabular/TRChatPanel.tsx
+++ b/frontend/src/app/components/tabular/TRChatPanel.tsx
@@ -38,6 +38,7 @@ import {
     type ModelProvider,
 } from "@/app/lib/modelAvailability";
 import type { ApiKeyState } from "@/app/lib/mikeApi";
+import { useTranslations } from "next-intl";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -67,12 +68,13 @@ interface Props {
 // Reasoning block
 // ---------------------------------------------------------------------------
 
-const THINKING_PHRASES = [
-    "Thinking...",
-    "Pondering...",
-    "Analyzing...",
-    "Reasoning...",
-];
+// Thinking phrases are looked up via translation keys at render time.
+const THINKING_PHRASE_KEYS = [
+    "thinkingPhrase0",
+    "thinkingPhrase1",
+    "thinkingPhrase2",
+    "thinkingPhrase3",
+] as const;
 
 function ReasoningBlock({
     text,
@@ -81,13 +83,14 @@ function ReasoningBlock({
     text: string;
     isStreaming: boolean;
 }) {
+    const t = useTranslations("Tabular.TRChatPanel");
     const [isOpen, setIsOpen] = useState(false);
     const [phraseIdx, setPhraseIdx] = useState(0);
 
     useEffect(() => {
         if (!isStreaming) return;
         const interval = setInterval(
-            () => setPhraseIdx((i) => (i + 1) % THINKING_PHRASES.length),
+            () => setPhraseIdx((i) => (i + 1) % THINKING_PHRASE_KEYS.length),
             2000,
         );
         return () => clearInterval(interval);
@@ -106,8 +109,8 @@ function ReasoningBlock({
                 )}
                 <span className="font-medium ml-2">
                     {isStreaming
-                        ? THINKING_PHRASES[phraseIdx]
-                        : "Thought process"}
+                        ? t(THINKING_PHRASE_KEYS[phraseIdx])
+                        : t("thoughtProcess")}
                 </span>
                 {!isStreaming && (
                     <ChevronDown
@@ -138,6 +141,7 @@ function DocReadBlock({
     label: string;
     isStreaming?: boolean;
 }) {
+    const t = useTranslations("Tabular.TRChatPanel");
     return (
         <div className="flex items-center text-sm text-gray-400 ml-1">
             {isStreaming ? (
@@ -146,7 +150,7 @@ function DocReadBlock({
                 <div className="w-1.5 h-1.5 rounded-full bg-green-400 shrink-0" />
             )}
             <span className="font-medium ml-2">
-                {isStreaming ? "Reading" : "Read"}
+                {isStreaming ? t("reading") : t("read")}
             </span>
             <span className="ml-1 text-gray-500">{label}</span>
         </div>
@@ -232,6 +236,7 @@ function TRAssistantMessage({
     msg: TRMessage;
     onCitationClick: (colIdx: number, rowIdx: number) => void;
 }) {
+    const t = useTranslations("Tabular.TRChatPanel");
     const annotations = msg.annotations ?? [];
     const citationsList: TRCitationAnnotation[] = [];
 
@@ -300,7 +305,7 @@ function TRAssistantMessage({
                     className="flex items-center text-sm text-gray-400 ml-1"
                 >
                     <div className="w-1.5 h-1.5 rounded-full border border-gray-400 border-t-transparent animate-spin shrink-0" />
-                    <span className="ml-2">Thinking...</span>
+                    <span className="ml-2">{t("thinkingPhrase0")}</span>
                 </div>
             );
         }
@@ -458,6 +463,7 @@ function TRChatInput({
     apiKeys?: ApiKeyState;
     onHeightChange: (height: number) => void;
 }) {
+    const t = useTranslations("Tabular.TRChatPanel");
     const [value, setValue] = useState("");
     const rootRef = useRef<HTMLDivElement>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -513,7 +519,7 @@ function TRChatInput({
                 <textarea
                     ref={textareaRef}
                     rows={1}
-                    placeholder="Ask a question about your documents..."
+                    placeholder={t("chatInputPlaceholder")}
                     value={value}
                     onChange={(e) => {
                         setValue(e.target.value);
@@ -568,6 +574,7 @@ function HistoryDropdown({
     currentChatId: string | null;
     onLoad: (chatId: string) => void;
 }) {
+    const t = useTranslations("Tabular.TRChatPanel");
     const [query, setQuery] = useState("");
     const filtered = chats
         .filter((c) => c.id !== currentChatId)
@@ -583,7 +590,7 @@ function HistoryDropdown({
                 <input
                     autoFocus
                     type="text"
-                    placeholder="Search chats…"
+                    placeholder={t("searchChatsPlaceholder")}
                     value={query}
                     onChange={(e) => setQuery(e.target.value)}
                     className="flex-1 text-xs bg-transparent outline-none placeholder:text-gray-400 text-gray-700"
@@ -594,8 +601,8 @@ function HistoryDropdown({
                     <p className="px-3 py-2 text-xs text-gray-400">
                         {chats.filter((c) => c.id !== currentChatId).length ===
                         0
-                            ? "No previous chats."
-                            : "No matches."}
+                            ? t("noPreviousChats")
+                            : t("noMatches")}
                     </p>
                 ) : (
                     filtered.map((chat) => {
@@ -642,6 +649,7 @@ export function TRChatPanel({
     initialChatId,
     onChatIdChange,
 }: Props) {
+    const t = useTranslations("Tabular.TRChatPanel");
     const { profile, updateModelPreference } = useUserProfile();
     const apiKeys = profile?.apiKeys;
     const currentModel = profile?.tabularModel ?? "gemini-3-flash-preview";
@@ -1308,7 +1316,7 @@ export function TRChatPanel({
                                     type: "content" as const,
                                     text: isAbort
                                         ? ""
-                                        : "An error occurred. Please try again.",
+                                        : t("errorOccurred"),
                                 },
                             ],
                         };
@@ -1374,7 +1382,7 @@ export function TRChatPanel({
                         className="min-w-0 overflow-x-hidden whitespace-nowrap scrollbar-none"
                     >
                         <span className="text-xs font-medium text-gray-700">
-                            {currentChatTitle ?? "Assistant"}
+                            {currentChatTitle ?? t("assistantTitle")}
                         </span>
                     </div>
                 </div>
@@ -1382,7 +1390,7 @@ export function TRChatPanel({
                     <div ref={historyRef} className="relative">
                         <button
                             onClick={() => setHistoryOpen((v) => !v)}
-                            title="Chat history"
+                            title={t("chatHistoryTitle")}
                             className={`flex items-center justify-center h-7 w-7 rounded-md transition-colors ${historyOpen ? "text-gray-900" : "text-gray-400 hover:text-gray-700"}`}
                         >
                             <Clock className="h-3.5 w-3.5" />
@@ -1399,7 +1407,7 @@ export function TRChatPanel({
                     </div>
                     <button
                         onClick={handleNewChat}
-                        title="New chat"
+                        title={t("newChatTitle")}
                         className="flex items-center justify-center h-7 w-7 rounded-md text-gray-400 hover:text-gray-700 transition-colors"
                     >
                         <MessageSquarePlus className="h-3.5 w-3.5" />
@@ -1407,7 +1415,7 @@ export function TRChatPanel({
                     {currentChatId && (
                         <button
                             onClick={handleDeleteChat}
-                            title="Delete chat"
+                            title={t("deleteChatTitle")}
                             className="flex items-center justify-center h-7 w-7 rounded-md text-gray-400 hover:text-red-600 transition-colors"
                         >
                             <Trash2 className="h-3.5 w-3.5" />
@@ -1415,7 +1423,7 @@ export function TRChatPanel({
                     )}
                     <button
                         onClick={onClose}
-                        title="Close"
+                        title={t("closeTitle")}
                         className="flex items-center justify-center h-7 w-7 rounded-md text-gray-400 hover:text-gray-700 transition-colors"
                     >
                         <X className="h-3.5 w-3.5" />
@@ -1433,7 +1441,7 @@ export function TRChatPanel({
                     <div className="flex flex-1 flex-col items-center justify-center gap-2">
                         <MikeIcon size={24} />
                         <p className="text-sm text-gray-400 text-center">
-                            Ask a question about this tabular review.
+                            {t("emptyState")}
                         </p>
                     </div>
                 )}

--- a/frontend/src/app/components/tabular/TREditColumnMenu.tsx
+++ b/frontend/src/app/components/tabular/TREditColumnMenu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { ChevronDown, Loader2, MoreHorizontal, Plus, Trash2, X } from "lucide-react";
 import type { ColumnConfig, ColumnFormat } from "../shared/types";
@@ -27,6 +28,7 @@ export function TREditColumnMenu({
     onSave,
     onDelete,
 }: TREditColumnMenuProps) {
+    const t = useTranslations("Tabular.TREditColumnMenu");
     const [open, setOpen] = useState(false);
     const [name, setName] = useState(column.name);
     const [prompt, setPrompt] = useState(column.prompt);
@@ -136,7 +138,7 @@ export function TREditColumnMenu({
                 >
                     <div className="flex items-center justify-between mb-3">
                         <p className="text-sm font-medium text-gray-800">
-                            Edit Column
+                            {t("editColumn")}
                         </p>
                         <button
                             type="button"
@@ -147,7 +149,7 @@ export function TREditColumnMenu({
                         </button>
                     </div>
                     <label className="text-xs font-medium text-gray-800">
-                        Label
+                        {t("labelField")}
                     </label>
                     <input
                         type="text"
@@ -159,7 +161,7 @@ export function TREditColumnMenu({
                     {/* Format */}
                     <div className="mt-3">
                         <label className="text-xs font-medium text-gray-800">
-                            Format
+                            {t("formatLabel")}
                         </label>
                         <DropdownMenu>
                             <DropdownMenuTrigger asChild>
@@ -239,7 +241,7 @@ export function TREditColumnMenu({
                                     onKeyDown={handleTagKeyDown}
                                     onBlur={commitTag}
                                     placeholder={
-                                        tags.length === 0 ? "Add tags…" : ""
+                                        tags.length === 0 ? t("addTagsPlaceholder") : ""
                                     }
                                     className="min-w-[60px] flex-1 bg-transparent text-xs text-gray-700 placeholder-gray-300 focus:outline-none"
                                 />
@@ -251,7 +253,7 @@ export function TREditColumnMenu({
                     <div className="mt-3">
                         <div className="flex items-center justify-between">
                             <label className="text-xs font-medium text-gray-800">
-                                Prompt
+                                {t("promptLabel")}
                             </label>
                             <button
                                 type="button"
@@ -264,7 +266,7 @@ export function TREditColumnMenu({
                                 ) : (
                                     <Plus className="h-3 w-3" />
                                 )}
-                                Auto-generate
+                                {t("autoGenerate")}
                             </button>
                         </div>
                         <textarea
@@ -283,7 +285,7 @@ export function TREditColumnMenu({
                             className="inline-flex items-center gap-1.5 text-xs text-red-500 transition-colors hover:text-red-600 disabled:text-red-300"
                         >
                             <Trash2 className="h-3.5 w-3.5" />
-                            Delete
+                            {t("delete")}
                         </button>
                         <button
                             type="button"
@@ -297,7 +299,7 @@ export function TREditColumnMenu({
                             }
                             className="rounded-full bg-gray-900 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-gray-700 disabled:opacity-40"
                         >
-                            {saving ? "Saving…" : "Save"}
+                            {saving ? t("saving") : t("save")}
                         </button>
                     </div>
                 </div>

--- a/frontend/src/app/components/tabular/TRSidePanel.tsx
+++ b/frontend/src/app/components/tabular/TRSidePanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 
 import ReactMarkdown from "react-markdown";
@@ -67,6 +68,7 @@ export function TRSidePanel({
     citationQuote,
     citationPage,
 }: Props) {
+    const t = useTranslations("Tabular.TRSidePanel");
     const sortedColumns = [...columns].sort((a, b) => a.index - b.index);
     const currentPos = sortedColumns.findIndex((c) => c.index === column.index);
     const prevColumn = currentPos > 0 ? sortedColumns[currentPos - 1] : null;
@@ -261,7 +263,7 @@ export function TRSidePanel({
                         {cell.content?.flag && (
                             <div className="mb-5">
                                 <h4 className="mb-2 text-sm font-semibold tracking-wider font-sans">
-                                    Flag
+                                    {t("flagHeading")}
                                 </h4>
                                 <span
                                     className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${FLAG_BADGE[cell.content.flag] ?? FLAG_BADGE.grey}`}
@@ -275,7 +277,7 @@ export function TRSidePanel({
                         {/* Results */}
                         <div className="mb-6">
                             <h4 className="mb-2 text-sm font-semibold tracking-wider font-sans">
-                                Results
+                                {t("resultsHeading")}
                             </h4>
                             <div className="text-xs leading-relaxed text-slate-600">
                                 <MarkdownContent
@@ -292,7 +294,7 @@ export function TRSidePanel({
                         {cell.content?.reasoning && (
                             <div>
                                 <h4 className="mb-2 text-sm font-semibold tracking-wider font-sans">
-                                    Reasoning
+                                    {t("reasoningHeading")}
                                 </h4>
                                 <div className="text-xs leading-relaxed text-slate-600">
                                     <MarkdownContent

--- a/frontend/src/app/components/tabular/TRTable.tsx
+++ b/frontend/src/app/components/tabular/TRTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { forwardRef, useImperativeHandle, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { Loader2, Plus, Table2, Upload } from "lucide-react";
 import type { ColumnConfig, MikeDocument, TabularCell } from "../shared/types";
 import { TabularCell as TabularCellComponent } from "./TabularCell";
@@ -64,6 +65,7 @@ export const TRTable = forwardRef<TRTableHandle, Props>(function TRTable(
     },
     ref,
 ) {
+    const t = useTranslations("Tabular.TRTable");
     const scrollContainerRef = useRef<HTMLDivElement>(null);
     const sortedColumns = [...columns].sort((a, b) => a.index - b.index);
     const totalContentWidth =
@@ -135,7 +137,7 @@ export const TRTable = forwardRef<TRTableHandle, Props>(function TRTable(
                     <div
                         className={`${COL_W} border-r border-gray-200 p-2 text-xs font-medium text-gray-500`}
                     >
-                        Document
+                        {t("documentColumn")}
                     </div>
                     {Array.from({ length: SKELETON_COLS }).map((_, i) => (
                         <div
@@ -181,7 +183,7 @@ export const TRTable = forwardRef<TRTableHandle, Props>(function TRTable(
                     <div
                         className={`${COL_W} border-r border-gray-200 p-2 text-xs font-medium text-gray-500 select-none`}
                     >
-                        Document
+                        {t("documentColumn")}
                     </div>
                     <div className="flex-1" />
                 </div>
@@ -192,24 +194,24 @@ export const TRTable = forwardRef<TRTableHandle, Props>(function TRTable(
                     <div className="flex flex-1 flex-col items-start justify-center w-full max-w-xs mx-auto">
                         <Table2 className="h-8 w-8 text-gray-300 mb-4" />
                         <p className="text-2xl font-medium font-serif text-gray-900">
-                            Tabular Review
+                            {t("emptyTitle")}
                         </p>
                         <p className="mt-1 text-xs text-gray-400 text-left">
-                            Add columns and documents to get started.
+                            {t("emptySubtitle")}
                         </p>
                         <div className="mt-4 flex items-center gap-2">
                             <button
                                 onClick={onAddColumn}
                                 className="inline-flex items-center gap-1 rounded-full bg-gray-900 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-gray-700 shadow-md"
                             >
-                                + Add Columns
+                                {t("addColumns")}
                             </button>
                             <button
                                 onClick={onAddDocuments}
                                 className="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors shadow-sm"
                             >
                                 <Upload className="h-3.5 w-3.5" />
-                                Add Documents
+                                {t("addDocuments")}
                             </button>
                         </div>
                     </div>

--- a/frontend/src/app/components/tabular/TabularCell.tsx
+++ b/frontend/src/app/components/tabular/TabularCell.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { AlertCircle, Expand } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ColumnConfig, TabularCell as TCell } from "../shared/types";
 import { preprocessCitations, type ParsedCitation } from "./citation-utils";
 import { getPillClass } from "./pillUtils";
@@ -152,6 +153,7 @@ export function TabularCell({
     onExpand,
     onCitationClick,
 }: Props) {
+    const t = useTranslations("Tabular.TabularCell");
     const [inlineExpanded, setInlineExpanded] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
 
@@ -258,7 +260,7 @@ export function TabularCell({
                             className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-700 transition-colors"
                         >
                             <Expand className="h-3 w-3" />
-                            See details
+                            {t("seeDetails")}
                         </button>
                     </div>
                 </div>

--- a/frontend/src/app/components/tabular/TabularReviewView.tsx
+++ b/frontend/src/app/components/tabular/TabularReviewView.tsx
@@ -42,6 +42,7 @@ import type { TRTableHandle } from "./TRTable";
 import { TRChatPanel } from "./TRChatPanel";
 import { exportTabularReviewToExcel } from "./exportToExcel";
 import { useSidebar } from "@/app/contexts/SidebarContext";
+import { useTranslations } from "next-intl";
 
 interface Props {
     reviewId: string;
@@ -49,6 +50,7 @@ interface Props {
 }
 
 export function TRView({ reviewId, projectId }: Props) {
+    const t = useTranslations("Tabular.TabularReviewView");
     const { setSidebarOpen } = useSidebar();
     const [review, setReview] = useState<TabularReview | null>(null);
     const [project, setProject] = useState<MikeProject | null>(null);
@@ -537,7 +539,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                     onClick={() => router.push("/projects")}
                                     className="text-gray-500 hover:text-gray-700 transition-colors"
                                 >
-                                    Projects
+                                    {t("breadcrumbProjects")}
                                 </button>
                                 <span className="text-gray-300">›</span>
                                 <button
@@ -568,7 +570,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                     }
                                     className="text-gray-500 hover:text-gray-700 transition-colors"
                                 >
-                                    Tabular Reviews
+                                    {t("breadcrumbTabularReviews")}
                                 </button>
                             </>
                         )}
@@ -577,7 +579,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                 onClick={() => router.push("/tabular-reviews")}
                                 className="text-gray-500 hover:text-gray-700 transition-colors"
                             >
-                                Tabular Reviews
+                                {t("breadcrumbTabularReviews")}
                             </button>
                         )}
                         <span className="text-gray-300">›</span>
@@ -585,7 +587,7 @@ export function TRView({ reviewId, projectId }: Props) {
                             <div className="h-6 w-40 rounded bg-gray-100 animate-pulse" />
                         ) : (
                             <RenameableTitle
-                                value={review?.title || "Untitled Review"}
+                                value={review?.title || t("untitledReview")}
                                 onCommit={handleTitleCommit}
                             />
                         )}
@@ -602,8 +604,8 @@ export function TRView({ reviewId, projectId }: Props) {
                                             ? "text-gray-300 cursor-default"
                                             : "text-gray-500 hover:text-gray-900 cursor-pointer"
                                     }`}
-                                    title="People with access"
-                                    aria-label="People with access"
+                                    title={t("peopleWithAccess")}
+                                    aria-label={t("peopleWithAccess")}
                                 >
                                     <Users className="h-4 w-4" />
                                 </button>
@@ -618,7 +620,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                     })
                                 }
                                 disabled={columns.length === 0 || documents.length === 0}
-                                title="Export to Excel"
+                                title={t("exportToExcel")}
                                 className={`flex h-8 items-center justify-center gap-1.5 px-3 text-sm transition-colors ${
                                     columns.length === 0 || documents.length === 0
                                         ? "text-gray-300 cursor-default"
@@ -626,7 +628,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                 }`}
                             >
                                 <Download className="h-4 w-4" />
-                                Export
+                                {t("export")}
                             </button>
                             <button
                                 onClick={handleGenerate}
@@ -650,7 +652,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                 ) : (
                                     <Play className="h-4 w-4" />
                                 )}
-                                {generating ? "Running…" : "Run"}
+                                {generating ? t("running") : t("run")}
                             </button>
                         </div>
                     )}
@@ -672,7 +674,7 @@ export function TRView({ reviewId, projectId }: Props) {
                         }`}
                     >
                         <MessageSquare className="h-3.5 w-3.5" />
-                        Assistant in Tabular Review
+                        {t("assistantInTabularReview")}
                     </button>
                     <div className="ml-auto flex items-center gap-5">
                         {loading ? (
@@ -687,7 +689,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                     onClick={() => setActionsOpen((v) => !v)}
                                     className="flex items-center gap-1 text-xs font-medium text-gray-600 hover:text-gray-900 transition-colors"
                                 >
-                                    Actions
+                                    {t("actions")}
                                     <ChevronDown className="h-3.5 w-3.5" />
                                 </button>
                                 {actionsOpen && (
@@ -696,13 +698,13 @@ export function TRView({ reviewId, projectId }: Props) {
                                             onClick={handleClearResults}
                                             className="w-full px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-50 transition-colors"
                                         >
-                                            Clear results
+                                            {t("clearResults")}
                                         </button>
                                         <button
                                             onClick={handleDeleteDocuments}
                                             className="w-full px-3 py-1.5 text-left text-xs text-red-600 hover:bg-red-50 transition-colors"
                                         >
-                                            Delete
+                                            {t("delete")}
                                         </button>
                                     </div>
                                 )}
@@ -720,7 +722,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                     }`}
                                 >
                                     <Upload className="h-3.5 w-3.5" />
-                                    Add Documents
+                                    {t("addDocuments")}
                                 </button>
                                 <button
                                     onClick={() => setAddColOpen(true)}
@@ -732,7 +734,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                     }`}
                                 >
                                     <Plus className="h-3.5 w-3.5" />
-                                    Add Columns
+                                    {t("addColumns")}
                                 </button>
                             </>
                         )}
@@ -874,14 +876,14 @@ export function TRView({ reviewId, projectId }: Props) {
                         handleAddDocuments(docs)
                     }
                     breadcrumb={[
-                        "Projects",
+                        t("breadcrumbProjects"),
                         project.name +
                             (project.cm_number
                                 ? ` (#${project.cm_number})`
                                 : ""),
-                        "Tabular Reviews",
-                        ...(review ? [review.title || "Untitled Review"] : []),
-                        "Add Documents",
+                        t("breadcrumbTabularReviews"),
+                        ...(review ? [review.title || t("untitledReview")] : []),
+                        t("addDocuments"),
                     ]}
                     projectId={project.id}
                     excludeDocIds={new Set(documents.map((d) => d.id))}
@@ -894,9 +896,9 @@ export function TRView({ reviewId, projectId }: Props) {
                         handleAddDocuments(docs)
                     }
                     breadcrumb={[
-                        "Tabular Reviews",
-                        ...(review ? [review.title || "Untitled Review"] : []),
-                        "Add Documents",
+                        t("breadcrumbTabularReviews"),
+                        ...(review ? [review.title || t("untitledReview")] : []),
+                        t("addDocuments"),
                     ]}
                 />
             )}
@@ -908,9 +910,9 @@ export function TRView({ reviewId, projectId }: Props) {
                 fetchPeople={getTabularReviewPeople}
                 currentUserEmail={user?.email ?? null}
                 breadcrumb={[
-                    "Tabular Reviews",
-                    review?.title || "Untitled Review",
-                    "People",
+                    t("breadcrumbTabularReviews"),
+                    review?.title || t("untitledReview"),
+                    t("breadcrumbPeople"),
                 ]}
                 // Only the review owner may modify the member list. PeopleModal
                 // hides the add/remove controls when this prop is undefined.

--- a/frontend/src/app/components/workflows/DisplayWorkflowModal.tsx
+++ b/frontend/src/app/components/workflows/DisplayWorkflowModal.tsx
@@ -20,6 +20,7 @@ import { useDirectoryData } from "../shared/useDirectoryData";
 import { FileDirectory } from "../shared/FileDirectory";
 import type { MikeProject } from "../shared/types";
 import { useChatHistoryContext } from "@/app/contexts/ChatHistoryContext";
+import { useTranslations } from "next-intl";
 
 interface Props {
     workflows: MikeWorkflow[];
@@ -56,6 +57,7 @@ function SimpleProjectPicker({
     selectedId: string | null;
     onSelect: (id: string | null) => void;
 }) {
+    const t = useTranslations("Workflows.DisplayWorkflowModal");
     const [search, setSearch] = useState("");
     const [open, setOpen] = useState(false);
     const selected = projects.find((p) => p.id === selectedId);
@@ -77,7 +79,7 @@ function SimpleProjectPicker({
                 }}
                 onFocus={() => setOpen(true)}
                 onBlur={() => setTimeout(() => setOpen(false), 150)}
-                placeholder="Select a project…"
+                placeholder={t("selectProjectPlaceholder")}
                 className="w-full text-xs text-gray-700 placeholder:text-gray-400 bg-gray-50 border border-gray-200 rounded-md px-3 py-2 outline-none"
             />
             {selectedId && (
@@ -95,7 +97,7 @@ function SimpleProjectPicker({
                 <div className="absolute z-10 top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-md shadow-sm overflow-y-auto max-h-40">
                     {filtered.length === 0 ? (
                         <p className="px-3 py-3 text-xs text-gray-400 text-center">
-                            No projects found
+                            {t("noProjectsFound")}
                         </p>
                     ) : (
                         filtered.map((p) => (
@@ -173,16 +175,17 @@ function MarkdownBody({ content }: { content: string }) {
 // Right panel for assistant workflows (select screen)
 // ---------------------------------------------------------------------------
 function AssistantPanel({ workflow }: { workflow: MikeWorkflow }) {
+    const t = useTranslations("Workflows.DisplayWorkflowModal");
     return (
         <div className="flex-1 border-l border-t border-gray-200 flex flex-col overflow-hidden px-3 pb-3">
             <div className="py-3 shrink-0">
                 <p className="text-xs font-medium text-gray-700">
-                    Workflow Prompt
+                    {t("workflowPrompt")}
                 </p>
             </div>
             <div className="flex-1 overflow-y-auto px-4 py-3 text-sm border border-gray-200 rounded-md text-gray-600 leading-relaxed font-serif bg-gray-50">
                 <MarkdownBody
-                    content={workflow.prompt_md ?? "_No prompt defined._"}
+                    content={workflow.prompt_md ?? t("noPromptDefined")}
                 />
             </div>
         </div>
@@ -193,6 +196,7 @@ function AssistantPanel({ workflow }: { workflow: MikeWorkflow }) {
 // Right panel for tabular workflows — accordion column list (select screen)
 // ---------------------------------------------------------------------------
 function TabularPanel({ workflow }: { workflow: MikeWorkflow }) {
+    const t = useTranslations("Workflows.DisplayWorkflowModal");
     const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
     const columns = (workflow.columns_config ?? []).sort(
         (a, b) => a.index - b.index,
@@ -201,12 +205,12 @@ function TabularPanel({ workflow }: { workflow: MikeWorkflow }) {
     return (
         <div className="flex-1 border-l border-t border-gray-200 flex flex-col overflow-hidden px-3 pb-3">
             <div className="py-3 shrink-0">
-                <p className="text-xs font-medium text-gray-700">Columns</p>
+                <p className="text-xs font-medium text-gray-700">{t("columns")}</p>
             </div>
             <div className="flex-1 overflow-y-auto border border-gray-200 rounded-md bg-gray-50">
                 {columns.length === 0 ? (
                     <p className="px-4 py-6 text-xs text-center text-gray-400">
-                        No columns defined
+                        {t("noColumnsDefined")}
                     </p>
                 ) : (
                     columns.map((col) => {
@@ -242,7 +246,7 @@ function TabularPanel({ workflow }: { workflow: MikeWorkflow }) {
                                         {col.tags && col.tags.length > 0 && (
                                             <div>
                                                 <p className="text-xs font-medium text-gray-400 mb-1.5 font-sans">
-                                                    Tags
+                                                    {t("tags")}
                                                 </p>
                                                 <div className="flex flex-wrap gap-1.5">
                                                     {col.tags.map((tag) => (
@@ -258,12 +262,12 @@ function TabularPanel({ workflow }: { workflow: MikeWorkflow }) {
                                         )}
                                         <div>
                                             <p className="text-xs font-medium text-gray-400 mb-1 font-sans">
-                                                Prompt
+                                                {t("prompt")}
                                             </p>
                                             <MarkdownBody
                                                 content={
                                                     col.prompt ||
-                                                    "_No prompt defined._"
+                                                    t("noPromptDefined")
                                                 }
                                             />
                                         </div>
@@ -282,6 +286,7 @@ function TabularPanel({ workflow }: { workflow: MikeWorkflow }) {
 // DisplayWorkflowModal
 // ---------------------------------------------------------------------------
 export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
+    const t = useTranslations("Workflows.DisplayWorkflowModal");
     const [screen, setScreen] = useState<"select" | "configure">("select");
     const [selected, setSelected] = useState<MikeWorkflow | null>(workflow);
     const [listSearch, setListSearch] = useState("");
@@ -454,9 +459,9 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                     <div className="flex items-center gap-1.5 text-xs text-gray-400">
                         {screen === "select" ? (
                             <>
-                                <span>Workflows</span>
+                                <span>{t("breadcrumbWorkflows")}</span>
                                 <span>›</span>
-                                <span>Select workflow</span>
+                                <span>{t("breadcrumbSelect")}</span>
                             </>
                         ) : (
                             <>
@@ -464,7 +469,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                     onClick={() => setScreen("select")}
                                     className="hover:text-gray-700 transition-colors"
                                 >
-                                    Workflows
+                                    {t("breadcrumbWorkflows")}
                                 </button>
                                 <span>›</span>
                                 <span className="truncate max-w-[160px]">
@@ -473,8 +478,8 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                 <span>›</span>
                                 <span>
                                     {wf.type === "assistant"
-                                        ? "New Chat"
-                                        : "New Review"}
+                                        ? t("newChat")
+                                        : t("newReview")}
                                 </span>
                             </>
                         )}
@@ -499,7 +504,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                         <Search className="h-3 w-3 text-gray-400 shrink-0" />
                                         <input
                                             type="text"
-                                            placeholder="Search…"
+                                            placeholder={t("searchPlaceholder")}
                                             value={listSearch}
                                             onChange={(e) => setListSearch(e.target.value)}
                                             className="flex-1 bg-transparent text-xs text-gray-700 placeholder:text-gray-400 outline-none"
@@ -553,7 +558,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                     }}
                                     className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-500 hover:bg-gray-50 transition-colors"
                                 >
-                                    View Page
+                                    {t("viewPage")}
                                 </button>
                             ) : (
                                 <button
@@ -563,14 +568,14 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                     }}
                                     className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-500 hover:bg-gray-50 transition-colors"
                                 >
-                                    Edit
+                                    {t("edit")}
                                 </button>
                             )}
                             <button
                                 onClick={() => setScreen("configure")}
                                 className="rounded-lg bg-gray-900 px-5 py-2 text-sm font-medium text-white hover:bg-gray-700"
                             >
-                                Use
+                                {t("use")}
                             </button>
                         </div>
                     </>
@@ -583,7 +588,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                             {/* Add-on prompt */}
                             <div className="px-5 pb-3 shrink-0">
                                 <p className="text-xs font-medium text-gray-700 mb-2">
-                                    Message (optional)
+                                    {t("messageOptional")}
                                 </p>
                                 <textarea
                                     rows={3}
@@ -591,7 +596,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                     onChange={(e) =>
                                         setAssistantPrompt(e.target.value)
                                     }
-                                    placeholder="Add any additional instructions to the workflow prompt…"
+                                    placeholder={t("additionalInstructionsPlaceholder")}
                                     className="w-full text-sm text-gray-700 placeholder:text-gray-400 bg-gray-50 border border-gray-200 rounded-md px-3 py-2 resize-none outline-none leading-relaxed"
                                 />
                             </div>
@@ -599,7 +604,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                             {/* Toggle row */}
                             <div className="px-5 py-3 flex flex-col gap-2 shrink-0">
                                 <span className="text-xs font-medium text-gray-700">
-                                    Create in a project
+                                    {t("createInProject")}
                                 </span>
                                 <Toggle
                                     on={inProject}
@@ -616,7 +621,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                 <>
                                     <div className="px-5 pt-1 pb-1 shrink-0">
                                         <p className="text-xs font-medium text-gray-700">
-                                            Select project
+                                            {t("selectProject")}
                                         </p>
                                     </div>
                                     <div className="px-5 pb-2 shrink-0">
@@ -631,7 +636,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                 <>
                                     <div className="px-5 pt-1 pb-1 shrink-0">
                                         <p className="text-xs font-medium text-gray-700">
-                                            Select documents
+                                            {t("selectDocuments")}
                                         </p>
                                     </div>
 
@@ -641,7 +646,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                             <Search className="h-3 w-3 text-gray-400 shrink-0" />
                                             <input
                                                 type="text"
-                                                placeholder="Search…"
+                                                placeholder={t("searchPlaceholder")}
                                                 value={docSearch}
                                                 onChange={(e) =>
                                                     setDocSearch(e.target.value)
@@ -675,8 +680,8 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                             forceExpanded={!!q}
                                             emptyMessage={
                                                 q
-                                                    ? "No matches found"
-                                                    : "No documents yet"
+                                                    ? t("noMatchesFound")
+                                                    : t("noDocumentsYet")
                                             }
                                         />
                                     </div>
@@ -687,7 +692,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                         <div className="border-t border-gray-200 px-5 py-3 flex items-center justify-between shrink-0">
                             <span className="text-xs text-gray-400">
                                 {!inProject && selectedDocIds.size > 0
-                                    ? `${selectedDocIds.size} selected`
+                                    ? t("selectedCount", { count: selectedDocIds.size })
                                     : ""}
                             </span>
                             <button
@@ -697,7 +702,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                 }
                                 className="rounded-lg bg-gray-900 px-5 py-2 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-50"
                             >
-                                {saving ? "Starting…" : "Start Chat"}
+                                {saving ? t("starting") : t("startChat")}
                             </button>
                         </div>
                     </>
@@ -710,7 +715,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                             {/* Toggle stacked */}
                             <div className="px-5 pb-3 flex flex-col gap-2 shrink-0">
                                 <span className="text-xs font-medium text-gray-700">
-                                    Create in a project
+                                    {t("createInProject")}
                                 </span>
                                 <Toggle
                                     on={inProject}
@@ -728,7 +733,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                 <>
                                     <div className="px-5 pt-1 pb-1 shrink-0">
                                         <p className="text-xs font-medium text-gray-700">
-                                            Select Project
+                                            {t("selectProject")}
                                         </p>
                                     </div>
                                     <div className="px-5 pb-2 shrink-0">
@@ -750,7 +755,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                             {/* Documents section */}
                             <div className="px-5 pt-3 pb-1 shrink-0">
                                 <p className="text-xs font-medium text-gray-700">
-                                    Select Documents
+                                    {t("selectDocuments")}
                                 </p>
                             </div>
 
@@ -760,7 +765,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                     <Search className="h-3 w-3 text-gray-400 shrink-0" />
                                     <input
                                         type="text"
-                                        placeholder="Search…"
+                                        placeholder={t("searchPlaceholder")}
                                         value={docSearch}
                                         onChange={(e) =>
                                             setDocSearch(e.target.value)
@@ -796,10 +801,10 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                     forceExpanded={!!q || inProject}
                                     emptyMessage={
                                         q
-                                            ? "No matches found"
+                                            ? t("noMatchesFound")
                                             : inProject
-                                              ? "No documents in this project"
-                                              : "No documents yet"
+                                              ? t("noDocumentsInProject")
+                                              : t("noDocumentsYet")
                                     }
                                 />
                             </div>
@@ -808,7 +813,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                         <div className="border-t border-gray-200 px-5 py-3 flex items-center justify-between shrink-0">
                             <span className="text-xs text-gray-400">
                                 {selectedDocIds.size > 0
-                                    ? `${selectedDocIds.size} selected`
+                                    ? t("selectedCount", { count: selectedDocIds.size })
                                     : ""}
                             </span>
                             <button
@@ -820,7 +825,7 @@ export function DisplayWorkflowModal({ workflows, workflow, onClose }: Props) {
                                 }
                                 className="rounded-lg bg-gray-900 px-5 py-2 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-50"
                             >
-                                {saving ? "Creating…" : "Create Review"}
+                                {saving ? t("creating") : t("createReview")}
                             </button>
                         </div>
                     </>

--- a/frontend/src/app/components/workflows/NewWorkflowModal.tsx
+++ b/frontend/src/app/components/workflows/NewWorkflowModal.tsx
@@ -5,6 +5,7 @@ import { X, MessageSquare, Table2 } from "lucide-react";
 import { createWorkflow, updateWorkflow } from "@/app/lib/mikeApi";
 import type { MikeWorkflow } from "../shared/types";
 import { PRACTICE_OPTIONS } from "./practices";
+import { useTranslations } from "next-intl";
 
 interface Props {
     open: boolean;
@@ -15,6 +16,7 @@ interface Props {
 }
 
 export function NewWorkflowModal({ open, onClose, onCreated, editWorkflow, onUpdated }: Props) {
+    const t = useTranslations("Workflows.NewWorkflowModal");
     const [title, setTitle] = useState("");
     const [type, setType] = useState<"assistant" | "tabular">("assistant");
     const [practice, setPractice] = useState<string>("");
@@ -75,7 +77,7 @@ export function NewWorkflowModal({ open, onClose, onCreated, editWorkflow, onUpd
             resetForm();
             onClose();
         } catch (err: unknown) {
-            setError((err as Error).message || `Failed to ${isEditing ? "update" : "create"} workflow`);
+            setError((err as Error).message || (isEditing ? t("errorUpdate") : t("errorCreate")));
         } finally {
             setLoading(false);
         }
@@ -100,9 +102,9 @@ export function NewWorkflowModal({ open, onClose, onCreated, editWorkflow, onUpd
                 {/* Header */}
                 <div className="flex items-center justify-between px-6 pt-5 pb-2 shrink-0">
                     <div className="flex items-center gap-1.5 text-xs text-gray-400">
-                        <span>Workflows</span>
+                        <span>{t("breadcrumbWorkflows")}</span>
                         <span>›</span>
-                        <span>{isEditing ? "Edit workflow" : "New workflow"}</span>
+                        <span>{isEditing ? t("breadcrumbEdit") : t("breadcrumbNew")}</span>
                     </div>
                     <button
                         onClick={handleClose}
@@ -120,7 +122,7 @@ export function NewWorkflowModal({ open, onClose, onCreated, editWorkflow, onUpd
                             type="text"
                             value={title}
                             onChange={(e) => setTitle(e.target.value)}
-                            placeholder="Workflow name"
+                            placeholder={t("namePlaceholder")}
                             className="w-full text-2xl font-serif text-gray-800 placeholder-gray-300 focus:outline-none bg-transparent"
                             autoFocus
                         />
@@ -128,7 +130,7 @@ export function NewWorkflowModal({ open, onClose, onCreated, editWorkflow, onUpd
                         {/* Type pills — only shown when creating */}
                         {!isEditing && (
                             <div className="mt-5">
-                                <p className="mb-2 text-sm font-medium text-gray-500">Type</p>
+                                <p className="mb-2 text-sm font-medium text-gray-500">{t("typeLabel")}</p>
                                 <div className="flex items-center gap-2">
                                     <button
                                         type="button"
@@ -140,7 +142,7 @@ export function NewWorkflowModal({ open, onClose, onCreated, editWorkflow, onUpd
                                         }`}
                                     >
                                         <MessageSquare className="h-3 w-3" />
-                                        Assistant
+                                        {t("typeAssistant")}
                                     </button>
                                     <button
                                         type="button"
@@ -152,7 +154,7 @@ export function NewWorkflowModal({ open, onClose, onCreated, editWorkflow, onUpd
                                         }`}
                                     >
                                         <Table2 className="h-3 w-3" />
-                                        Tabular
+                                        {t("typeTabular")}
                                     </button>
                                 </div>
                             </div>
@@ -160,7 +162,7 @@ export function NewWorkflowModal({ open, onClose, onCreated, editWorkflow, onUpd
 
                         {/* Practice */}
                         <div className="mt-5">
-                            <p className="mb-2 text-sm font-medium text-gray-500">Practice Area</p>
+                            <p className="mb-2 text-sm font-medium text-gray-500">{t("practiceAreaLabel")}</p>
                             <div className="flex flex-wrap gap-2">
                                 {PRACTICE_OPTIONS.map((p) => (
                                     <button
@@ -183,7 +185,7 @@ export function NewWorkflowModal({ open, onClose, onCreated, editWorkflow, onUpd
                                     type="text"
                                     value={customPractice}
                                     onChange={(e) => setCustomPractice(e.target.value)}
-                                    placeholder="Enter practice area…"
+                                    placeholder={t("customPracticePlaceholder")}
                                     className="mt-3 w-full rounded-md border border-gray-200 px-3 py-1.5 text-sm text-gray-700 placeholder-gray-400 focus:border-gray-400 focus:outline-none"
                                 />
                             )}
@@ -201,14 +203,14 @@ export function NewWorkflowModal({ open, onClose, onCreated, editWorkflow, onUpd
                             onClick={handleClose}
                             className="rounded-lg px-4 py-2 text-sm text-gray-500 hover:bg-gray-100 transition-colors"
                         >
-                            Cancel
+                            {t("cancel")}
                         </button>
                         <button
                             type="submit"
                             disabled={!title.trim() || loading}
                             className="rounded-lg bg-gray-900 px-5 py-2 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-40 transition-colors"
                         >
-                            {loading ? (isEditing ? "Saving…" : "Creating…") : (isEditing ? "Save changes" : "Create workflow")}
+                            {loading ? (isEditing ? t("saving") : t("creating")) : (isEditing ? t("saveChanges") : t("createWorkflow"))}
                         </button>
                     </div>
                 </form>

--- a/frontend/src/app/components/workflows/ShareWorkflowModal.tsx
+++ b/frontend/src/app/components/workflows/ShareWorkflowModal.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/app/lib/mikeApi";
 import { useAuth } from "@/contexts/AuthContext";
 import { EmailPillInput } from "../shared/EmailPillInput";
+import { useTranslations } from "next-intl";
 
 interface Share {
     id: string;
@@ -29,6 +30,7 @@ export function ShareWorkflowModal({
     workflowName,
     onClose,
 }: Props) {
+    const t = useTranslations("Workflows.ShareWorkflowModal");
     const [pendingEmails, setPendingEmails] = useState<string[]>([]);
     const [allowEdit, setAllowEdit] = useState(false);
     const [existingShares, setExistingShares] = useState<Share[]>([]);
@@ -73,13 +75,13 @@ export function ShareWorkflowModal({
                 {/* Header */}
                 <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
                     <div className="flex items-center gap-1.5 text-xs text-gray-400">
-                        <span>Workflows</span>
+                        <span>{t("breadcrumbWorkflows")}</span>
                         <span>›</span>
                         <span className="truncate max-w-[220px]">
                             {workflowName}
                         </span>
                         <span>›</span>
-                        <span>People</span>
+                        <span>{t("breadcrumbPeople")}</span>
                     </div>
                     <button onClick={onClose} className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600">
                         <X className="h-4 w-4" />
@@ -92,16 +94,16 @@ export function ShareWorkflowModal({
                         onChange={setPendingEmails}
                         validate={async (email) =>
                             ownEmail && email === ownEmail
-                                ? "You cannot share a workflow with yourself."
+                                ? t("cannotShareWithSelf")
                                 : null
                         }
-                        placeholder="Add people by email…"
+                        placeholder={t("addPeoplePlaceholder")}
                         autoFocus
                     />
 
                     {/* Permission toggle */}
                     <div className="flex flex-col gap-2">
-                        <span className="text-xs font-medium text-gray-700">Allow editing by share recipients</span>
+                        <span className="text-xs font-medium text-gray-700">{t("allowEditing")}</span>
                         <button
                             type="button"
                             onClick={() => setAllowEdit((v) => !v)}
@@ -113,7 +115,7 @@ export function ShareWorkflowModal({
 
                     {/* Existing access */}
                     <div>
-                        <p className="text-xs font-medium text-gray-700 mb-2">People with access</p>
+                        <p className="text-xs font-medium text-gray-700 mb-2">{t("peopleWithAccess")}</p>
                         {loading ? (
                             <div className="space-y-2">
                                 {[1, 2].map((i) => (
@@ -124,14 +126,14 @@ export function ShareWorkflowModal({
                                 ))}
                             </div>
                         ) : existingShares.length === 0 ? (
-                            <p className="text-sm text-gray-400">None</p>
+                            <p className="text-sm text-gray-400">{t("none")}</p>
                         ) : (
                             <div className="space-y-1">
                                 {existingShares.map((share) => (
                                     <div key={share.id} className="flex items-center justify-between py-1">
                                         <span className="text-sm text-gray-700 truncate">{share.shared_with_email}</span>
                                         <div className="flex items-center gap-3 shrink-0">
-                                            <span className="text-xs text-gray-400">{share.allow_edit ? "Can edit" : "Read-only"}</span>
+                                            <span className="text-xs text-gray-400">{share.allow_edit ? t("canEdit") : t("readOnly")}</span>
                                             <button
                                                 onClick={() => handleRemoveShare(share.id)}
                                                 className="text-gray-300 hover:text-red-500 transition-colors"
@@ -152,14 +154,14 @@ export function ShareWorkflowModal({
                         onClick={onClose}
                         className="rounded-lg px-5 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 transition-colors"
                     >
-                        Cancel
+                        {t("cancel")}
                     </button>
                     <button
                         onClick={handleConfirm}
                         disabled={saving || pendingEmails.length === 0}
                         className="rounded-lg bg-gray-900 px-5 py-2 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-40 transition-colors"
                     >
-                        {saving ? "Sharing…" : "Share"}
+                        {saving ? t("sharing") : t("share")}
                     </button>
                 </div>
             </div>

--- a/frontend/src/app/components/workflows/WFColumnViewModal.tsx
+++ b/frontend/src/app/components/workflows/WFColumnViewModal.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ColumnConfig } from "../shared/types";
 import { formatIcon, formatLabel } from "../tabular/columnFormat";
+import { useTranslations } from "next-intl";
 
 interface Props {
     col: ColumnConfig;
@@ -13,13 +14,14 @@ interface Props {
 }
 
 export function WFColumnViewModal({ col, onClose }: Props) {
+    const t = useTranslations("Workflows.WFColumnViewModal");
     const FormatIcon = formatIcon(col.format ?? "text");
     return createPortal(
         <div className="fixed inset-0 z-[101] flex items-center justify-center bg-black/20 backdrop-blur-xs">
             <div className="w-full max-w-2xl rounded-2xl bg-white shadow-2xl flex flex-col h-[600px]">
                 <div className="flex items-center justify-between px-6 pt-5 pb-2">
                     <div className="flex items-center gap-1.5 text-xs text-gray-400">
-                        <span>Workflows</span>
+                        <span>{t("breadcrumbWorkflows")}</span>
                         <span>›</span>
                         <span className="truncate max-w-[200px] text-gray-600">{col.name}</span>
                     </div>
@@ -29,11 +31,11 @@ export function WFColumnViewModal({ col, onClose }: Props) {
                 </div>
                 <div className="px-6 pt-3 pb-5 flex flex-col gap-4 overflow-y-auto flex-1">
                     <div>
-                        <p className="text-sm font-medium text-gray-500 mb-2">Column Title</p>
+                        <p className="text-sm font-medium text-gray-500 mb-2">{t("columnTitle")}</p>
                         <p className="text-sm text-gray-800">{col.name}</p>
                     </div>
                     <div>
-                        <p className="text-sm font-medium text-gray-500 mb-2">Format</p>
+                        <p className="text-sm font-medium text-gray-500 mb-2">{t("format")}</p>
                         <span className="inline-flex items-center gap-1.5 text-sm text-gray-700">
                             <FormatIcon className="h-3.5 w-3.5 text-gray-400" />
                             {formatLabel(col.format ?? "text")}
@@ -41,7 +43,7 @@ export function WFColumnViewModal({ col, onClose }: Props) {
                     </div>
                     {col.tags && col.tags.length > 0 && (
                         <div>
-                            <p className="text-sm font-medium text-gray-500 mb-2.5">Tags</p>
+                            <p className="text-sm font-medium text-gray-500 mb-2.5">{t("tags")}</p>
                             <div className="flex flex-wrap gap-1.5">
                                 {col.tags.map((tag) => (
                                     <span key={tag} className="inline-block rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">{tag}</span>
@@ -50,15 +52,15 @@ export function WFColumnViewModal({ col, onClose }: Props) {
                         </div>
                     )}
                     <div>
-                        <p className="text-sm font-medium text-gray-500 mb-2">Prompt</p>
+                        <p className="text-sm font-medium text-gray-500 mb-2">{t("prompt")}</p>
                         <div className="text-base text-gray-700 leading-relaxed font-serif prose prose-base max-w-none">
-                            <ReactMarkdown remarkPlugins={[remarkGfm]}>{col.prompt || "_No prompt defined._"}</ReactMarkdown>
+                            <ReactMarkdown remarkPlugins={[remarkGfm]}>{col.prompt || t("noPromptDefined")}</ReactMarkdown>
                         </div>
                     </div>
                 </div>
                 <div className="border-t border-gray-100 px-6 py-4 flex justify-end shrink-0">
                     <button onClick={onClose} className="rounded-lg bg-gray-900 px-5 py-2 text-sm font-medium text-white hover:bg-gray-700">
-                        Close
+                        {t("close")}
                     </button>
                 </div>
             </div>

--- a/frontend/src/app/components/workflows/WFEditColumnModal.tsx
+++ b/frontend/src/app/components/workflows/WFEditColumnModal.tsx
@@ -15,6 +15,7 @@ import {
     DropdownMenuRadioItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useTranslations } from "next-intl";
 
 interface ColumnDraft {
     name: string;
@@ -32,6 +33,7 @@ interface Props {
 }
 
 export function WFEditColumnModal({ column, onClose, onSave, onDelete }: Props) {
+    const t = useTranslations("Workflows.WFEditColumnModal");
     const [draft, setDraft] = useState<ColumnDraft>({
         name: column.name,
         prompt: column.prompt,
@@ -122,9 +124,9 @@ export function WFEditColumnModal({ column, onClose, onSave, onDelete }: Props) 
                 {/* Header */}
                 <div className="flex items-center justify-between px-6 pt-5 pb-2">
                     <div className="flex items-center gap-1.5 text-xs text-gray-400">
-                        <span>Workflows</span>
+                        <span>{t("breadcrumbWorkflows")}</span>
                         <span>›</span>
-                        <span>Edit column</span>
+                        <span>{t("breadcrumbEditColumn")}</span>
                     </div>
                     <button
                         onClick={onClose}
@@ -156,14 +158,14 @@ export function WFEditColumnModal({ column, onClose, onSave, onDelete }: Props) 
                                             } : {}),
                                         });
                                     }}
-                                    placeholder="Column name"
+                                    placeholder={t("columnNamePlaceholder")}
                                     className="flex-1 text-2xl font-serif text-gray-800 placeholder-gray-400 focus:outline-none bg-transparent"
                                     autoFocus
                                 />
                                 <button
                                     type="button"
                                     onClick={() => setPresetsOpen((v) => !v)}
-                                    title="Column presets"
+                                    title={t("columnPresetsTitle")}
                                     className="mt-1.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
                                 >
                                     <ChevronDown className={`h-4 w-4 transition-transform ${presetsOpen ? "rotate-180" : ""}`} />
@@ -175,7 +177,7 @@ export function WFEditColumnModal({ column, onClose, onSave, onDelete }: Props) 
                                             onClick={() => { update({ name: "", prompt: "", format: "text", tags: [], tagInput: "" }); setPresetsOpen(false); }}
                                             className="w-full px-3 py-2 text-left text-sm text-gray-400 hover:bg-gray-50 transition-colors border-b border-gray-100"
                                         >
-                                            No Preset
+                                            {t("noPreset")}
                                         </button>
                                         {PROMPT_PRESETS.map((preset) => (
                                             <button
@@ -197,7 +199,7 @@ export function WFEditColumnModal({ column, onClose, onSave, onDelete }: Props) 
 
                         {/* Format */}
                         <div className="mt-4">
-                            <label className="text-sm font-medium text-gray-500">Format</label>
+                            <label className="text-sm font-medium text-gray-500">{t("formatLabel")}</label>
                             <DropdownMenu>
                                 <DropdownMenuTrigger asChild>
                                     <button className="mt-1 flex items-center justify-between rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm text-gray-700 hover:border-gray-400 focus:outline-none">
@@ -227,7 +229,7 @@ export function WFEditColumnModal({ column, onClose, onSave, onDelete }: Props) 
                         {/* Tag input */}
                         {draft.format === "tag" && (
                             <div className="mt-3">
-                                <label className="text-sm font-medium text-gray-500">Tags</label>
+                                <label className="text-sm font-medium text-gray-500">{t("tagsLabel")}</label>
                                 <div className="mt-1 flex flex-wrap gap-1.5 rounded-md border border-gray-200 px-2 py-1.5 focus-within:border-gray-400">
                                     {draft.tags.map((tag, tagIdx) => (
                                         <span
@@ -250,17 +252,17 @@ export function WFEditColumnModal({ column, onClose, onSave, onDelete }: Props) 
                                         onChange={(e) => update({ tagInput: e.target.value })}
                                         onKeyDown={handleTagKeyDown}
                                         onBlur={commitTag}
-                                        placeholder="Add tag…"
+                                        placeholder={t("addTagPlaceholder")}
                                         className="min-w-[80px] flex-1 bg-transparent text-sm text-gray-700 placeholder-gray-400 focus:outline-none"
                                     />
                                 </div>
-                                <p className="mt-1 text-xs text-gray-400">Press Enter or comma to add a tag.</p>
+                                <p className="mt-1 text-xs text-gray-400">{t("addTagHint")}</p>
                             </div>
                         )}
 
                         {/* Prompt */}
                         <div className="mt-4 flex items-center justify-between">
-                            <label className="text-sm font-medium text-gray-500">Prompt</label>
+                            <label className="text-sm font-medium text-gray-500">{t("promptLabel")}</label>
                             <button
                                 type="button"
                                 onClick={autoGeneratePrompt}
@@ -272,14 +274,14 @@ export function WFEditColumnModal({ column, onClose, onSave, onDelete }: Props) 
                                 ) : (
                                     <Plus className="h-4 w-4" />
                                 )}
-                                Auto-Generate Prompt
+                                {t("autoGeneratePrompt")}
                             </button>
                         </div>
                         <textarea
                             rows={6}
                             value={draft.prompt}
                             onChange={(e) => update({ prompt: e.target.value })}
-                            placeholder="Write the analysis prompt — describe what Mike should extract from each document for this column…"
+                            placeholder={t("promptPlaceholder")}
                             className="mt-2 w-full rounded-md border border-gray-200 px-3 py-2 text-sm text-gray-700 placeholder-gray-400 focus:border-gray-400 focus:outline-none bg-transparent resize-none leading-relaxed"
                         />
                     </div>
@@ -291,7 +293,7 @@ export function WFEditColumnModal({ column, onClose, onSave, onDelete }: Props) 
                             onClick={onDelete}
                             className="rounded-lg px-4 py-2 text-sm text-red-500 hover:bg-red-50 transition-colors"
                         >
-                            Delete
+                            {t("delete")}
                         </button>
                         <div className="flex items-center gap-2">
                             <button
@@ -299,14 +301,14 @@ export function WFEditColumnModal({ column, onClose, onSave, onDelete }: Props) 
                                 onClick={onClose}
                                 className="rounded-lg px-4 py-2 text-sm text-gray-500 hover:bg-gray-100 transition-colors"
                             >
-                                Cancel
+                                {t("cancel")}
                             </button>
                             <button
                                 type="submit"
                                 disabled={!draft.name.trim() || !draft.prompt.trim()}
                                 className="rounded-lg bg-gray-900 px-5 py-2 text-sm font-medium text-white hover:bg-gray-700 disabled:opacity-40 transition-colors"
                             >
-                                Save changes
+                                {t("saveChanges")}
                             </button>
                         </div>
                     </div>

--- a/frontend/src/app/components/workflows/WorkflowList.tsx
+++ b/frontend/src/app/components/workflows/WorkflowList.tsx
@@ -27,20 +27,21 @@ import { ToolbarTabs } from "../shared/ToolbarTabs";
 import { RowActions } from "../shared/RowActions";
 import { MikeIcon } from "@/components/chat/mike-icon";
 import { useAuth } from "@/contexts/AuthContext";
+import { useTranslations } from "next-intl";
 
 type Tab = "all" | "builtin" | "custom" | "hidden";
 
 const CHECK_W = "w-8 shrink-0";
 const NAME_COL_W = "w-[300px] shrink-0";
 
-const TABS: { id: Tab; label: string }[] = [
-    { id: "all", label: "All" },
-    { id: "builtin", label: "Built-in" },
-    { id: "custom", label: "Custom" },
-    { id: "hidden", label: "Hidden" },
-];
-
 export function WorkflowList() {
+    const t = useTranslations("Workflows.WorkflowList");
+    const TABS: { id: Tab; label: string }[] = [
+        { id: "all", label: t("tabAll") },
+        { id: "builtin", label: t("tabBuiltin") },
+        { id: "custom", label: t("tabCustom") },
+        { id: "hidden", label: t("tabHidden") },
+    ];
     const router = useRouter();
     const { user } = useAuth();
     const [custom, setCustom] = useState<MikeWorkflow[]>([]);
@@ -201,9 +202,9 @@ export function WorkflowList() {
 
     const getTypeMeta = (type: MikeWorkflow["type"]) =>
         type === "tabular"
-            ? { label: "Tabular", Icon: Table2, className: "text-violet-700" }
+            ? { label: t("typeTabular"), Icon: Table2, className: "text-violet-700" }
             : {
-                  label: "Assistant",
+                  label: t("typeAssistant"),
                   Icon: MessageSquare,
                   className: "text-blue-700",
               };
@@ -220,9 +221,9 @@ export function WorkflowList() {
             >
                 {typeFilter
                     ? typeFilter === "tabular"
-                        ? "Tabular"
-                        : "Assistant"
-                    : "Filter by type"}
+                        ? t("typeTabular")
+                        : t("typeAssistant")
+                    : t("filterByType")}
                 <ChevronDown className="h-3 w-3" />
             </button>
             {typeFilterOpen && (
@@ -234,7 +235,7 @@ export function WorkflowList() {
                         }}
                         className="flex items-center justify-between w-full px-3 py-2 text-xs text-gray-600 hover:bg-gray-50 transition-colors"
                     >
-                        All Types
+                        {t("allTypes")}
                         {!typeFilter && (
                             <Check className="h-3.5 w-3.5 text-gray-400" />
                         )}
@@ -278,7 +279,7 @@ export function WorkflowList() {
                         : "text-gray-500 hover:text-gray-700"
                 }`}
             >
-                {practiceFilter ?? "Filter by practice"}
+                {practiceFilter ?? t("filterByPractice")}
                 <ChevronDown className="h-3 w-3" />
             </button>
             {practiceFilterOpen && (
@@ -290,7 +291,7 @@ export function WorkflowList() {
                         }}
                         className="flex items-center justify-between w-full px-3 py-2 text-xs text-gray-600 hover:bg-gray-50 transition-colors"
                     >
-                        All Practices
+                        {t("allPractices")}
                         {!practiceFilter && (
                             <Check className="h-3.5 w-3.5 text-gray-400" />
                         )}
@@ -326,7 +327,7 @@ export function WorkflowList() {
                         onClick={() => setActionsOpen((v) => !v)}
                         className="flex items-center gap-1 text-xs font-medium text-gray-700 hover:text-gray-900 transition-colors"
                     >
-                        Actions
+                        {t("actions")}
                         <ChevronDown className="h-3.5 w-3.5" />
                     </button>
                     {actionsOpen && (
@@ -336,14 +337,14 @@ export function WorkflowList() {
                                     onClick={handleBulkUnhide}
                                     className="w-full px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-50 transition-colors"
                                 >
-                                    Unhide
+                                    {t("unhide")}
                                 </button>
                             ) : (
                                 <button
                                     onClick={handleBulkRemove}
                                     className="w-full px-3 py-1.5 text-left text-xs text-red-600 hover:bg-red-50 transition-colors"
                                 >
-                                    Delete
+                                    {t("delete")}
                                 </button>
                             )}
                         </div>
@@ -362,13 +363,13 @@ export function WorkflowList() {
             {/* Page header */}
             <div className="mb-1 flex items-center justify-between px-4 py-3 md:px-10 shrink-0">
                 <h1 className="text-2xl font-medium font-serif text-gray-900">
-                    Workflows
+                    {t("pageTitle")}
                 </h1>
                 <div className="flex items-center gap-2">
                     <HeaderSearchBtn
                         value={search}
                         onChange={setSearch}
-                        placeholder="Search workflows…"
+                        placeholder={t("searchPlaceholder")}
                     />
                     <button
                         onClick={() => setNewModalOpen(true)}
@@ -405,11 +406,11 @@ export function WorkflowList() {
                             )}
                         </div>
                         <div className={`sticky left-8 z-[60] ${NAME_COL_W} bg-white pl-2 text-left`}>
-                            Name
+                            {t("colName")}
                         </div>
-                        <div className="ml-auto w-28 shrink-0">Type</div>
-                        <div className="w-40 shrink-0">Practice</div>
-                        <div className="w-28 shrink-0">Source</div>
+                        <div className="ml-auto w-28 shrink-0">{t("colType")}</div>
+                        <div className="w-40 shrink-0">{t("colPractice")}</div>
+                        <div className="w-28 shrink-0">{t("colSource")}</div>
                         <div className="w-8 shrink-0" />
                     </div>
 
@@ -443,41 +444,36 @@ export function WorkflowList() {
                                 <>
                                     <Library className="h-8 w-8 text-gray-300 mb-4" />
                                     <p className="text-2xl font-medium font-serif text-gray-900">
-                                        Custom Workflows
+                                        {t("emptyCustomTitle")}
                                     </p>
                                     <p className="mt-1 text-xs text-gray-400 text-left">
-                                        Build reusable prompts and tabular
-                                        review templates tailored to your
-                                        practice.
+                                        {t("emptyCustomDescription")}
                                     </p>
                                     <button
                                         onClick={() => setNewModalOpen(true)}
                                         className="mt-4 inline-flex items-center gap-1 rounded-full bg-gray-900 px-3 py-1 text-xs font-medium text-white hover:bg-gray-700 transition-colors shadow-md"
                                     >
-                                        + Create New
+                                        {t("createNew")}
                                     </button>
                                 </>
                             ) : activeTab === "hidden" ? (
                                 <>
                                     <Library className="h-8 w-8 text-gray-300 mb-4" />
                                     <p className="text-2xl font-medium font-serif text-gray-900">
-                                        Hidden Workflows
+                                        {t("emptyHiddenTitle")}
                                     </p>
                                     <p className="mt-1 text-xs text-gray-400 text-left">
-                                        Built-in workflows you've hidden will
-                                        appear here. You can unhide them at any
-                                        time.
+                                        {t("emptyHiddenDescription")}
                                     </p>
                                 </>
                             ) : (
                                 <>
                                     <Library className="h-8 w-8 text-gray-300 mb-4" />
                                     <p className="text-2xl font-medium font-serif text-gray-900">
-                                        Workflows
+                                        {t("emptyAllTitle")}
                                     </p>
                                     <p className="mt-1 text-xs text-gray-400 text-left">
-                                        Automate document analysis with reusable
-                                        prompts and tabular review templates.
+                                        {t("emptyAllDescription")}
                                     </p>
                                 </>
                             )}
@@ -538,18 +534,18 @@ export function WorkflowList() {
                                     {wf.is_system ? (
                                         <span className="inline-flex items-center gap-1.5 text-xs font-medium text-gray-600">
                                             <MikeIcon size={14} />
-                                            Mike
+                                            {t("sourceMike")}
                                         </span>
                                     ) : wf.user_id === user?.id ? (
                                         <span className="inline-flex items-center gap-1.5 text-xs font-medium text-gray-600">
                                             <User className="h-3.5 w-3.5 text-gray-500" />
-                                            Myself
+                                            {t("sourceMyself")}
                                         </span>
                                     ) : (
                                         <span className="inline-flex items-center gap-1.5 text-xs font-medium text-gray-600 truncate max-w-full">
                                             <User className="h-3.5 w-3.5 text-gray-400 shrink-0" />
                                             <span className="truncate">
-                                                {wf.shared_by_name ?? "Shared"}
+                                                {wf.shared_by_name ?? t("sourceShared")}
                                             </span>
                                         </span>
                                     )}

--- a/frontend/src/app/components/workflows/WorkflowPromptEditor.tsx
+++ b/frontend/src/app/components/workflows/WorkflowPromptEditor.tsx
@@ -13,6 +13,7 @@ import {
     List,
     ListOrdered,
 } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 interface Props {
     value: string;
@@ -55,6 +56,7 @@ export function WorkflowPromptEditor({
     onChange,
     readOnly = false,
 }: Props) {
+    const t = useTranslations("Workflows.WorkflowPromptEditor");
     const lastEmittedRef = useRef(value);
 
     const editor = useEditor({
@@ -111,7 +113,7 @@ export function WorkflowPromptEditor({
                                 .run()
                         }
                         active={editor.isActive("heading", { level: 1 })}
-                        title="Heading 1"
+                        title={t("heading1")}
                     >
                         <Heading1 className="h-4 w-4" />
                     </ToolbarBtn>
@@ -124,7 +126,7 @@ export function WorkflowPromptEditor({
                                 .run()
                         }
                         active={editor.isActive("heading", { level: 2 })}
-                        title="Heading 2"
+                        title={t("heading2")}
                     >
                         <Heading2 className="h-4 w-4" />
                     </ToolbarBtn>
@@ -137,7 +139,7 @@ export function WorkflowPromptEditor({
                                 .run()
                         }
                         active={editor.isActive("heading", { level: 3 })}
-                        title="Heading 3"
+                        title={t("heading3")}
                     >
                         <Heading3 className="h-4 w-4" />
                     </ToolbarBtn>
@@ -147,7 +149,7 @@ export function WorkflowPromptEditor({
                             editor.chain().focus().toggleBold().run()
                         }
                         active={editor.isActive("bold")}
-                        title="Bold"
+                        title={t("bold")}
                     >
                         <Bold className="h-4 w-4" />
                     </ToolbarBtn>
@@ -156,7 +158,7 @@ export function WorkflowPromptEditor({
                             editor.chain().focus().toggleItalic().run()
                         }
                         active={editor.isActive("italic")}
-                        title="Italic"
+                        title={t("italic")}
                     >
                         <Italic className="h-4 w-4" />
                     </ToolbarBtn>
@@ -166,7 +168,7 @@ export function WorkflowPromptEditor({
                             editor.chain().focus().toggleBulletList().run()
                         }
                         active={editor.isActive("bulletList")}
-                        title="Bullet list"
+                        title={t("bulletList")}
                     >
                         <List className="h-4 w-4" />
                     </ToolbarBtn>
@@ -175,7 +177,7 @@ export function WorkflowPromptEditor({
                             editor.chain().focus().toggleOrderedList().run()
                         }
                         active={editor.isActive("orderedList")}
-                        title="Numbered list"
+                        title={t("numberedList")}
                     >
                         <ListOrdered className="h-4 w-4" />
                     </ToolbarBtn>

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -2,12 +2,15 @@
 
 import Link from "next/link";
 import { useEffect } from "react";
+import { useTranslations } from "next-intl";
 
 export default function Error({
     error,
 }: {
     error: Error & { digest?: string };
 }) {
+    const t = useTranslations("Errors");
+
     useEffect(() => {
         console.error("App error:", error);
     }, [error]);
@@ -16,18 +19,17 @@ export default function Error({
         <div className="min-h-screen bg-white flex items-center justify-center px-4">
             <div className="text-center max-w-md">
                 <h1 className="text-3xl font-eb-garamond font-light text-gray-900 mb-3">
-                    Something went wrong
+                    {t("title")}
                 </h1>
                 <p className="text-[0.9375rem] text-gray-500 leading-relaxed mb-8">
-                    We encountered an unexpected error. This has been logged and
-                    our team will look into it.
+                    {t("description")}
                 </p>
 
                 <Link
                     href="/"
                     className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full text-sm font-medium text-white bg-gray-900 hover:bg-gray-700 transition-colors"
                 >
-                    Home
+                    {t("home")}
                 </Link>
             </div>
         </div>

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -1,6 +1,26 @@
 "use client";
 
 import { useEffect } from "react";
+import { NextIntlClientProvider, useTranslations } from "next-intl";
+import enMessages from "../../messages/en.json";
+import { defaultLocale } from "@/i18n/config";
+
+function GlobalErrorContent() {
+    const t = useTranslations("GlobalError");
+
+    return (
+        <div className="error-container">
+            <h1 className="error-title">{t("title")}</h1>
+            <p className="error-message">{t("description")}</p>
+            <button
+                className="btn-back"
+                onClick={() => window.history.back()}
+            >
+                {t("back")}
+            </button>
+        </div>
+    );
+}
 
 export default function GlobalError({
     error,
@@ -11,10 +31,14 @@ export default function GlobalError({
         console.error("Global error:", error);
     }, [error]);
 
+    // global-error replaces the root layout (and thus the app-level
+    // NextIntlClientProvider), so it must supply its own i18n context. As a
+    // Client Component it can't read the locale cookie on the server, so it
+    // falls back to the default locale's catalog.
     return (
-        <html lang="en">
+        <html lang={defaultLocale}>
             <head>
-                <title>Something went wrong – Mike</title>
+                <title>{`${enMessages.GlobalError.title} – Mike`}</title>
                 <style>{`
                     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=EB+Garamond:wght@400;500&display=swap');
                     
@@ -78,19 +102,12 @@ export default function GlobalError({
                 `}</style>
             </head>
             <body>
-                <div className="error-container">
-                    <h1 className="error-title">Something went wrong</h1>
-                    <p className="error-message">
-                        We encountered an unexpected error. This has been logged
-                        and our team will look into it.
-                    </p>
-                    <button
-                        className="btn-back"
-                        onClick={() => window.history.back()}
-                    >
-                        Back
-                    </button>
-                </div>
+                <NextIntlClientProvider
+                    locale={defaultLocale}
+                    messages={enMessages}
+                >
+                    <GlobalErrorContent />
+                </NextIntlClientProvider>
             </body>
         </html>
     );

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { Inter, EB_Garamond } from "next/font/google";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getTranslations } from "next-intl/server";
 import "./globals.css";
 import { Providers } from "@/components/providers";
 
@@ -14,54 +16,61 @@ const ebGaramond = EB_Garamond({
     weight: ["400", "500", "600", "700"],
 });
 
-export const metadata: Metadata = {
-    metadataBase: new URL("https://app.mikeoss.com"),
-    title: "Mike - AI Legal Platform",
-    description:
-        "AI-powered legal document analysis and contract review platform.",
-    icons: {
-        icon: [
-            { url: "/icon.svg", type: "image/svg+xml" },
-            { url: "/favicon.ico" },
-        ],
-        apple: "/apple-touch-icon.png",
-    },
-    openGraph: {
-        type: "website",
-        url: "https://app.mikeoss.com",
-        siteName: "Mike",
-        title: "Mike - AI Legal Platform",
-        description:
-            "AI-powered legal document analysis and contract review platform.",
-        images: [
-            {
-                url: "/link-image.jpg",
-                width: 1200,
-                height: 651,
-                alt: "Mike",
-            },
-        ],
-    },
-    twitter: {
-        card: "summary_large_image",
-        title: "Mike - AI Legal Platform",
-        description:
-            "AI-powered legal document analysis and contract review platform.",
-        images: ["/link-image.jpg"],
-    },
-};
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations("Metadata");
+    const title = t("title");
+    const description = t("description");
 
-export default function RootLayout({
+    return {
+        metadataBase: new URL("https://app.mikeoss.com"),
+        title,
+        description,
+        icons: {
+            icon: [
+                { url: "/icon.svg", type: "image/svg+xml" },
+                { url: "/favicon.ico" },
+            ],
+            apple: "/apple-touch-icon.png",
+        },
+        openGraph: {
+            type: "website",
+            url: "https://app.mikeoss.com",
+            siteName: "Mike",
+            title,
+            description,
+            images: [
+                {
+                    url: "/link-image.jpg",
+                    width: 1200,
+                    height: 651,
+                    alt: "Mike",
+                },
+            ],
+        },
+        twitter: {
+            card: "summary_large_image",
+            title,
+            description,
+            images: ["/link-image.jpg"],
+        },
+    };
+}
+
+export default async function RootLayout({
     children,
 }: Readonly<{
     children: React.ReactNode;
 }>) {
+    const locale = await getLocale();
+
     return (
-        <html lang="en">
+        <html lang={locale}>
             <body
                 className={`${inter.variable} ${ebGaramond.variable} font-sans antialiased`}
             >
-                <Providers>{children}</Providers>
+                <NextIntlClientProvider>
+                    <Providers>{children}</Providers>
+                </NextIntlClientProvider>
             </body>
         </html>
     );

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -8,7 +8,9 @@ import { Input } from "@/components/ui/input";
 import Link from "next/link";
 import { SiteLogo } from "@/components/site-logo";
 import { useAuth } from "@/contexts/AuthContext";
+import { useTranslations } from "next-intl";
 export default function LoginPage() {
+    const t = useTranslations("Auth.Login");
     const router = useRouter();
     const { isAuthenticated, authLoading } = useAuth();
     const [email, setEmail] = useState("");
@@ -37,7 +39,7 @@ export default function LoginPage() {
 
             router.push("/assistant");
         } catch (error: any) {
-            setError(error.message || "An error occurred during login");
+            setError(error.message || t("errorDefault"));
         } finally {
             setLoading(false);
         }
@@ -53,17 +55,17 @@ export default function LoginPage() {
                 <div className="bg-white border border-gray-200 rounded-2xl p-8 mb-4">
                     <div className="flex justify-between items-center mb-6">
                         <h2 className="text-left text-2xl font-serif">
-                            Log In
+                            {t("heading")}
                         </h2>
                         <div className="bg-gray-100 p-1 rounded-md flex text-xs font-medium">
                             <span className="text-gray-600 px-3 py-1 bg-white rounded-sm shadow-sm">
-                                Log in
+                                {t("tabLogin")}
                             </span>
                             <Link
                                 href="/signup"
                                 className="px-3 py-1 text-gray-500 hover:text-gray-900"
                             >
-                                Sign up
+                                {t("tabSignup")}
                             </Link>
                         </div>
                     </div>
@@ -73,14 +75,14 @@ export default function LoginPage() {
                                 htmlFor="email"
                                 className="block text-sm font-medium text-gray-700 mb-2"
                             >
-                                Email
+                                {t("emailLabel")}
                             </label>
                             <Input
                                 id="email"
                                 type="email"
                                 value={email}
                                 onChange={(e) => setEmail(e.target.value)}
-                                placeholder="Enter your email"
+                                placeholder={t("emailPlaceholder")}
                                 required
                                 className="w-full"
                             />
@@ -91,14 +93,14 @@ export default function LoginPage() {
                                 htmlFor="password"
                                 className="block text-sm font-medium text-gray-700 mb-2"
                             >
-                                Password
+                                {t("passwordLabel")}
                             </label>
                             <Input
                                 id="password"
                                 type="password"
                                 value={password}
                                 onChange={(e) => setPassword(e.target.value)}
-                                placeholder="Enter your password"
+                                placeholder={t("passwordPlaceholder")}
                                 required
                                 className="w-full"
                             />
@@ -115,15 +117,12 @@ export default function LoginPage() {
                             disabled={loading}
                             className="w-full mt-5 bg-black hover:bg-gray-900 text-white"
                         >
-                            {loading ? "Logging in..." : "Log in"}
+                            {loading ? t("buttonLoading") : t("button")}
                         </Button>
                     </form>
                 </div>
                 <p className="text-center text-xs text-gray-500 leading-relaxed px-2">
-                    Mike hosted on MikeOSS.com is currently a demo service.
-                    Please do not upload, submit, or store sensitive,
-                    confidential, privileged, client, or personally
-                    identifiable documents.
+                    {t("demoDisclaimer")}
                 </p>
             </div>
         </div>

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,22 +1,24 @@
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 
 export default function NotFound() {
+    const t = useTranslations("NotFound");
+
     return (
         <div className="min-h-screen bg-white flex items-center justify-center px-4">
             <div className="text-center max-w-md">
                 <h1 className="text-3xl font-eb-garamond font-light text-gray-900 mb-3">
-                    Page not found
+                    {t("title")}
                 </h1>
                 <p className="text-[0.9375rem] text-gray-500 leading-relaxed mb-8">
-                    The page you&apos;re looking for doesn&apos;t exist or may
-                    have been moved.
+                    {t("description")}
                 </p>
 
                 <Link
                     href="/"
                     className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full text-sm font-medium text-white bg-gray-900 hover:bg-gray-700 transition-colors"
                 >
-                    Go home
+                    {t("goHome")}
                 </Link>
             </div>
         </div>

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
@@ -12,6 +13,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { updateUserProfile } from "@/app/lib/mikeApi";
 
 export default function SignupPage() {
+    const t = useTranslations("Auth.Signup");
     const router = useRouter();
     const { isAuthenticated, authLoading } = useAuth();
     const [email, setEmail] = useState("");
@@ -36,14 +38,14 @@ export default function SignupPage() {
 
         // Validate passwords match
         if (password !== confirmPassword) {
-            setError("Passwords do not match");
+            setError(t("errorPasswordsMismatch"));
             setLoading(false);
             return;
         }
 
         // Validate password length
         if (password.length < 6) {
-            setError("Password must be at least 6 characters");
+            setError(t("errorPasswordTooShort"));
             setLoading(false);
             return;
         }
@@ -81,7 +83,7 @@ export default function SignupPage() {
             setError(
                 error instanceof Error
                     ? error.message
-                    : "An error occurred during signup",
+                    : t("errorDefault"),
             );
         } finally {
             setLoading(false);
@@ -101,10 +103,10 @@ export default function SignupPage() {
                             <CheckCircle2 className="h-6 w-6 text-green-600" />
                         </div>
                         <h2 className="text-2xl font-semibold text-gray-900 mb-3">
-                            Account created!
+                            {t("successHeading")}
                         </h2>
                         <p className="text-gray-600 leading-relaxed">
-                            Redirecting you to the home page...
+                            {t("successRedirecting")}
                         </p>
                     </div>
                 </div>
@@ -122,17 +124,17 @@ export default function SignupPage() {
                 <div className="bg-white border border-gray-200 rounded-2xl p-8 mb-4">
                     <div className="flex justify-between items-center mb-6">
                         <h2 className="text-left text-2xl font-serif">
-                            Create Account
+                            {t("heading")}
                         </h2>
                         <div className="bg-gray-100 p-1 rounded-md flex text-xs font-medium">
                             <Link
                                 href="/login"
                                 className="px-3 py-1 text-gray-500 hover:text-gray-900"
                             >
-                                Log in
+                                {t("tabLogin")}
                             </Link>
                             <span className="px-3 py-1 bg-white rounded-sm shadow-sm text-gray-900">
-                                Sign up
+                                {t("tabSignup")}
                             </span>
                         </div>
                     </div>
@@ -143,9 +145,9 @@ export default function SignupPage() {
                                 htmlFor="name"
                                 className="block text-sm font-medium text-gray-700 mb-2"
                             >
-                                Name{" "}
+                                {t("nameLabel")}{" "}
                                 <span className="text-gray-400 font-normal">
-                                    (optional)
+                                    {t("optional")}
                                 </span>
                             </label>
                             <Input
@@ -153,7 +155,7 @@ export default function SignupPage() {
                                 type="text"
                                 value={name}
                                 onChange={(e) => setName(e.target.value)}
-                                placeholder="Your name"
+                                placeholder={t("namePlaceholder")}
                                 className="w-full"
                             />
                         </div>
@@ -163,9 +165,9 @@ export default function SignupPage() {
                                 htmlFor="organisation"
                                 className="block text-sm font-medium text-gray-700 mb-2"
                             >
-                                Organisation{" "}
+                                {t("organisationLabel")}{" "}
                                 <span className="text-gray-400 font-normal">
-                                    (optional)
+                                    {t("optional")}
                                 </span>
                             </label>
                             <Input
@@ -175,7 +177,7 @@ export default function SignupPage() {
                                 onChange={(e) =>
                                     setOrganisation(e.target.value)
                                 }
-                                placeholder="Your organisation"
+                                placeholder={t("organisationPlaceholder")}
                                 className="w-full"
                             />
                         </div>
@@ -185,14 +187,14 @@ export default function SignupPage() {
                                 htmlFor="email"
                                 className="block text-sm font-medium text-gray-700 mb-2"
                             >
-                                Email
+                                {t("emailLabel")}
                             </label>
                             <Input
                                 id="email"
                                 type="email"
                                 value={email}
                                 onChange={(e) => setEmail(e.target.value)}
-                                placeholder="Enter your email"
+                                placeholder={t("emailPlaceholder")}
                                 required
                                 className="w-full"
                             />
@@ -203,14 +205,14 @@ export default function SignupPage() {
                                 htmlFor="password"
                                 className="block text-sm font-medium text-gray-700 mb-2"
                             >
-                                Password
+                                {t("passwordLabel")}
                             </label>
                             <Input
                                 id="password"
                                 type="password"
                                 value={password}
                                 onChange={(e) => setPassword(e.target.value)}
-                                placeholder="Create a password (min. 6 characters)"
+                                placeholder={t("passwordPlaceholder")}
                                 required
                                 className="w-full"
                             />
@@ -221,7 +223,7 @@ export default function SignupPage() {
                                 htmlFor="confirmPassword"
                                 className="block text-sm font-medium text-gray-700 mb-2"
                             >
-                                Confirm Password
+                                {t("confirmPasswordLabel")}
                             </label>
                             <Input
                                 id="confirmPassword"
@@ -230,7 +232,7 @@ export default function SignupPage() {
                                 onChange={(e) =>
                                     setConfirmPassword(e.target.value)
                                 }
-                                placeholder="Confirm your password"
+                                placeholder={t("confirmPasswordPlaceholder")}
                                 required
                                 className="w-full"
                             />
@@ -247,37 +249,34 @@ export default function SignupPage() {
                             disabled={loading}
                             className="w-full bg-black hover:bg-gray-900 text-white"
                         >
-                            {loading ? "Creating account..." : "Sign up"}
+                            {loading ? t("buttonLoading") : t("button")}
                         </Button>
                     </form>
 
                     {/* Terms and Privacy */}
                     <div className="mt-4 text-center text-xs text-gray-500">
-                        By signing up, you agree to our{" "}
+                        {t("termsPrefix")}{" "}
                         <Link
                             href="https://mikeoss.com/terms"
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-blue-600 hover:underline"
                         >
-                            Terms of Use
+                            {t("termsLink")}
                         </Link>{" "}
-                        and{" "}
+                        {t("termsAnd")}{" "}
                         <Link
                             href="https://mikeoss.com/privacy"
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-blue-600 hover:underline"
                         >
-                            Privacy Policy
+                            {t("privacyLink")}
                         </Link>
                     </div>
                 </div>
                 <p className="text-center text-xs text-gray-500 leading-relaxed px-2">
-                    Mike hosted on MikeOSS.com is currently a demo service.
-                    Please do not upload, submit, or store sensitive,
-                    confidential, privileged, client, or personally identifiable
-                    documents.
+                    {t("demoDisclaimer")}
                 </p>
             </div>
         </div>

--- a/frontend/src/app/support/page.tsx
+++ b/frontend/src/app/support/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { Send, CheckCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
@@ -8,6 +9,7 @@ import { useAuth } from "@/contexts/AuthContext";
 type FeedbackType = "bug" | "feature" | "question" | "other";
 
 export default function SupportPage() {
+    const t = useTranslations("Auth.Support");
     const router = useRouter();
     const { user, isAuthenticated, authLoading } = useAuth();
 
@@ -31,23 +33,23 @@ export default function SupportPage() {
     }[] = [
         {
             value: "bug",
-            label: "Bug Report",
-            description: "Report something that isn't working",
+            label: t("typeBugLabel"),
+            description: t("typeBugDescription"),
         },
         {
             value: "feature",
-            label: "Feature Request",
-            description: "Suggest a new feature or improvement",
+            label: t("typeFeatureLabel"),
+            description: t("typeFeatureDescription"),
         },
         {
             value: "question",
-            label: "Question",
-            description: "Ask a question about using Mike",
+            label: t("typeQuestionLabel"),
+            description: t("typeQuestionDescription"),
         },
         {
             value: "other",
-            label: "Other",
-            description: "General feedback or other inquiries",
+            label: t("typeOtherLabel"),
+            description: t("typeOtherDescription"),
         },
     ];
 
@@ -76,7 +78,7 @@ export default function SupportPage() {
             setIsSubmitted(true);
         } catch (err) {
             console.error("Error submitting feedback:", err);
-            setError("Failed to submit your feedback. Please try again.");
+            setError(t("errorSubmit"));
         } finally {
             setIsSubmitting(false);
         }
@@ -92,16 +94,16 @@ export default function SupportPage() {
                         </div>
                     </div>
                     <h2 className="text-2xl font-semibold text-gray-900 mb-2">
-                        Thank you for helping us improve.
+                        {t("successHeading")}
                     </h2>
                     <p className="text-gray-600 mb-6">
-                        We will get in touch with you soon via email.
+                        {t("successBody")}
                     </p>
                     <button
                         onClick={() => router.push("/")}
                         className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium text-sm"
                     >
-                        Back to Home
+                        {t("backToHome")}
                     </button>
                 </div>
             </div>
@@ -115,7 +117,7 @@ export default function SupportPage() {
                 <div className="flex-shrink-0 pt-6 md:pt-10 pb-0">
                     <div className="mb-5">
                         <h1 className="text-4xl font-medium font-eb-garamond text-gray-900 mb-3">
-                            Support
+                            {t("heading")}
                         </h1>
                     </div>
                 </div>
@@ -127,7 +129,7 @@ export default function SupportPage() {
                             {/* Feedback Type Selection */}
                             <div>
                                 <label className="block text-sm font-medium text-gray-700 mb-3">
-                                    What can we help you with?
+                                    {t("typeLabel")}
                                 </label>
                                 <div className="grid grid-cols-2 gap-3">
                                     {feedbackTypes.map((type) => (
@@ -167,7 +169,7 @@ export default function SupportPage() {
                                         htmlFor="link"
                                         className="block text-sm font-medium text-gray-700 mb-2"
                                     >
-                                        Link to issue (optional)
+                                        {t("linkLabel")}
                                     </label>
                                     <input
                                         type="url"
@@ -180,10 +182,7 @@ export default function SupportPage() {
                                         className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all"
                                     />
                                     <p className="text-xs text-gray-500 mt-1">
-                                        If the bug is in a chat, mouseover the
-                                        chat in the sidebar, click the dots,
-                                        then click share and paste the link
-                                        here.
+                                        {t("linkHint")}
                                     </p>
                                 </div>
                             )}
@@ -194,7 +193,7 @@ export default function SupportPage() {
                                     htmlFor="subject"
                                     className="block text-sm font-medium text-gray-700 mb-2"
                                 >
-                                    Subject
+                                    {t("subjectLabel")}
                                 </label>
                                 <input
                                     type="text"
@@ -212,13 +211,13 @@ export default function SupportPage() {
                                     htmlFor="message"
                                     className="block text-sm font-medium text-gray-700 mb-2"
                                 >
-                                    Message
+                                    {t("messageLabel")}
                                 </label>
                                 <textarea
                                     id="message"
                                     value={message}
                                     onChange={(e) => setMessage(e.target.value)}
-                                    placeholder="Please describe your question, issue, or suggestion in detail..."
+                                    placeholder={t("messagePlaceholder")}
                                     rows={5}
                                     className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all resize-none"
                                     required
@@ -228,7 +227,7 @@ export default function SupportPage() {
                             {/* Email Display (if logged in) */}
                             {user?.email && (
                                 <div className="text-sm text-gray-500">
-                                    We'll respond to:{" "}
+                                    {t("respondTo")}{" "}
                                     <span className="font-medium">
                                         {user.email}
                                     </span>
@@ -255,12 +254,12 @@ export default function SupportPage() {
                                 {isSubmitting ? (
                                     <>
                                         <div className="h-4 w-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                                        <span>Sending...</span>
+                                        <span>{t("buttonLoading")}</span>
                                     </>
                                 ) : (
                                     <>
                                         <Send className="h-4 w-4" />
-                                        <span>Submit</span>
+                                        <span>{t("button")}</span>
                                     </>
                                 )}
                             </button>

--- a/frontend/src/components/ui/cite-button.tsx
+++ b/frontend/src/components/ui/cite-button.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Check } from "lucide-react";
 import { QuoteIcon } from "@radix-ui/react-icons";
+import { useTranslations } from "next-intl";
 
 interface CiteButtonProps {
     quoteText: string;
@@ -19,6 +20,7 @@ export function CiteButton({
     iconSize = 12,
     textClassName = "text-[10px] font-medium",
 }: CiteButtonProps) {
+    const t = useTranslations("Common.CiteButton");
     const [isCopied, setIsCopied] = useState(false);
 
     const handleClick = async (e: React.MouseEvent) => {
@@ -41,7 +43,7 @@ export function CiteButton({
         <button
             onClick={handleClick}
             className={`transition-colors flex items-center gap-1 ${className}`}
-            title="Copy Quote and Citation"
+            title={t("copyTitle")}
         >
             {isCopied ? (
                 <Check
@@ -59,7 +61,7 @@ export function CiteButton({
                             : textClassName
                     }
                 >
-                    {isCopied ? "Copied" : "Cite"}
+                    {isCopied ? t("copied") : t("cite")}
                 </span>
             )}
         </button>

--- a/frontend/src/components/ui/text-search-widget.tsx
+++ b/frontend/src/components/ui/text-search-widget.tsx
@@ -1,6 +1,7 @@
 import { Input } from "@/components/ui/input";
 import { ArrowUp, ArrowDown, X } from "lucide-react";
 import { useRef } from "react";
+import { useTranslations } from "next-intl";
 
 interface TextSearchWidgetProps {
     isOpen: boolean;
@@ -23,6 +24,7 @@ export function TextSearchWidget({
     setCurrentMatchIdx,
     className = "",
 }: TextSearchWidgetProps) {
+    const t = useTranslations("Common.TextSearchWidget");
     const searchInputRef = useRef<HTMLInputElement>(null);
 
     const handleNext = () => {
@@ -46,7 +48,7 @@ export function TextSearchWidget({
                     <Input
                         ref={searchInputRef}
                         autoFocus
-                        placeholder="Find"
+                        placeholder={t("placeholder")}
                         value={searchQuery}
                         onChange={(e) => onSearchChange(e.target.value)}
                         className="h-8 text-sm w-full pr-[80px] rounded-sm border-gray-200 bg-gray-100/50 focus-visible:ring-0 focus-visible:border-blue-600 placeholder:text-gray-500"
@@ -68,8 +70,8 @@ export function TextSearchWidget({
                 <div className="flex items-center justify-between px-2 pb-1 pt-0.5 text-xs text-gray-500">
                     <span>
                         {matchCount > 0
-                            ? `${currentMatchIdx + 1} of ${matchCount}`
-                            : "No results"}
+                            ? t("matchPosition", { current: currentMatchIdx + 1, total: matchCount })
+                            : t("noResults")}
                     </span>
                     <div className="flex items-center gap-1">
                         <button

--- a/frontend/src/i18n/actions.ts
+++ b/frontend/src/i18n/actions.ts
@@ -1,0 +1,22 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { isLocale, LOCALE_COOKIE, type Locale } from "./config";
+
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
+
+/**
+ * Persists the user's locale choice in the `NEXT_LOCALE` cookie. The next
+ * request is then resolved by `i18n/request.ts`. Callers should refresh the
+ * router afterwards so server components re-render with the new locale.
+ */
+export async function setLocale(locale: Locale): Promise<void> {
+    if (!isLocale(locale)) return;
+
+    const cookieStore = await cookies();
+    cookieStore.set(LOCALE_COOKIE, locale, {
+        maxAge: ONE_YEAR_IN_SECONDS,
+        path: "/",
+        sameSite: "lax",
+    });
+}

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -1,0 +1,26 @@
+/**
+ * Central i18n configuration.
+ *
+ * To add a new language:
+ *   1. Add its code to `locales` and a label to `localeLabels`.
+ *   2. Drop a matching `messages/<locale>.json` file (same shape as `en.json`).
+ * Everything else (request config, language switcher, cookie handling) reads
+ * from here, so no other wiring is required.
+ */
+export const locales = ["en"] as const;
+
+export type Locale = (typeof locales)[number];
+
+export const defaultLocale: Locale = "en";
+
+/** Cookie that stores the user's selected locale (read in `i18n/request.ts`). */
+export const LOCALE_COOKIE = "NEXT_LOCALE";
+
+/** Human-readable names shown in the language switcher. */
+export const localeLabels: Record<Locale, string> = {
+    en: "English",
+};
+
+export function isLocale(value: string | undefined | null): value is Locale {
+    return value != null && (locales as readonly string[]).includes(value);
+}

--- a/frontend/src/i18n/request.ts
+++ b/frontend/src/i18n/request.ts
@@ -1,0 +1,20 @@
+import { getRequestConfig } from "next-intl/server";
+import { cookies } from "next/headers";
+import { defaultLocale, isLocale, LOCALE_COOKIE, type Locale } from "./config";
+
+/**
+ * Resolves the active locale per request from the `NEXT_LOCALE` cookie and
+ * loads the matching message catalog. Falls back to the default locale when no
+ * (valid) cookie is present. Wired into Next.js via `createNextIntlPlugin` in
+ * `next.config.ts`.
+ */
+export default getRequestConfig(async () => {
+    const cookieStore = await cookies();
+    const cookieLocale = cookieStore.get(LOCALE_COOKIE)?.value;
+    const locale: Locale = isLocale(cookieLocale) ? cookieLocale : defaultLocale;
+
+    return {
+        locale,
+        messages: (await import(`../../messages/${locale}.json`)).default,
+    };
+});

--- a/frontend/src/types/next-intl.d.ts
+++ b/frontend/src/types/next-intl.d.ts
@@ -1,0 +1,14 @@
+import type { Locale } from "@/i18n/config";
+
+/**
+ * Type augmentation for next-intl. Binds the message catalog and locale union
+ * to the library so `useTranslations`, `getTranslations`, and `useLocale` are
+ * type-checked against `messages/en.json` keys. A `t("...")` call referencing a
+ * missing key becomes a compile-time error.
+ */
+declare module "next-intl" {
+    interface AppConfig {
+        Locale: Locale;
+        Messages: typeof import("../../messages/en.json");
+    }
+}


### PR DESCRIPTION
## Summary

Adds internationalization (i18n) to the frontend using **next-intl** (v4, App Router, **cookie-based — no URL changes**). All user-facing UI strings are extracted into a typed message catalog. English-only for now; adding a language is a matter of dropping in `messages/<locale>.json`.

## What's included

### Infrastructure
- `next-intl@4.13` wired via `createNextIntlPlugin` in `next.config.ts`
- `src/i18n/config.ts` — single source of truth: locales, default locale, cookie name, labels
- `src/i18n/request.ts` — resolves locale from the `NEXT_LOCALE` cookie (fallback `en`)
- `src/i18n/actions.ts` — `setLocale` server action (writes the cookie)
- `NextIntlClientProvider` in the root layout + dynamic `<html lang>`
- `src/types/next-intl.d.ts` — **typed messages**: every `t('key')` is compile-checked against `en.json`
- `LanguageSwitcher` component (design-system dropdown), mounted on the Account page
- Localized `generateMetadata`, `error`, `not-found`, and `global-error` (the last self-provides its own `NextIntlClientProvider` because it replaces the root layout when active)

### String migration
- ~85 components/pages migrated from hardcoded English to `useTranslations()` / `getTranslations()`
- `messages/en.json`: **671 keys across 16 namespaces** (`Common`, `Shared`, `Documents`, `Projects`, `Assistant`, `Tabular`, `Workflows`, `Modals`, `Auth`, `Account`, …)

## Adding a new language
1. Add the code to `locales` + a label to `localeLabels` in `src/i18n/config.ts`
2. Add `messages/<locale>.json` (same shape as `en.json`)

The switcher and cookie handling pick it up automatically — no other wiring needed.

## Deliberately left as-is
- Brand name ("Mike"), model provider names (Anthropic/Google/OpenAI), and version codes (`V{n}`)
- `console.*`, API field names, route paths, and LLM prompt strings (not UI copy)
- Date formatting already uses locale-aware `toLocaleDateString`

## Test plan
- [x] `tsc --noEmit` — 0 errors (typed catalog validates all 671 keys against `t()` calls)
- [x] `next build` — all 20 routes compile
- [x] No new ESLint errors vs `main`
- [ ] Manual: switch language on `/account`, confirm `NEXT_LOCALE` cookie is set and server components re-render
- [ ] Manual: spot-check key screens (assistant, projects, tabular reviews, workflows) render expected copy
