### PR TITLE
feat: content hashes on document versions + tamper-evident project export manifest

### DIFF
--- a/backend/oss-migrations/20260612_document_version_content_sha256.sql
+++ b/backend/oss-migrations/20260612_document_version_content_sha256.sql
@@ -1,0 +1,7 @@
+-- Tamper-evidence: store a SHA-256 hex digest of each version's file bytes
+-- at write time so exports can prove a file matches what the workspace held.
+-- Nullable — rows written before this migration stay unhashed until their
+-- bytes are next rewritten (in-place edit resolution or version replace).
+
+alter table public.document_versions
+  add column if not exists content_sha256 text;

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -128,6 +128,7 @@ create table if not exists public.document_versions (
   file_type text,
   size_bytes integer,
   page_count integer,
+  content_sha256 text,
   deleted_at timestamptz,
   deleted_by uuid,
   created_at timestamptz not null default now(),

--- a/backend/src/lib/chatTools.ts
+++ b/backend/src/lib/chatTools.ts
@@ -15,6 +15,7 @@ import {
 import { buildDownloadUrl } from "./downloadTokens";
 import {
   attachActiveVersionPaths,
+  contentSha256,
   loadActiveVersion,
 } from "./documentVersions";
 import {
@@ -1329,6 +1330,7 @@ export async function generateDocx(
         file_type: "docx",
         size_bytes: buf.byteLength,
         page_count: null,
+        content_sha256: contentSha256(buf),
       })
       .select("id")
       .single();
@@ -1470,6 +1472,7 @@ export async function runEditDocument(params: {
         file_type: "docx",
         size_bytes: editedBytes.byteLength,
         page_count: null,
+        content_sha256: contentSha256(editedBytes),
       })
       .eq("id", versionRowId);
   } else {
@@ -1521,6 +1524,7 @@ export async function runEditDocument(params: {
         file_type: "docx",
         size_bytes: editedBytes.byteLength,
         page_count: null,
+        content_sha256: contentSha256(editedBytes),
       })
       .select("id")
       .single();
@@ -3374,6 +3378,7 @@ export async function runToolCalls(
                 file_type: active?.file_type ?? sourceInfo.file_type,
                 size_bytes: active?.size_bytes ?? raw.byteLength,
                 page_count: active?.page_count ?? null,
+                content_sha256: contentSha256(raw),
               }));
               const { data: insertedVersions, error: verErr } = await db
                 .from("document_versions")

--- a/backend/src/lib/documentVersions.ts
+++ b/backend/src/lib/documentVersions.ts
@@ -1,6 +1,20 @@
+import { createHash } from "node:crypto";
 import type { createServerSupabase } from "./supabase";
 
 type Supa = ReturnType<typeof createServerSupabase>;
+
+/**
+ * SHA-256 hex digest of a version's file bytes. Stored on
+ * `document_versions.content_sha256` at write time so an export can
+ * prove a file matches the bytes the workspace held. Recompute whenever
+ * stored bytes change (new version row or in-place overwrite).
+ */
+export function contentSha256(bytes: ArrayBuffer | ArrayBufferView): string {
+    const buf = ArrayBuffer.isView(bytes)
+        ? Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+        : Buffer.from(bytes);
+    return createHash("sha256").update(buf).digest("hex");
+}
 
 interface DocRow {
     id: string;

--- a/backend/src/lib/userDataExport.ts
+++ b/backend/src/lib/userDataExport.ts
@@ -160,6 +160,111 @@ export async function buildUserTabularReviewsExport(
     };
 }
 
