### PR TITLE
Filter project documents before tabular generation

### DIFF
--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -927,7 +927,22 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
             .select("id, current_version_id")
             .eq("project_id", review.project_id)
             .order("created_at", { ascending: true });
-        docs = data ?? [];
+        const projectDocs = (data ?? []) as Record<string, unknown>[];
+        const accessibleProjectDocIds = new Set(
+            await filterAccessibleDocumentIds(
+                projectDocs
+                    .map((doc) => doc.id)
+                    .filter((id): id is string => typeof id === "string"),
+                userId,
+                userEmail,
+                db,
+            ),
+        );
+        docs = projectDocs.filter(
+            (doc) =>
+                typeof doc.id === "string" &&
+                accessibleProjectDocIds.has(doc.id),
+        );
     }
     await attachActiveVersionPaths(
         db,


### PR DESCRIPTION
## Summary
- filter fallback project documents through `filterAccessibleDocumentIds` before tabular generation
- prevent directly shared reviews from expanding into private project document access

## Why
`POST /tabular-review/:reviewId/generate` allows access through `ensureReviewAccess`, including direct `shared_with` review sharing. When a linked project review has no existing cells, the route falls back to loading every document in `review.project_id` without checking whether the requester can access those documents. A user who can access only the review could therefore trigger extraction over private project documents.

## Test
- `npm run build --prefix backend`