### PR TITLE
Fix frontend build without Supabase env

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,21 +1,24 @@
 import type { NextConfig } from "next";
+import path from "node:path";
 
 const nextConfig: NextConfig = {
-    /* config options here */
-    reactCompiler: true,
-    async rewrites() {
-        return [
-            {
-                source: "/sitemap.xml",
-                destination: "/api/sitemap/sitemap.xml",
-            },
-            {
-                source: "/sitemap_:slug.xml",
-                destination: "/api/sitemap/sitemap_:slug.xml",
-            },
-        ];
-    },
-    skipTrailingSlashRedirect: true,
+  turbopack: {
+    root: path.resolve(__dirname),
+  },
+  reactCompiler: true,
+  async rewrites() {
+    return [
+      {
+        source: "/sitemap.xml",
+        destination: "/api/sitemap/sitemap.xml",
+      },
+      {
+        source: "/sitemap_:slug.xml",
+        destination: "/api/sitemap/sitemap_:slug.xml",
+      },
+    ];
+  },
+  skipTrailingSlashRedirect: true,
 };
 
 export default nextConfig;

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,9 +1,9 @@
-import { NextRequest } from 'next/server';
+import { NextRequest } from "next/server";
 
 /**
  * Extract and validate user from Supabase JWT token
  * Returns user info if valid, null if invalid or missing
- * 
+ *
  * @param request NextRequest with Authorization header
  * @returns User object with email and id, or null
  */
@@ -12,43 +12,52 @@ export async function getUserFromRequest(request: NextRequest): Promise<{
   id: string;
 } | null> {
   try {
-    const authHeader = request.headers.get('Authorization');
-    
-    if (!authHeader?.startsWith('Bearer ')) {
+    const authHeader = request.headers.get("Authorization");
+
+    if (!authHeader?.startsWith("Bearer ")) {
       return null;
     }
 
     const token = authHeader.substring(7);
-    
+
     if (!token) {
       return null;
     }
-    
-    // Validate with Supabase
-    const { createClient } = await import('@supabase/supabase-js');
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!
-    );
 
-    const { data: { user }, error } = await supabase.auth.getUser(token);
-    
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey =
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      console.error("[Auth] Supabase environment variables are not configured");
+      return null;
+    }
+
+    // Validate with Supabase
+    const { createClient } = await import("@supabase/supabase-js");
+    const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser(token);
+
     if (error || !user) {
-      console.warn('[Auth] Invalid or expired token:', error?.message);
+      console.warn("[Auth] Invalid or expired token:", error?.message);
       return null;
     }
 
     if (!user.email) {
-      console.warn('[Auth] User has no email');
+      console.warn("[Auth] User has no email");
       return null;
     }
 
     return {
       email: user.email,
-      id: user.id
+      id: user.id,
     };
   } catch (error) {
-    console.error('[Auth] Error validating token:', error);
+    console.error("[Auth] Error validating token:", error);
     return null;
   }
 }

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1,7 +1,17 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
+const supabaseUrl =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || "http://localhost:54321";
 const supabaseAnonKey =
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY || "";
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY ||
+  "missing-supabase-anon-key";
+
+if (
+  typeof window !== "undefined" &&
+  (!process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY)
+) {
+  console.error("Supabase environment variables are not configured.");
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- avoid constructing the Supabase browser client with empty env values during static prerender
- make token validation fail closed with a clear log when Supabase env is missing
- pin Turbopack's root to the frontend app to avoid workspace-root misdetection

## Verification
- npm run build --prefix backend
- npm run build --prefix frontend

## Notes
- This fixes a fresh-checkout build failure where `npm run build --prefix frontend` crashed on `/account/api-keys` with `supabaseUrl is required` before any runtime Supabase call was made.