### PR TITLE
Require review owner for tabular settings edits

### DIFF
--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -534,6 +534,14 @@ tabularRouter.patch("/:reviewId", requireAuth, async (req, res) => {
     );
     if (!access.ok)
         return void res.status(404).json({ detail: "Review not found" });
+    if (
+        (req.body.title != null || req.body.document_ids != null) &&
+        !access.isOwner
+    ) {
+        return void res.status(403).json({
+            detail: "Only the review owner can change review settings",
+        });
+    }
     if (req.body.columns_config != null) {
         if (!access.isOwner) {
             return void res.status(403).json({


### PR DESCRIPTION
## Summary
- require tabular review ownership before changing the review title
- require tabular review ownership before changing the review document list
- keep existing owner-only checks for columns, sharing, and project moves unchanged

## Bug
`PATCH /tabular-review/:reviewId` already restricted columns, sharing, and project moves to the review owner, but it allowed any user with review access to change `title` or `document_ids`. That let collaborators rename another user’s review or add/remove documents and cells by calling the API directly, even though the UI treats these as owner-controlled structural settings.

## Verification
- npm run build --prefix backend