### PR TITLE
Restrict project folder deletion to project owners

### DIFF
--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -743,6 +743,7 @@ projectsRouter.delete("/:projectId/folders/:folderId", requireAuth, async (req, 
 
   const access = await checkProjectAccess(projectId, userId, userEmail, db);
   if (!access.ok) return void res.status(404).json({ detail: "Project not found" });
+  if (!access.isOwner) return void res.status(404).json({ detail: "Project not found" });
 
   const { data: allFolders, error: foldersError } = await db
     .from("project_subfolders")


### PR DESCRIPTION
## Summary
- block shared project members from calling `DELETE /projects/:projectId/folders/:folderId`
- keep folder-tree and document deletion behind project-owner authorization

## Why
The folder delete route previously accepted any user with project access. Because that endpoint recursively deletes the folder tree and removes every document inside it, a shared project member could permanently delete documents they do not own.

## Test
- `npm run build --prefix backend`