+export function projectManifestFilename(projectId: string) {
+    return `mike-project-manifest-${projectId.slice(0, 8)}-${nowStamp()}.json`;
+}
+
+/**
+ * Tamper-evident manifest for one project: every document version with
+ * its content_sha256 plus the accept/reject trail. Lets an exported file
+ * set be verified against what the workspace held — recompute a file's
+ * SHA-256 and compare. Field order is stable so manifests diff cleanly.
+ * Versions written before content hashing shipped have a null hash.
+ */
+export async function buildProjectExportManifest(
+    db: Db,
+    projectId: string,
+) {
+    const { data: project, error: projectError } = await db
+        .from("projects")
+        .select("id, name, cm_number, created_at")
+        .eq("id", projectId)
+        .single();
+    await throwIfError(projectError, "Failed to export project");
+
+    const documents = await selectAll(
+        db,
+        "documents",
+        (query) =>
+            query
+                .eq("project_id", projectId)
+                .order("created_at", { ascending: true }),
+        "id, project_id, status, current_version_id, created_at",
+    );
+    const documentIds = idsFrom(documents);
+
+    const [versions, edits] = await Promise.all([
+        documentIds.length === 0
+            ? Promise.resolve([])
+            : selectAll(
+                  db,
+                  "document_versions",
+                  (query) =>
+                      query
+                          .in("document_id", documentIds)
+                          .order("created_at", { ascending: true }),
+                  "id, document_id, version_number, source, filename, file_type, size_bytes, content_sha256, deleted_at, created_at",
+              ),
+        documentIds.length === 0
+            ? Promise.resolve([])
+            : selectAll(
+                  db,
+                  "document_edits",
+                  (query) =>
+                      query
+                          .in("document_id", documentIds)
+                          .order("created_at", { ascending: true }),
+                  "id, document_id, version_id, change_id, status, created_at, resolved_at",
+              ),
+    ]);
+
+    const groupByDocument = (rows: Record<string, unknown>[]) => {
+        const byDoc = new Map<string, Record<string, unknown>[]>();
+        for (const row of rows) {
+            const docId = row.document_id as string;
+            const list = byDoc.get(docId) ?? [];
+            list.push(row);
+            byDoc.set(docId, list);
+        }
+        return byDoc;
+    };
+    const versionsByDoc = groupByDocument(versions);
+    const editsByDoc = groupByDocument(edits);
+
+    return {
+        manifest_version: 1,
+        exported_at: new Date().toISOString(),
+        project,
+        documents: documents.map((doc) => ({
+            id: doc.id,
+            status: doc.status,
+            current_version_id: doc.current_version_id,
+            created_at: doc.created_at,
+            versions: (versionsByDoc.get(doc.id as string) ?? []).map(
+                (v) => ({
+                    id: v.id,
+                    version_number: v.version_number,
+                    source: v.source,
+                    filename: v.filename,
+                    file_type: v.file_type,
+                    size_bytes: v.size_bytes,
+                    content_sha256: v.content_sha256,
+                    deleted_at: v.deleted_at,
+                    created_at: v.created_at,
+                }),
+            ),
+            edits: (editsByDoc.get(doc.id as string) ?? []).map((e) => ({
+                id: e.id,
+                version_id: e.version_id,
+                change_id: e.change_id,
+                status: e.status,
+                created_at: e.created_at,
+                resolved_at: e.resolved_at,
+            })),
+        })),
+    };
+}
+
 export async function buildUserAccountExport(
     db: Db,
     userId: string,

--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -19,6 +19,7 @@ import { buildDownloadUrl } from "../lib/downloadTokens";
 import {
   attachActiveVersionPaths,
   attachLatestVersionNumbers,
+  contentSha256,
   loadActiveVersion,
 } from "../lib/documentVersions";
 import { ensureDocAccess } from "../lib/access";
@@ -527,6 +528,7 @@ documentsRouter.post(
         file_type: sourceType || null,
         size_bytes: active.size_bytes ?? bytes.byteLength,
         page_count: active.page_count,
+        content_sha256: contentSha256(bytes),
       })
       .select("id, version_number, source, created_at, filename")
       .single();
@@ -699,6 +701,7 @@ documentsRouter.post(
         file_type: suffix,
         size_bytes: file.buffer.byteLength,
         page_count: pageCount,
+        content_sha256: contentSha256(file.buffer),
       })
       .select("id, version_number, source, created_at, filename")
       .single();
@@ -897,6 +900,7 @@ documentsRouter.put(
         file_type: suffix,
         size_bytes: file.buffer.byteLength,
         page_count: pageCount,
+        content_sha256: contentSha256(file.buffer),
         created_at: uploadedAt,
       })
       .eq("id", versionId)
@@ -1241,6 +1245,12 @@ async function handleEditResolution(
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   );
 
+  // The rewrite changed the version's stored bytes, so refresh its hash.
+  await db
+    .from("document_versions")
+    .update({ content_sha256: contentSha256(ab) })
+    .eq("id", doc.current_version_id);
+
   const { error: statusErr } = await db
     .from("document_edits")
     .update({
@@ -1397,6 +1407,7 @@ async function handleDocumentUpload(
         file_type: suffix,
         size_bytes: content.byteLength,
         page_count: pageCount,
+        content_sha256: contentSha256(content),
       })
       .select("id")
       .single();

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -5,6 +5,7 @@ import { createClient } from "@supabase/supabase-js";
 import {
   attachActiveVersionPaths,
   attachLatestVersionNumbers,
+  contentSha256,
 } from "../lib/documentVersions";
 import {
   deleteFile,
@@ -14,6 +15,10 @@ import {
 } from "../lib/storage";
 import { docxToPdf, convertedPdfKey } from "../lib/convert";
 import { checkProjectAccess } from "../lib/access";
+import {
+  buildProjectExportManifest,
+  projectManifestFilename,
+} from "../lib/userDataExport";
 import { singleFileUpload } from "../lib/upload";
 import { deleteUserProjects } from "../lib/userDataCleanup";
 
@@ -424,6 +429,36 @@ projectsRouter.get("/:projectId/documents", requireAuth, async (req, res) => {
   res.json(docsTyped);
 });
 
+// GET /projects/:projectId/export — tamper-evident manifest of the
+// project's documents: every version with its content_sha256 plus the
+// accept/reject trail. Recompute a downloaded file's SHA-256 and compare
+// to verify an export matches what the workspace held.
+projectsRouter.get("/:projectId/export", requireAuth, async (req, res) => {
+  const userId = res.locals.userId as string;
+  const userEmail = res.locals.userEmail as string | undefined;
+  const { projectId } = req.params;
+  const db = createServerSupabase();
+
+  const access = await checkProjectAccess(projectId, userId, userEmail, db);
+  if (!access.ok)
+    return void res.status(404).json({ detail: "Project not found" });
+
+  try {
+    const data = await buildProjectExportManifest(db, projectId);
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${projectManifestFilename(projectId)}"`,
+    );
+    res.json(data);
+  } catch (err) {
+    console.error("[projects/export] failed", { projectId, error: String(err) });
+    res
+      .status(500)
+      .json({ detail: "Failed to build project export manifest" });
+  }
+});
+
 // POST /projects/:projectId/documents/:documentId — assign or copy existing doc into project
 projectsRouter.post(
   "/:projectId/documents/:documentId",
@@ -561,6 +596,7 @@ projectsRouter.post(
               (srcV.size_bytes as number | null) ?? doc.size_bytes ?? null,
             page_count:
               (srcV.page_count as number | null) ?? doc.page_count ?? null,
+            content_sha256: contentSha256(srcBytes),
           })
           .select("id")
           .single();
@@ -972,6 +1008,7 @@ export async function handleDocumentUpload(
         file_type: suffix,
         size_bytes: content.byteLength,
         page_count: pageCount,
+        content_sha256: contentSha256(content),
       })
       .select("id")
       .single();


### PR DESCRIPTION
## Summary

Exports today cannot prove that a document version is the file the workspace actually held. There are no content hashes anywhere in the schema, so once a file leaves Mike there is no way to tell an untouched export from a modified one. This PR stores a SHA-256 of every version's bytes at write time and adds a per-project export manifest, making any export of those files tamper-evident at the source.

## Changes

- `oss-migrations/20260612_document_version_content_sha256.sql` and `schema.sql`: nullable `content_sha256 text` column on `document_versions`. Existing rows stay unhashed until their bytes are next rewritten.
- `lib/documentVersions.ts`: one small helper, `contentSha256(bytes)`, SHA-256 hex over `ArrayBuffer | ArrayBufferView`.
- Hash set at every version write: upload (standalone and project), versions/upload, versions/copy, versions/replace, copy-into-project, assistant edit, generated docs, and the bulk document replication path in `chatTools.ts`.
- Hash refreshed on the in-place byte rewrites: edit accept/reject resolution, turn-version reuse in `runEditDocument`, and version replace.
- `lib/userDataExport.ts`: `buildProjectExportManifest` follows the same builder pattern as the account export. Stable field order so manifests diff cleanly.
- `routes/projects.ts`: `GET /projects/:projectId/export`, same `checkProjectAccess` gate and Content-Disposition idiom as the user export routes. The manifest carries project id/name, every version's `content_sha256`, `source` provenance, `created_at`, and the `document_edits` accept/reject trail (references only, no edit text).

## Why

Verification becomes one command: `shasum -a 256 file.docx` against the manifest. This also seems useful for the local/desktop direction and the questions firms ask before adopting a tool like this ("can you prove what was reviewed and accepted"), and hashes at write time are the cheapest possible foundation for that. Zero behavior change otherwise: no existing endpoint's response changes, the column is nullable, and unhashed legacy rows simply show `null` in the manifest.

A storage backfill for legacy rows would need to stream every object from S3, so I left it out rather than guess at how you would want to batch it. Happy to follow up with one if useful.

## Testing

- `npm run build --prefix backend` passes (tsc, no errors).
- Hash helper smoke-tested against the known SHA-256 vector for "abc" across `Buffer`, `ArrayBuffer`, and offset `Uint8Array` views (several call sites pass views into larger buffers, e.g. multer's `file.buffer`).
- No test framework exists in `backend/`, so I did not introduce one for this.

I work on Legalise, a UK-side project on the accountability layer; happy to align this manifest with anything you'd rather see.

Andy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

