### PR TITLE
Run Mike locally without Supabase, auth, or R2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ next-env.d.ts
 .DS_Store
 .vercel
 coverage
+
+# Local Postgres data (docker compose) and on-disk file storage
+pgdata/
+backend/uploads/

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -1,0 +1,79 @@
+# Running Mike locally (no Supabase, no auth, no R2)
+
+This setup runs Mike entirely on your machine with **zero external services**:
+
+- **Database:** a plain Postgres (via Docker Compose) instead of Supabase.
+- **Auth:** disabled — every request is the single hardcoded local user.
+- **File storage:** local disk (`backend/uploads/`) instead of Cloudflare R2 / S3.
+
+All Mike functionality, routes, and the frontend UI are unchanged.
+
+## 1. Start Postgres
+
+```bash
+docker compose up -d
+```
+
+This starts Postgres 16 with database/user/password all `mike`, on `localhost:5432`,
+and **auto-applies the schema on first boot** (it mounts
+`backend/migrations/000_one_shot_schema.sql` into the container's init dir).
+
+If you ever need to (re)apply the schema manually:
+
+```bash
+psql postgresql://mike:mike@localhost:5432/mike -f backend/migrations/000_one_shot_schema.sql
+```
+
+> The one-shot migration wraps the original Supabase schema (`backend/schema.sql`)
+> with a tiny `auth` shim: it creates an `auth.users` table plus the
+> `anon`/`authenticated`/`service_role` roles the schema's GRANTs reference, then
+> seeds a single local user. It must run as a Postgres **superuser** — the
+> docker-compose Postgres user is one by default.
+
+## 2. Configure environment
+
+Copy the examples (already filled with working local defaults):
+
+```bash
+cp backend/.env.example backend/.env          # or use the committed backend/.env
+cp frontend/.env.local.example frontend/.env.local
+```
+
+Set `ANTHROPIC_API_KEY` (and optionally `GEMINI_API_KEY` / `OPENAI_API_KEY`) in
+`backend/.env` if you want the chat/agent features to work.
+
+## 3. Run the apps
+
+```bash
+npm install --prefix backend
+npm install --prefix frontend
+
+npm run dev --prefix backend     # http://localhost:3001
+npm run dev --prefix frontend    # http://localhost:3000
+```
+
+Open <http://localhost:3000> — the app loads directly, no login screen, as a
+single `local@localhost` user.
+
+## The "local user"
+
+Every `user_id` column in the schema is a `uuid`, so the local user is the fixed
+UUID **`00000000-0000-0000-0000-000000000001`** (email `local@localhost`) rather
+than a plain string. It's defined once in `backend/src/middleware/auth.ts`
+(`LOCAL_USER_ID`) and seeded by the migration.
+
+## What changed vs. the upstream (Supabase) setup
+
+| Concern | Before | Now |
+| --- | --- | --- |
+| DB client | `@supabase/supabase-js` | `pg` behind a PostgREST-compatible shim in `backend/src/lib/supabase.ts` (same `createServerSupabase()` API) |
+| Auth | Supabase JWT in `requireAuth` | passthrough injecting the local user |
+| File storage | Cloudflare R2 (`@aws-sdk/client-s3`) in `backend/src/lib/storage.ts` | local disk under `backend/uploads/`, same function signatures |
+| Download URLs | R2 presigned URLs | absolute `/download/<hmac-token>` links served by the backend; files also browsable under `/uploads` |
+| Frontend auth | Supabase client + session checks | `frontend/src/lib/supabase.ts` stub returning a fixed local session |
+
+## Future: Python chat backend
+
+The chat route (`/projects/:id/chat`) is kept independent of document/storage
+routing so it can later be proxied to a separate Python (FastAPI + LangGraph)
+service with a one-line change in the Express app.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,23 +1,27 @@
 PORT=3001
 FRONTEND_URL=http://localhost:3000
+# Backend's own externally reachable base URL — used to build absolute
+# download links for the frontend.
+PUBLIC_BASE_URL=http://localhost:3001
+
+# Local Postgres connection string (see docker-compose.yml at the repo root).
+# Auth is bypassed locally, so no Supabase project is required.
+DATABASE_URL=postgresql://mike:mike@localhost:5432/mike
 
 # HMAC key used to sign /download/:token URLs. Required at startup.
 # Generate with: openssl rand -hex 32
-# Use a dedicated secret distinct from SUPABASE_SECRET_KEY.
 DOWNLOAD_SIGNING_SECRET=replace-with-a-random-32-byte-hex-string
-SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_SECRET_KEY=your-supabase-service-role-key
 
-R2_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
-R2_ACCESS_KEY_ID=your-r2-access-key
-R2_SECRET_ACCESS_KEY=your-r2-secret-key
-R2_BUCKET_NAME=mike
+# Secret used to encrypt user-provided API keys at rest.
+USER_API_KEYS_ENCRYPTION_SECRET=your-long-random-secret
 
+# Optional: override the on-disk storage location (default: backend/uploads).
+# UPLOAD_DIR=
+
+# LLM provider keys
 GEMINI_API_KEY=your-gemini-key
 ANTHROPIC_API_KEY=your-anthropic-key
 OPENAI_API_KEY=your-openai-key
-RESEND_API_KEY=your-resend-key
-USER_API_KEYS_ENCRYPTION_SECRET=your-long-random-secret
 
 # Optional: enables higher-rate CourtListener case law/citation lookup tools.
 COURTLISTENER_API_TOKEN=your-courtlistener-token

--- a/backend/migrations/000_one_shot_schema.sql
+++ b/backend/migrations/000_one_shot_schema.sql
@@ -1,0 +1,495 @@
+-- =====================================================================
+-- Mike OSS — one-shot schema for a LOCAL, plain-Postgres setup.
+--
+-- This is the Supabase schema (backend/schema.sql) wrapped with a tiny
+-- "auth" shim so it applies on a vanilla Postgres instance with no
+-- Supabase services. It:
+--   1. Creates an `auth` schema + minimal `auth.users` table so the
+--      foreign keys and the on-signup trigger in the schema resolve.
+--   2. Runs the full application schema (tables, indexes, triggers).
+--   3. Seeds a single hardcoded local user. Inserting into auth.users
+--      fires handle_new_user(), which creates the matching user_profiles
+--      row automatically.
+--
+-- The local user's UUID matches LOCAL_USER_ID in backend/src/middleware/auth.ts.
+-- (auth is bypassed entirely; every request resolves to this user.)
+--
+-- Apply manually with:
+--   psql postgresql://mike:mike@localhost:5432/mike -f backend/migrations/000_one_shot_schema.sql
+-- or let docker-compose auto-apply it on first boot.
+-- =====================================================================
+
+create extension if not exists "pgcrypto";
+
+-- Supabase ships these roles by default; the application schema references
+-- them in its GRANT/REVOKE hardening. Create them locally as harmless,
+-- login-less roles so those statements apply cleanly. (No RLS policies are
+-- used locally — the backend owns the tables and bypasses RLS.)
+do $$ begin
+  if not exists (select from pg_roles where rolname = 'anon') then
+    create role anon nologin noinherit;
+  end if;
+  if not exists (select from pg_roles where rolname = 'authenticated') then
+    create role authenticated nologin noinherit;
+  end if;
+  if not exists (select from pg_roles where rolname = 'service_role') then
+    create role service_role nologin noinherit bypassrls;
+  end if;
+end $$;
+
+create schema if not exists auth;
+
+-- Minimal stand-in for Supabase's auth.users. Only the columns the
+-- application schema/triggers reference (id, email) are needed locally.
+create table if not exists auth.users (
+  id uuid primary key default gen_random_uuid(),
+  email text,
+  created_at timestamptz not null default now()
+);
+
+-- =====================================================================
+-- Application schema (verbatim from backend/schema.sql)
+-- =====================================================================
+
+-- Mike Supabase schema
+-- Use this for a fresh Supabase database. Existing deployments should continue
+-- to apply the incremental migration files in backend/oss-migrations instead.
+
+create extension if not exists "pgcrypto";
+
+-- ---------------------------------------------------------------------------
+-- User profiles
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.user_profiles (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null unique references auth.users(id) on delete cascade,
+  display_name text,
+  organisation text,
+  tier text not null default 'Free',
+  message_credits_used integer not null default 0,
+  credits_reset_date timestamptz not null default (now() + interval '30 days'),
+  title_model text,
+  tabular_model text not null default 'gemini-3-flash-preview',
+  quote_model text,
+  mfa_on_login boolean not null default false,
+  legal_research_us boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_user_profiles_user
+  on public.user_profiles(user_id);
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.user_profiles (user_id)
+  values (new.id)
+  on conflict (user_id) do nothing;
+  return new;
+exception when others then
+  -- Never block signup if the profile insert fails.
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute procedure public.handle_new_user();
+
+create table if not exists public.user_api_keys (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  provider text not null check (provider in ('claude', 'gemini', 'openai', 'openrouter', 'courtlistener')),
+  encrypted_key text not null,
+  iv text not null,
+  auth_tag text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(user_id, provider)
+);
+
+create index if not exists idx_user_api_keys_user
+  on public.user_api_keys(user_id);
+
+alter table public.user_api_keys enable row level security;
+
+-- ---------------------------------------------------------------------------
+-- Projects and documents
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.projects (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null,
+  name text not null,
+  cm_number text,
+  visibility text not null default 'private',
+  shared_with jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_projects_user
+  on public.projects(user_id);
+
+create index if not exists projects_shared_with_idx
+  on public.projects using gin (shared_with);
+
+create table if not exists public.project_subfolders (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  user_id text not null,
+  name text not null,
+  parent_folder_id uuid references public.project_subfolders(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_project_subfolders_project
+  on public.project_subfolders(project_id);
+
+create table if not exists public.documents (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid references public.projects(id) on delete cascade,
+  user_id text not null,
+  status text not null default 'pending',
+  folder_id uuid references public.project_subfolders(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_documents_user_project
+  on public.documents(user_id, project_id);
+
+create index if not exists idx_documents_project_folder
+  on public.documents(project_id, folder_id);
+
+create table if not exists public.document_versions (
+  id uuid primary key default gen_random_uuid(),
+  document_id uuid not null references public.documents(id) on delete cascade,
+  storage_path text,
+  pdf_storage_path text,
+  source text not null default 'upload',
+  version_number integer,
+  filename text,
+  file_type text,
+  size_bytes integer,
+  page_count integer,
+  deleted_at timestamptz,
+  deleted_by uuid,
+  created_at timestamptz not null default now(),
+  constraint document_versions_source_check
+    check (source = any (array[
+      'upload'::text,
+      'user_upload'::text,
+      'assistant_edit'::text,
+      'user_accept'::text,
+      'user_reject'::text,
+      'generated'::text
+    ]))
+);
+
+create index if not exists document_versions_document_id_idx
+  on public.document_versions(document_id, created_at desc);
+
+create index if not exists document_versions_active_document_id_idx
+  on public.document_versions(document_id, created_at desc)
+  where deleted_at is null;
+
+create index if not exists document_versions_doc_vnum_idx
+  on public.document_versions(document_id, version_number);
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'document_versions_doc_version_unique'
+      and conrelid = 'public.document_versions'::regclass
+  ) then
+    alter table public.document_versions
+      add constraint document_versions_doc_version_unique
+      unique (document_id, version_number);
+  end if;
+end;
+$$;
+
+alter table public.documents
+  add column if not exists current_version_id uuid
+  references public.document_versions(id) on delete set null;
+
+create table if not exists public.document_edits (
+  id uuid primary key default gen_random_uuid(),
+  document_id uuid not null references public.documents(id) on delete cascade,
+  chat_message_id uuid,
+  version_id uuid not null references public.document_versions(id) on delete cascade,
+  change_id text not null,
+  del_w_id text,
+  ins_w_id text,
+  deleted_text text not null default '',
+  inserted_text text not null default '',
+  context_before text,
+  context_after text,
+  status text not null default 'pending'
+    check (status = any (array[
+      'pending'::text,
+      'accepted'::text,
+      'rejected'::text
+    ])),
+  created_at timestamptz not null default now(),
+  resolved_at timestamptz
+);
+
+create index if not exists document_edits_document_id_idx
+  on public.document_edits(document_id, created_at desc);
+
+create index if not exists document_edits_message_id_idx
+  on public.document_edits(chat_message_id);
+
+create index if not exists document_edits_version_id_idx
+  on public.document_edits(version_id);
+
+-- ---------------------------------------------------------------------------
+-- Workflows
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.workflows (
+  id uuid primary key default gen_random_uuid(),
+  user_id text,
+  title text not null,
+  type text not null,
+  prompt_md text,
+  columns_config jsonb,
+  practice text,
+  is_system boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_workflows_user
+  on public.workflows(user_id);
+
+create table if not exists public.hidden_workflows (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null,
+  workflow_id text not null,
+  created_at timestamptz not null default now(),
+  unique(user_id, workflow_id)
+);
+
+create index if not exists idx_hidden_workflows_user
+  on public.hidden_workflows(user_id);
+
+create table if not exists public.workflow_shares (
+  id uuid primary key default gen_random_uuid(),
+  workflow_id uuid not null references public.workflows(id) on delete cascade,
+  shared_by_user_id text not null,
+  shared_with_email text not null,
+  allow_edit boolean not null default false,
+  created_at timestamptz not null default now(),
+  constraint workflow_shares_workflow_email_unique
+    unique(workflow_id, shared_with_email)
+);
+
+create index if not exists workflow_shares_workflow_id_idx
+  on public.workflow_shares(workflow_id);
+
+create index if not exists workflow_shares_email_idx
+  on public.workflow_shares(shared_with_email);
+
+-- ---------------------------------------------------------------------------
+-- Assistant chats
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.chats (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid references public.projects(id) on delete cascade,
+  user_id text not null,
+  title text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_chats_user
+  on public.chats(user_id);
+
+create index if not exists idx_chats_project
+  on public.chats(project_id);
+
+create table if not exists public.chat_messages (
+  id uuid primary key default gen_random_uuid(),
+  chat_id uuid not null references public.chats(id) on delete cascade,
+  role text not null,
+  content jsonb,
+  files jsonb,
+  annotations jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_chat_messages_chat
+  on public.chat_messages(chat_id);
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'document_edits_chat_message_id_fkey'
+      and conrelid = 'public.document_edits'::regclass
+  ) then
+    alter table public.document_edits
+      add constraint document_edits_chat_message_id_fkey
+      foreign key (chat_message_id)
+      references public.chat_messages(id)
+      on delete set null;
+  end if;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Tabular reviews
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.tabular_reviews (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid references public.projects(id) on delete cascade,
+  user_id text not null,
+  title text,
+  columns_config jsonb,
+  document_ids jsonb,
+  workflow_id uuid references public.workflows(id) on delete set null,
+  practice text,
+  shared_with jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_tabular_reviews_user
+  on public.tabular_reviews(user_id);
+
+create index if not exists idx_tabular_reviews_project
+  on public.tabular_reviews(project_id);
+
+create index if not exists tabular_reviews_shared_with_idx
+  on public.tabular_reviews using gin (shared_with);
+
+create table if not exists public.tabular_cells (
+  id uuid primary key default gen_random_uuid(),
+  review_id uuid not null references public.tabular_reviews(id) on delete cascade,
+  document_id uuid not null references public.documents(id) on delete cascade,
+  column_index integer not null,
+  content text,
+  citations jsonb,
+  status text not null default 'pending',
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_tabular_cells_review
+  on public.tabular_cells(review_id, document_id, column_index);
+
+create table if not exists public.tabular_review_chats (
+  id uuid primary key default gen_random_uuid(),
+  review_id uuid not null references public.tabular_reviews(id) on delete cascade,
+  user_id text not null,
+  title text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists tabular_review_chats_review_idx
+  on public.tabular_review_chats(review_id, updated_at desc);
+
+create index if not exists tabular_review_chats_user_idx
+  on public.tabular_review_chats(user_id);
+
+create table if not exists public.tabular_review_chat_messages (
+  id uuid primary key default gen_random_uuid(),
+  chat_id uuid not null references public.tabular_review_chats(id) on delete cascade,
+  role text not null,
+  content jsonb,
+  annotations jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists tabular_review_chat_messages_chat_idx
+  on public.tabular_review_chat_messages(chat_id, created_at);
+
+-- ---------------------------------------------------------------------------
+-- CourtListener bulk-data indexes
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.courtlistener_citation_index (
+  id bigint primary key,
+  volume text not null,
+  reporter text not null,
+  page text not null,
+  type integer,
+  cluster_id bigint not null,
+  date_created timestamptz,
+  date_modified timestamptz
+);
+
+create index if not exists courtlistener_citation_lookup_idx
+  on public.courtlistener_citation_index(volume, reporter, page);
+
+create index if not exists courtlistener_citation_cluster_idx
+  on public.courtlistener_citation_index(cluster_id);
+
+alter table public.courtlistener_citation_index enable row level security;
+
+create table if not exists public.courtlistener_opinion_cluster_index (
+  id bigint primary key,
+  case_name text,
+  case_name_short text,
+  case_name_full text,
+  slug text,
+  date_filed date,
+  citation_count integer,
+  precedential_status text,
+  filepath_pdf_harvard text,
+  filepath_json_harvard text,
+  docket_id bigint
+);
+
+alter table public.courtlistener_opinion_cluster_index enable row level security;
+
+-- ---------------------------------------------------------------------------
+-- Direct client grant hardening
+-- ---------------------------------------------------------------------------
+--
+-- The frontend uses Supabase directly only for authentication. Application
+-- data access goes through the backend API with the service role after the
+-- backend verifies the user's JWT. Do not grant the browser anon/authenticated
+-- roles direct table privileges for backend-owned data.
+
+revoke all on public.user_profiles from anon, authenticated;
+revoke all on public.projects from anon, authenticated;
+revoke all on public.project_subfolders from anon, authenticated;
+revoke all on public.documents from anon, authenticated;
+revoke all on public.document_versions from anon, authenticated;
+revoke all on public.document_edits from anon, authenticated;
+revoke all on public.workflows from anon, authenticated;
+revoke all on public.hidden_workflows from anon, authenticated;
+revoke all on public.workflow_shares from anon, authenticated;
+revoke all on public.chats from anon, authenticated;
+revoke all on public.chat_messages from anon, authenticated;
+revoke all on public.tabular_reviews from anon, authenticated;
+revoke all on public.tabular_cells from anon, authenticated;
+revoke all on public.tabular_review_chats from anon, authenticated;
+revoke all on public.tabular_review_chat_messages from anon, authenticated;
+revoke all on public.user_api_keys from anon, authenticated;
+revoke all on public.courtlistener_citation_index from anon, authenticated;
+revoke all on public.courtlistener_opinion_cluster_index from anon, authenticated;
+
+-- =====================================================================
+-- Seed the single local user. The on_auth_user_created trigger creates
+-- the corresponding public.user_profiles row.
+-- =====================================================================
+
+insert into auth.users (id, email)
+values ('00000000-0000-0000-0000-000000000001', 'local@localhost')
+on conflict (id) do nothing;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,12 +7,14 @@
     "": {
       "name": "mike-backend",
       "version": "1.0.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
         "@aws-sdk/client-s3": "^3.787.0",
         "@aws-sdk/s3-request-presigner": "^3.787.0",
         "@google/genai": "^1.50.1",
         "@supabase/supabase-js": "^2.49.4",
+        "@types/pg": "^8.20.0",
         "cors": "^2.8.5",
         "docx": "^9.5.0",
         "dotenv": "^17.4.1",
@@ -26,6 +28,7 @@
         "mammoth": "^1.9.0",
         "multer": "^1.4.5-lts.2",
         "pdfjs-dist": "^4.10.38",
+        "pg": "^8.21.0",
         "resend": "^4.5.1"
       },
       "devDependencies": {
@@ -2689,6 +2692,17 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
@@ -4270,6 +4284,134 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
@@ -4632,6 +4774,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "mammoth": "^1.9.0",
     "multer": "^1.4.5-lts.2",
     "pdfjs-dist": "^4.10.38",
+    "pg": "^8.21.0",
     "resend": "^4.5.1"
   },
   "devDependencies": {
@@ -33,6 +34,7 @@
     "@types/express": "^4.17.21",
     "@types/multer": "^1.4.12",
     "@types/node": "^22.14.1",
+    "@types/pg": "^8.20.0",
     "prettier": "^3.8.1",
     "tsx": "^4.19.3",
     "typescript": "^5.8.3"

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,8 +1,10 @@
 import "dotenv/config";
+import path from "path";
 import express from "express";
 import cors from "cors";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
+import { ensureUploadDir } from "./lib/storage";
 import { chatRouter } from "./routes/chat";
 import { projectsRouter } from "./routes/projects";
 import { projectChatRouter } from "./routes/projectChat";
@@ -156,8 +158,17 @@ app.use("/users", userRouter);
 app.use("/download", downloadsRouter);
 app.use("/case-law", caseLawRouter);
 
+// Local on-disk file storage. Files are written under backend/uploads by
+// src/lib/storage.ts; this serves them directly (alongside the signed
+// /download routes used for attachment downloads).
+app.use("/uploads", express.static(path.join(__dirname, "../uploads")));
+
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
-app.listen(PORT, () => {
-  console.log(`Mike backend running on port ${PORT}`);
-});
+ensureUploadDir()
+  .catch((err) => console.error("Failed to create uploads directory", err))
+  .finally(() => {
+    app.listen(PORT, () => {
+      console.log(`Mike backend running on port ${PORT}`);
+    });
+  });

--- a/backend/src/lib/storage.ts
+++ b/backend/src/lib/storage.ts
@@ -1,56 +1,54 @@
 /**
- * Cloudflare R2 storage utilities for Mike document management.
- * R2 is S3-compatible — uses @aws-sdk/client-s3.
+ * Local on-disk file storage for Mike document management.
  *
- * Required env vars:
- *   R2_ENDPOINT_URL     — https://<account-id>.r2.cloudflarestorage.com
- *   R2_ACCESS_KEY_ID    — R2 API token (Access Key ID)
- *   R2_SECRET_ACCESS_KEY — R2 API token (Secret Access Key)
- *   R2_BUCKET_NAME      — bucket name (default: "mike")
+ * Drop-in replacement for the previous Cloudflare R2 / S3 backend: same
+ * exported functions and signatures, so no calling code changed. Files are
+ * stored under an `uploads/` directory in the backend, keyed by the same
+ * "documents/<user>/<doc>/…" paths that were used as R2 object keys.
+ *
+ * Env vars:
+ *   UPLOAD_DIR        — override the storage directory (default: backend/uploads)
+ *   PUBLIC_BASE_URL   — backend's externally reachable base URL, used to build
+ *                       absolute download links (default: http://localhost:<PORT>)
  */
 
-import {
-  S3Client,
-  PutObjectCommand,
-  DeleteObjectCommand,
-  ListObjectsV2Command,
-} from "@aws-sdk/client-s3";
-import * as S3Commands from "@aws-sdk/client-s3";
-import { getSignedUrl as awsGetSignedUrl } from "@aws-sdk/s3-request-presigner";
+import fs from "fs/promises";
+import path from "path";
+import { buildDownloadUrl } from "./downloadTokens";
 
-const GetObjectCommand = (S3Commands as any).GetObjectCommand;
+const UPLOAD_DIR =
+  process.env.UPLOAD_DIR || path.resolve(__dirname, "../../uploads");
 
-let cachedClient: S3Client | undefined;
+// Local disk is always available — no external service to configure.
+export const storageEnabled = true;
 
-function getClient(): S3Client {
-  if (!cachedClient) {
-    cachedClient = new S3Client({
-      region: "auto",
-      endpoint: process.env.R2_ENDPOINT_URL!,
-      forcePathStyle: true,
-      credentials: {
-        accessKeyId: process.env.R2_ACCESS_KEY_ID!,
-        secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
-      },
-    });
-  }
-  return cachedClient;
+function publicBaseUrl(): string {
+  return (
+    process.env.PUBLIC_BASE_URL ||
+    `http://localhost:${process.env.PORT ?? 3001}`
+  );
 }
 
-const BUCKET = process.env.R2_BUCKET_NAME ?? "mike";
-
-export const storageEnabled = Boolean(
-  process.env.R2_ENDPOINT_URL &&
-  process.env.R2_ACCESS_KEY_ID &&
-  process.env.R2_SECRET_ACCESS_KEY,
-);
-
-function requireStorageConfig(): void {
-  if (!storageEnabled) {
-    throw new Error(
-      "R2_ENDPOINT_URL, R2_ACCESS_KEY_ID, and R2_SECRET_ACCESS_KEY must be set",
-    );
+/**
+ * Map a storage key to an absolute path inside UPLOAD_DIR, guarding against
+ * path traversal. Keys are generated internally (see the *Key helpers below)
+ * so this is belt-and-suspenders.
+ */
+function resolveKeyPath(key: string): string {
+  const normalized = path
+    .normalize(key)
+    .replace(/^(\.\.(\/|\\|$))+/, "")
+    .replace(/^[/\\]+/, "");
+  const full = path.resolve(UPLOAD_DIR, normalized);
+  if (full !== UPLOAD_DIR && !full.startsWith(UPLOAD_DIR + path.sep)) {
+    throw new Error("Invalid storage key");
   }
+  return full;
+}
+
+/** Ensure the base uploads directory exists. Called on startup. */
+export async function ensureUploadDir(): Promise<void> {
+  await fs.mkdir(UPLOAD_DIR, { recursive: true });
 }
 
 // ---------------------------------------------------------------------------
@@ -60,18 +58,11 @@ function requireStorageConfig(): void {
 export async function uploadFile(
   key: string,
   content: ArrayBuffer,
-  contentType: string,
+  _contentType: string,
 ): Promise<void> {
-  requireStorageConfig();
-  const client = getClient();
-  await client.send(
-    new PutObjectCommand({
-      Bucket: BUCKET,
-      Key: key,
-      Body: Buffer.from(content),
-      ContentType: contentType,
-    }),
-  );
+  const filePath = resolveKeyPath(key);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, Buffer.from(content));
 }
 
 // ---------------------------------------------------------------------------
@@ -79,38 +70,41 @@ export async function uploadFile(
 // ---------------------------------------------------------------------------
 
 export async function downloadFile(key: string): Promise<ArrayBuffer | null> {
-  if (!storageEnabled) return null;
   try {
-    const client = getClient();
-    const response = (await client.send(
-      new GetObjectCommand({ Bucket: BUCKET, Key: key }),
-    )) as any;
-    if (!response.Body) return null;
-    const bytes = await response.Body.transformToByteArray();
-    return bytes.buffer as ArrayBuffer;
+    const filePath = resolveKeyPath(key);
+    const buf = await fs.readFile(filePath);
+    return buf.buffer.slice(
+      buf.byteOffset,
+      buf.byteOffset + buf.byteLength,
+    ) as ArrayBuffer;
   } catch {
     return null;
   }
 }
 
 export async function listFiles(prefix: string): Promise<string[]> {
-  if (!storageEnabled) return [];
-  const client = getClient();
   const keys: string[] = [];
-  let ContinuationToken: string | undefined;
-  do {
-    const response = await client.send(
-      new ListObjectsV2Command({
-        Bucket: BUCKET,
-        Prefix: prefix,
-        ContinuationToken,
-      }),
-    );
-    for (const item of response.Contents ?? []) {
-      if (item.Key) keys.push(item.Key);
+
+  async function walk(dir: string): Promise<void> {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
     }
-    ContinuationToken = response.NextContinuationToken;
-  } while (ContinuationToken);
+    for (const entry of entries) {
+      const abs = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(abs);
+      } else {
+        // Reconstruct the forward-slash storage key relative to UPLOAD_DIR.
+        const key = path.relative(UPLOAD_DIR, abs).split(path.sep).join("/");
+        if (key.startsWith(prefix)) keys.push(key);
+      }
+    }
+  }
+
+  await walk(UPLOAD_DIR);
   return keys;
 }
 
@@ -119,39 +113,27 @@ export async function listFiles(prefix: string): Promise<string[]> {
 // ---------------------------------------------------------------------------
 
 export async function deleteFile(key: string): Promise<void> {
-  if (!storageEnabled) return;
-  const client = getClient();
-  await client.send(new DeleteObjectCommand({ Bucket: BUCKET, Key: key }));
+  try {
+    await fs.unlink(resolveKeyPath(key));
+  } catch {
+    // Already gone — nothing to do.
+  }
 }
 
 // ---------------------------------------------------------------------------
-// Signed URL (pre-signed for temporary direct access)
+// "Signed" URL — locally this is just an HMAC-signed /download link served by
+// the backend (see routes/downloads.ts). It streams the bytes with the right
+// Content-Disposition, so the previous presigned-URL behaviour is preserved.
 // ---------------------------------------------------------------------------
 
 export async function getSignedUrl(
   key: string,
-  expiresIn = 3600,
+  _expiresIn = 3600,
   downloadFilename?: string,
 ): Promise<string | null> {
-  if (!storageEnabled) return null;
-  try {
-    const client = getClient();
-    // Override the response Content-Disposition so the browser uses this
-    // filename on download, instead of the last path segment of the R2 key
-    // (which includes the document UUID). The `download` attribute on <a>
-    // is ignored for cross-origin URLs, so we have to set it server-side.
-    const responseContentDisposition = downloadFilename
-      ? buildContentDisposition("attachment", downloadFilename)
-      : undefined;
-    const command = new GetObjectCommand({
-      Bucket: BUCKET,
-      Key: key,
-      ResponseContentDisposition: responseContentDisposition,
-    }) as any;
-    return await awsGetSignedUrl(client, command, { expiresIn });
-  } catch {
-    return null;
-  }
+  const filename =
+    downloadFilename || normalizeDownloadFilename(key.split("/").pop() ?? "download");
+  return `${publicBaseUrl()}${buildDownloadUrl(key, filename)}`;
 }
 
 export function normalizeDownloadFilename(name: string): string {
@@ -182,7 +164,7 @@ export function buildContentDisposition(
 }
 
 // ---------------------------------------------------------------------------
-// Storage key helpers
+// Storage key helpers (unchanged)
 // ---------------------------------------------------------------------------
 
 export function storageKey(

--- a/backend/src/lib/supabase.ts
+++ b/backend/src/lib/supabase.ts
@@ -1,44 +1,668 @@
-import { createClient } from "@supabase/supabase-js";
-
 /**
- * Server-side Supabase client using the service role key.
- * Bypasses RLS — only use in API routes after verifying the user.
+ * Local Postgres adapter — drop-in replacement for the Supabase client.
+ *
+ * The rest of the codebase talks to the database through a small subset of
+ * the Supabase / PostgREST query-builder API:
+ *
+ *   db.from(table).select(cols).eq(...).order(...).limit(...)        → { data, error }
+ *   db.from(table).select(cols).eq(...).single() / .maybeSingle()
+ *   db.from(table).insert(rows).select(cols).single()
+ *   db.from(table).update(obj).eq(...).select(...)
+ *   db.from(table).delete().eq(...)
+ *   db.from(table).upsert(rows, { onConflict })
+ *   db.auth.admin.{ getUserById, listUsers, deleteUser }
+ *
+ * This module reimplements exactly that surface on top of `pg`, pointed at a
+ * local Postgres database. `createServerSupabase()` keeps its name and
+ * signature so no calling code had to change.
+ *
+ * Connection string comes from DATABASE_URL, defaulting to the local
+ * docker-compose Postgres.
  */
-export function createServerSupabase() {
-  const url = process.env.SUPABASE_URL || "";
-  const key = process.env.SUPABASE_SECRET_KEY || "";
-  if (!url || !key) {
-    throw new Error("SUPABASE_URL and SUPABASE_SECRET_KEY must be set");
-  }
-  return createClient(url, key, { auth: { persistSession: false } });
-}
 
-/**
- * Extract and verify the Supabase JWT from the Authorization header.
- * Returns the user's UUID string, or throws a Response with 401.
- */
-export async function getUserIdFromRequest(req: Request): Promise<string> {
-  const auth = req.headers.get("authorization") ?? "";
-  if (!auth.startsWith("Bearer ")) {
-    throw new Response("Missing or invalid Authorization header", {
-      status: 401,
+import { Pool, type PoolClient } from "pg";
+
+const DEFAULT_DATABASE_URL = "postgresql://mike:mike@localhost:5432/mike";
+
+let pool: Pool | undefined;
+
+function getPool(): Pool {
+  if (!pool) {
+    pool = new Pool({
+      connectionString: process.env.DATABASE_URL || DEFAULT_DATABASE_URL,
     });
   }
-  const token = auth.slice(7).trim();
-
-  const supabaseUrl = process.env.SUPABASE_URL || "";
-  const serviceKey = process.env.SUPABASE_SECRET_KEY || "";
-
-  if (!supabaseUrl || !serviceKey) {
-    throw new Response("Server auth is not configured", { status: 500 });
-  }
-
-  const admin = createClient(supabaseUrl, serviceKey, {
-    auth: { persistSession: false },
-  });
-  const { data } = await admin.auth.getUser(token);
-  if (!data.user) {
-    throw new Response("Invalid or expired token", { status: 401 });
-  }
-  return data.user.id;
+  return pool;
 }
+
+export type DbError = { message: string; code?: string } | null;
+
+export type DbResult<T = any> = {
+  data: T;
+  error: DbError;
+  count?: number | null;
+};
+
+/** Resolved shape of a list query (select / insert / update / delete). */
+export type ListResult = {
+  data: any[] | null;
+  error: DbError;
+  count?: number | null;
+};
+
+/** Resolved shape of `.single()` / `.maybeSingle()`. */
+export type SingleResult = {
+  data: any | null;
+  error: DbError;
+};
+
+type FilterClause = (params: unknown[]) => string;
+
+// ---------------------------------------------------------------------------
+// Value / identifier helpers
+// ---------------------------------------------------------------------------
+
+function quoteIdent(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed === "*") return "*";
+  return `"${trimmed.replace(/"/g, '""')}"`;
+}
+
+function buildColumnList(cols: string | null | undefined): string {
+  if (!cols || cols.trim() === "" || cols.trim() === "*") return "*";
+  return cols
+    .split(",")
+    .map((c) => quoteIdent(c))
+    .join(", ");
+}
+
+/**
+ * Push a value as a bound parameter and return its placeholder. Objects and
+ * arrays are JSON-encoded and cast to jsonb (every array/object column in the
+ * schema is jsonb); Dates become ISO strings; scalars pass through.
+ */
+function placeholder(value: unknown, params: unknown[]): string {
+  if (value !== null && value !== undefined && typeof value === "object") {
+    if (value instanceof Date) {
+      params.push(value.toISOString());
+      return `$${params.length}`;
+    }
+    params.push(JSON.stringify(value));
+    return `$${params.length}::jsonb`;
+  }
+  params.push(value ?? null);
+  return `$${params.length}`;
+}
+
+// ---------------------------------------------------------------------------
+// Query builder
+// ---------------------------------------------------------------------------
+
+type Op = "select" | "insert" | "update" | "delete";
+
+class QueryBuilder implements PromiseLike<ListResult> {
+  private op: Op = "select";
+  private selectArg: string | null = null;
+  private wantsReturning = false;
+  private insertRows: Record<string, any>[] = [];
+  private updateValues: Record<string, any> = {};
+  private conflictColumns: string[] | null = null;
+  private ignoreDuplicates = false;
+  private filterClauses: FilterClause[] = [];
+  private orClause: FilterClause | null = null;
+  private orderParts: {
+    col: string;
+    ascending: boolean;
+    nullsFirst?: boolean;
+  }[] = [];
+  private limitN: number | null = null;
+  private offsetN: number | null = null;
+  private singleMode: false | "single" | "maybe" = false;
+  private countMode = false;
+  private headMode = false;
+
+  constructor(private readonly table: string) {}
+
+  // -- query kind ----------------------------------------------------------
+
+  select(
+    cols?: string,
+    options?: { count?: "exact" | "planned" | "estimated"; head?: boolean },
+  ): this {
+    // After a mutation, .select() just requests RETURNING; otherwise it
+    // starts a SELECT query.
+    this.selectArg = cols ?? "*";
+    this.wantsReturning = true;
+    if (options?.count) this.countMode = true;
+    if (options?.head) this.headMode = true;
+    return this;
+  }
+
+  insert(rows: Record<string, any> | Record<string, any>[]): this {
+    this.op = "insert";
+    this.insertRows = Array.isArray(rows) ? rows : [rows];
+    return this;
+  }
+
+  update(values: Record<string, any>): this {
+    this.op = "update";
+    this.updateValues = values;
+    return this;
+  }
+
+  delete(): this {
+    this.op = "delete";
+    return this;
+  }
+
+  upsert(
+    rows: Record<string, any> | Record<string, any>[],
+    options?: { onConflict?: string; ignoreDuplicates?: boolean },
+  ): this {
+    this.op = "insert";
+    this.insertRows = Array.isArray(rows) ? rows : [rows];
+    this.conflictColumns = options?.onConflict
+      ? options.onConflict.split(",").map((c) => c.trim())
+      : [];
+    this.ignoreDuplicates = options?.ignoreDuplicates === true;
+    return this;
+  }
+
+  // -- filters -------------------------------------------------------------
+
+  eq(column: string, value: unknown): this {
+    if (value === null) {
+      this.filterClauses.push(() => `${quoteIdent(column)} IS NULL`);
+    } else {
+      this.filterClauses.push(
+        (p) => `${quoteIdent(column)} = ${placeholder(value, p)}`,
+      );
+    }
+    return this;
+  }
+
+  neq(column: string, value: unknown): this {
+    if (value === null) {
+      this.filterClauses.push(() => `${quoteIdent(column)} IS NOT NULL`);
+    } else {
+      this.filterClauses.push(
+        (p) => `${quoteIdent(column)} <> ${placeholder(value, p)}`,
+      );
+    }
+    return this;
+  }
+
+  gt(column: string, value: unknown): this {
+    this.filterClauses.push(
+      (p) => `${quoteIdent(column)} > ${placeholder(value, p)}`,
+    );
+    return this;
+  }
+
+  gte(column: string, value: unknown): this {
+    this.filterClauses.push(
+      (p) => `${quoteIdent(column)} >= ${placeholder(value, p)}`,
+    );
+    return this;
+  }
+
+  lt(column: string, value: unknown): this {
+    this.filterClauses.push(
+      (p) => `${quoteIdent(column)} < ${placeholder(value, p)}`,
+    );
+    return this;
+  }
+
+  lte(column: string, value: unknown): this {
+    this.filterClauses.push(
+      (p) => `${quoteIdent(column)} <= ${placeholder(value, p)}`,
+    );
+    return this;
+  }
+
+  in(column: string, values: readonly unknown[]): this {
+    this.filterClauses.push((p) => {
+      if (!values || values.length === 0) return "1 = 0";
+      const placeholders = values.map((v) => placeholder(v, p)).join(", ");
+      return `${quoteIdent(column)} IN (${placeholders})`;
+    });
+    return this;
+  }
+
+  is(column: string, value: null | boolean): this {
+    this.filterClauses.push(() => {
+      if (value === null) return `${quoteIdent(column)} IS NULL`;
+      return `${quoteIdent(column)} IS ${value ? "TRUE" : "FALSE"}`;
+    });
+    return this;
+  }
+
+  not(column: string, operator: string, value: null | boolean): this {
+    this.filterClauses.push(() => {
+      if (operator === "is") {
+        if (value === null) return `${quoteIdent(column)} IS NOT NULL`;
+        return `${quoteIdent(column)} IS NOT ${value ? "TRUE" : "FALSE"}`;
+      }
+      // Unused by the codebase beyond `not(col, "is", null)`, but keep a
+      // sensible generic fallback.
+      return `NOT (${quoteIdent(column)} ${operator} ${value})`;
+    });
+    return this;
+  }
+
+  /**
+   * PostgREST-style `filter`. Only the `cs` (contains) operator on jsonb
+   * columns is used in this codebase (shared_with membership checks).
+   */
+  filter(column: string, operator: string, value: string): this {
+    this.filterClauses.push((p) => {
+      if (operator === "cs") {
+        // value is already a JSON string, e.g. '["a@b.com"]'
+        return `${quoteIdent(column)} @> ${pushRaw(value, p)}::jsonb`;
+      }
+      return `${quoteIdent(column)} ${operator} ${pushRaw(value, p)}`;
+    });
+    return this;
+  }
+
+  /**
+   * PostgREST `or` filter, e.g. "user_id.eq.X,project_id.in.(a,b,c)".
+   */
+  or(filterString: string): this {
+    this.orClause = (p) => buildOrClause(filterString, p);
+    return this;
+  }
+
+  // -- modifiers -----------------------------------------------------------
+
+  order(
+    column: string,
+    options?: { ascending?: boolean; nullsFirst?: boolean },
+  ): this {
+    this.orderParts.push({
+      col: column,
+      ascending: options?.ascending !== false,
+      nullsFirst: options?.nullsFirst,
+    });
+    return this;
+  }
+
+  limit(n: number): this {
+    this.limitN = n;
+    return this;
+  }
+
+  range(from: number, to: number): this {
+    this.offsetN = from;
+    this.limitN = to - from + 1;
+    return this;
+  }
+
+  // -- terminators ---------------------------------------------------------
+
+  single(): PromiseLike<SingleResult> {
+    this.singleMode = "single";
+    this.wantsReturning = true;
+    return this as unknown as PromiseLike<SingleResult>;
+  }
+
+  maybeSingle(): PromiseLike<SingleResult> {
+    this.singleMode = "maybe";
+    this.wantsReturning = true;
+    return this as unknown as PromiseLike<SingleResult>;
+  }
+
+  // -- SQL assembly --------------------------------------------------------
+
+  private buildWhere(params: unknown[]): string {
+    const clauses = this.filterClauses.map((fn) => fn(params));
+    if (this.orClause) clauses.push(this.orClause(params));
+    if (clauses.length === 0) return "";
+    return ` WHERE ${clauses.join(" AND ")}`;
+  }
+
+  private buildOrderLimit(): string {
+    let sql = "";
+    if (this.orderParts.length > 0) {
+      const parts = this.orderParts.map((o) => {
+        let part = `${quoteIdent(o.col)} ${o.ascending ? "ASC" : "DESC"}`;
+        if (o.nullsFirst !== undefined) {
+          part += o.nullsFirst ? " NULLS FIRST" : " NULLS LAST";
+        }
+        return part;
+      });
+      sql += ` ORDER BY ${parts.join(", ")}`;
+    }
+    if (this.limitN !== null) sql += ` LIMIT ${Math.max(0, this.limitN)}`;
+    if (this.offsetN !== null) sql += ` OFFSET ${Math.max(0, this.offsetN)}`;
+    return sql;
+  }
+
+  private buildSql(params: unknown[]): string {
+    const table = quoteIdent(this.table);
+    const returning = this.wantsReturning
+      ? ` RETURNING ${buildColumnList(this.selectArg)}`
+      : "";
+
+    if (this.op === "select") {
+      return (
+        `SELECT ${buildColumnList(this.selectArg)} FROM ${table}` +
+        this.buildWhere(params) +
+        this.buildOrderLimit()
+      );
+    }
+
+    if (this.op === "insert") {
+      const columnSet = new Set<string>();
+      for (const row of this.insertRows) {
+        for (const key of Object.keys(row)) columnSet.add(key);
+      }
+      const columns = Array.from(columnSet);
+      if (columns.length === 0) {
+        // INSERT of an empty object — fall back to default values.
+        return `INSERT INTO ${table} DEFAULT VALUES${returning}`;
+      }
+      const colSql = columns.map((c) => quoteIdent(c)).join(", ");
+      const rowsSql = this.insertRows
+        .map(
+          (row) =>
+            `(${columns
+              .map((c) =>
+                c in row ? placeholder(row[c], params) : "DEFAULT",
+              )
+              .join(", ")})`,
+        )
+        .join(", ");
+      let sql = `INSERT INTO ${table} (${colSql}) VALUES ${rowsSql}`;
+      if (this.conflictColumns !== null) {
+        const conflictCols = this.conflictColumns;
+        if (conflictCols.length === 0) {
+          sql += ` ON CONFLICT DO NOTHING`;
+        } else {
+          const updateCols = columns.filter((c) => !conflictCols.includes(c));
+          const target = conflictCols.map((c) => quoteIdent(c)).join(", ");
+          if (this.ignoreDuplicates || updateCols.length === 0) {
+            sql += ` ON CONFLICT (${target}) DO NOTHING`;
+          } else {
+            const setSql = updateCols
+              .map((c) => `${quoteIdent(c)} = EXCLUDED.${quoteIdent(c)}`)
+              .join(", ");
+            sql += ` ON CONFLICT (${target}) DO UPDATE SET ${setSql}`;
+          }
+        }
+      }
+      return sql + returning;
+    }
+
+    if (this.op === "update") {
+      const setSql = Object.keys(this.updateValues)
+        .map((c) => `${quoteIdent(c)} = ${placeholder(this.updateValues[c], params)}`)
+        .join(", ");
+      return (
+        `UPDATE ${table} SET ${setSql}` + this.buildWhere(params) + returning
+      );
+    }
+
+    // delete
+    return `DELETE FROM ${table}` + this.buildWhere(params) + returning;
+  }
+
+  // -- execution -----------------------------------------------------------
+
+  private async run(): Promise<DbResult> {
+    // Count queries (select with { count: ... }) run a separate count(*),
+    // and optionally the row query too (unless head: true).
+    if (this.op === "select" && this.countMode) {
+      try {
+        const countParams: unknown[] = [];
+        const where = this.buildWhere(countParams);
+        const countSql = `SELECT count(*)::int AS count FROM ${quoteIdent(
+          this.table,
+        )}${where}`;
+        const countRes = await getPool().query(countSql, countParams);
+        const count: number = countRes.rows[0]?.count ?? 0;
+
+        if (this.headMode) return { data: null, count, error: null };
+
+        const rowParams: unknown[] = [];
+        const rowsSql =
+          `SELECT ${buildColumnList(this.selectArg)} FROM ${quoteIdent(
+            this.table,
+          )}` +
+          this.buildWhere(rowParams) +
+          this.buildOrderLimit();
+        const rowsRes = await getPool().query(rowsSql, rowParams);
+        return { data: rowsRes.rows, count, error: null };
+      } catch (err: any) {
+        return {
+          data: null,
+          count: null,
+          error: { message: err?.message ?? String(err), code: err?.code },
+        };
+      }
+    }
+
+    const params: unknown[] = [];
+    let text: string;
+    try {
+      text = this.buildSql(params);
+    } catch (err: any) {
+      return { data: null, error: { message: err?.message ?? String(err) } };
+    }
+
+    try {
+      const result = await getPool().query(text, params);
+      const rows = result.rows ?? [];
+
+      if (this.singleMode === "single") {
+        if (rows.length === 1) return { data: rows[0], error: null };
+        return {
+          data: null,
+          error: {
+            code: "PGRST116",
+            message:
+              rows.length === 0
+                ? "JSON object requested, multiple (or no) rows returned"
+                : "Results contain more than one row",
+          },
+        };
+      }
+      if (this.singleMode === "maybe") {
+        if (rows.length === 0) return { data: null, error: null };
+        if (rows.length === 1) return { data: rows[0], error: null };
+        return {
+          data: null,
+          error: {
+            code: "PGRST116",
+            message: "Results contain more than one row",
+          },
+        };
+      }
+
+      // Mutations without a RETURNING clause resolve to null data (matches
+      // supabase-js, where you must chain .select() to get rows back).
+      if (this.op !== "select" && !this.wantsReturning) {
+        return { data: null, error: null };
+      }
+
+      return { data: rows, error: null };
+    } catch (err: any) {
+      return {
+        data: null,
+        error: { message: err?.message ?? String(err), code: err?.code },
+      };
+    }
+  }
+
+  then<TResult1 = ListResult, TResult2 = never>(
+    onfulfilled?:
+      | ((value: ListResult) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+  ): PromiseLike<TResult1 | TResult2> {
+    return (this.run() as Promise<ListResult>).then(onfulfilled, onrejected);
+  }
+}
+
+function pushRaw(value: unknown, params: unknown[]): string {
+  params.push(value);
+  return `$${params.length}`;
+}
+
+function splitTopLevel(input: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const ch of input) {
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    if (ch === "," && depth === 0) {
+      parts.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  if (current) parts.push(current);
+  return parts;
+}
+
+function buildOrClause(filterString: string, params: unknown[]): string {
+  const tokens = splitTopLevel(filterString);
+  const clauses = tokens.map((token) => {
+    const inMatch = token.match(/^([a-zA-Z0-9_]+)\.in\.\((.*)\)$/);
+    if (inMatch) {
+      const col = inMatch[1];
+      const values = inMatch[2].split(",").map((v) => v.trim()).filter(Boolean);
+      if (values.length === 0) return "1 = 0";
+      const placeholders = values
+        .map((v) => pushRaw(v, params))
+        .join(", ");
+      return `${quoteIdent(col)} IN (${placeholders})`;
+    }
+    const m = token.match(/^([a-zA-Z0-9_]+)\.([a-z]+)\.(.*)$/);
+    if (!m) return "1 = 0";
+    const [, col, op, rawVal] = m;
+    const sqlCol = quoteIdent(col);
+    switch (op) {
+      case "eq":
+        return `${sqlCol} = ${pushRaw(rawVal, params)}`;
+      case "neq":
+        return `${sqlCol} <> ${pushRaw(rawVal, params)}`;
+      case "gt":
+        return `${sqlCol} > ${pushRaw(rawVal, params)}`;
+      case "gte":
+        return `${sqlCol} >= ${pushRaw(rawVal, params)}`;
+      case "lt":
+        return `${sqlCol} < ${pushRaw(rawVal, params)}`;
+      case "lte":
+        return `${sqlCol} <= ${pushRaw(rawVal, params)}`;
+      case "is":
+        return rawVal === "null"
+          ? `${sqlCol} IS NULL`
+          : `${sqlCol} IS ${rawVal.toUpperCase()}`;
+      default:
+        return "1 = 0";
+    }
+  });
+  return `(${clauses.join(" OR ")})`;
+}
+
+// ---------------------------------------------------------------------------
+// Auth admin shim (single local user)
+// ---------------------------------------------------------------------------
+
+/** Loose stand-in for a Supabase auth user (only id/email are real). */
+type LocalAuthUser = {
+  id: string;
+  email: string;
+  factors?: any[];
+  [key: string]: any;
+};
+
+const authAdmin = {
+  async getUserById(
+    id: string,
+  ): Promise<DbResult<{ user: LocalAuthUser | null }>> {
+    try {
+      const result = await getPool().query(
+        `SELECT id, email FROM auth.users WHERE id = $1`,
+        [id],
+      );
+      const row = result.rows[0];
+      return {
+        data: { user: row ? { id: row.id, email: row.email ?? "" } : null },
+        error: null,
+      };
+    } catch (err: any) {
+      return { data: { user: null }, error: { message: err?.message } };
+    }
+  },
+
+  async listUsers(_options?: {
+    perPage?: number;
+    page?: number;
+  }): Promise<DbResult<{ users: LocalAuthUser[] }>> {
+    try {
+      const result = await getPool().query(`SELECT id, email FROM auth.users`);
+      return {
+        data: {
+          users: result.rows.map((r) => ({
+            id: r.id,
+            email: r.email ?? "",
+          })),
+        },
+        error: null,
+      };
+    } catch (err: any) {
+      return { data: { users: [] }, error: { message: err?.message } };
+    }
+  },
+
+  async deleteUser(id: string): Promise<DbResult<Record<string, never>>> {
+    try {
+      // Cascades to user_profiles / user_api_keys via their FKs.
+      await getPool().query(`DELETE FROM auth.users WHERE id = $1`, [id]);
+      return { data: {}, error: null };
+    } catch (err: any) {
+      return { data: {}, error: { message: err?.message } };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Public API — same name/signature as the old Supabase factory
+// ---------------------------------------------------------------------------
+
+export function createServerSupabase() {
+  return {
+    from(table: string): QueryBuilder {
+      return new QueryBuilder(table);
+    },
+    auth: {
+      admin: authAdmin,
+    },
+  };
+}
+
+/**
+ * Auth is bypassed locally — every request resolves to the single hardcoded
+ * local user. Kept for signature compatibility with the previous Supabase
+ * helper. See backend/src/middleware/auth.ts for the canonical id.
+ */
+export const LOCAL_USER_ID = "00000000-0000-0000-0000-000000000001";
+export const LOCAL_USER_EMAIL = "local@localhost";
+
+export async function getUserIdFromRequest(_req: unknown): Promise<string> {
+  return LOCAL_USER_ID;
+}
+
+/** Exposed for graceful shutdown / tests. */
+export async function closePool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = undefined;
+  }
+}
+
+export type { PoolClient };

--- a/backend/src/lib/userDataCleanup.ts
+++ b/backend/src/lib/userDataCleanup.ts
@@ -133,7 +133,7 @@ async function removeEmailFromSharedWith(
         .map((row) => {
             const sharedWith = Array.isArray(row.shared_with)
                 ? row.shared_with.filter(
-                      (value) =>
+                      (value: unknown) =>
                           typeof value !== "string" ||
                           value.trim().toLowerCase() !== normalizedEmail,
                   )

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,202 +1,39 @@
 import { Request, Response, NextFunction } from "express";
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { LOCAL_USER_EMAIL, LOCAL_USER_ID } from "../lib/supabase";
 
-const isDev = process.env.NODE_ENV !== "production";
-const devLog = (...args: Parameters<typeof console.log>) => {
-  if (isDev) console.log(...args);
-};
-
-function summarizeMfaFactors(
-  factors: Array<{
-    factor_type?: string;
-    status?: string;
-  }> | null | undefined,
-) {
-  return (factors ?? []).map((factor) => ({
-    type: factor.factor_type ?? "unknown",
-    status: factor.status ?? "unknown",
-  }));
-}
-
-function isLoginMfaBootstrapRoute(req: Request) {
-  const path = req.originalUrl.split("?")[0];
-  return (
-    (req.method === "GET" || req.method === "POST") &&
-    (path === "/user/profile" || path === "/users/profile")
-  );
-}
-
-async function enforceLoginMfaIfEnabled(
-  req: Request,
-  res: Response,
-  admin: SupabaseClient<any, "public", any>,
-  token: string,
-) {
-  if (isLoginMfaBootstrapRoute(req)) return true;
-
-  const { data, error } = await admin
-    .from("user_profiles")
-    .select("mfa_on_login")
-    .eq("user_id", res.locals.userId)
-    .maybeSingle();
-
-  if (error) {
-    devLog("[auth/mfa] login preference lookup failed", {
-      method: req.method,
-      path: req.originalUrl,
-      userId: res.locals.userId,
-      error: error.message,
-      code: error.code,
-    });
-    if (error.code === "42703") return true;
-    res.status(500).json({ detail: error.message });
-    return false;
-  }
-
-  const profile = data as { mfa_on_login?: boolean } | null;
-  if (profile?.mfa_on_login !== true) return true;
-
-  const { data: assurance, error: assuranceError } =
-    await admin.auth.mfa.getAuthenticatorAssuranceLevel(token);
-
-  if (assuranceError) {
-    devLog("[auth/mfa] login assurance lookup failed", {
-      method: req.method,
-      path: req.originalUrl,
-      userId: res.locals.userId,
-      error: assuranceError.message,
-    });
-    res.status(401).json({ detail: assuranceError.message });
-    return false;
-  }
-
-  if (assurance.nextLevel === "aal2" && assurance.currentLevel !== "aal2") {
-    devLog("[auth/mfa] login verification required", {
-      method: req.method,
-      path: req.originalUrl,
-      userId: res.locals.userId,
-    });
-    res.status(403).json({
-      code: "mfa_verification_required",
-      detail: "MFA verification required",
-    });
-    return false;
-  }
-
-  return true;
-}
-
-export async function requireAuth(
+/**
+ * Auth is disabled for the local / OSS setup.
+ *
+ * Every request is treated as the single hardcoded local user. No tokens are
+ * checked and no Supabase calls are made. The rest of the codebase reads the
+ * user from `res.locals.userId` / `res.locals.userEmail`, so we populate those
+ * (and `req.user`) and pass straight through.
+ *
+ * The user id is a real UUID because every `user_id` column in the schema is
+ * typed `uuid`; it matches the row seeded by the one-shot migration.
+ */
+export function requireAuth(
   req: Request,
   res: Response,
   next: NextFunction,
-): Promise<void> {
-  const auth = req.headers.authorization ?? "";
-  if (!auth.startsWith("Bearer ")) {
-    res.status(401).json({ detail: "Missing or invalid Authorization header" });
-    return;
-  }
-  const token = auth.slice(7).trim();
-
-  const supabaseUrl = process.env.SUPABASE_URL ?? "";
-  const serviceKey = process.env.SUPABASE_SECRET_KEY ?? "";
-
-  if (!supabaseUrl || !serviceKey) {
-    res.status(500).json({ detail: "Server auth is not configured" });
-    return;
-  }
-
-  const admin = createClient(supabaseUrl, serviceKey, {
-    auth: { persistSession: false },
-  });
-  const { data } = await admin.auth.getUser(token);
-  if (!data.user) {
-    res.status(401).json({ detail: "Invalid or expired token" });
-    return;
-  }
-
-  res.locals.userId = data.user.id;
-  res.locals.userEmail = data.user.email?.toLowerCase() ?? "";
-  res.locals.token = token;
-  if (!(await enforceLoginMfaIfEnabled(req, res, admin, token))) {
-    return;
-  }
+): void {
+  res.locals.userId = LOCAL_USER_ID;
+  res.locals.userEmail = LOCAL_USER_EMAIL;
+  res.locals.token = "local-dev-token";
+  (req as Request & { user?: { id: string; email: string } }).user = {
+    id: LOCAL_USER_ID,
+    email: LOCAL_USER_EMAIL,
+  };
   next();
 }
 
-export async function requireMfaIfEnrolled(
-  req: Request,
-  res: Response,
+/**
+ * MFA is not used locally — always allow.
+ */
+export function requireMfaIfEnrolled(
+  _req: Request,
+  _res: Response,
   next: NextFunction,
-): Promise<void> {
-  const token = typeof res.locals.token === "string" ? res.locals.token : "";
-  if (!token) {
-    devLog("[auth/mfa] missing auth session", {
-      method: req.method,
-      path: req.originalUrl,
-    });
-    res.status(401).json({ detail: "Missing auth session" });
-    return;
-  }
-
-  const supabaseUrl = process.env.SUPABASE_URL ?? "";
-  const serviceKey = process.env.SUPABASE_SECRET_KEY ?? "";
-
-  if (!supabaseUrl || !serviceKey) {
-    res.status(500).json({ detail: "Server auth is not configured" });
-    return;
-  }
-
-  const admin = createClient(supabaseUrl, serviceKey, {
-    auth: { persistSession: false },
-  });
-  const { data, error } =
-    await admin.auth.mfa.getAuthenticatorAssuranceLevel(token);
-
-  if (error) {
-    devLog("[auth/mfa] assurance lookup failed", {
-      method: req.method,
-      path: req.originalUrl,
-      userId: res.locals.userId,
-      error: error.message,
-    });
-    res.status(401).json({ detail: error.message });
-    return;
-  }
-
-  devLog("[auth/mfa] assurance level", {
-    method: req.method,
-    path: req.originalUrl,
-    userId: res.locals.userId,
-    currentLevel: data.currentLevel,
-    nextLevel: data.nextLevel,
-    required: data.nextLevel === "aal2" && data.currentLevel !== "aal2",
-  });
-
-  if (isDev) {
-    const { data: userData, error: userError } = await admin.auth.getUser(token);
-    devLog("[auth/mfa] user factors", {
-      method: req.method,
-      path: req.originalUrl,
-      userId: res.locals.userId,
-      factorCount: userData.user?.factors?.length ?? 0,
-      factors: summarizeMfaFactors(userData.user?.factors),
-      error: userError?.message ?? null,
-    });
-  }
-
-  if (data.nextLevel === "aal2" && data.currentLevel !== "aal2") {
-    devLog("[auth/mfa] verification required", {
-      method: req.method,
-      path: req.originalUrl,
-      userId: res.locals.userId,
-    });
-    res.status(403).json({
-      code: "mfa_verification_required",
-      detail: "MFA verification required",
-    });
-    return;
-  }
-
+): void {
   next();
 }

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -1,7 +1,6 @@
 import { Router } from "express";
 import { requireAuth } from "../middleware/auth";
 import { createServerSupabase } from "../lib/supabase";
-import { createClient } from "@supabase/supabase-js";
 import {
   attachActiveVersionPaths,
   attachLatestVersionNumbers,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: mike
+      POSTGRES_USER: mike
+      POSTGRES_PASSWORD: mike
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./pgdata:/var/lib/postgresql/data
+      # Auto-applies the one-shot schema on first boot (empty data dir only).
+      # You can also run it manually — see backend/migrations/000_one_shot_schema.sql.
+      - ./backend/migrations/000_one_shot_schema.sql:/docker-entrypoint-initdb.d/000_one_shot_schema.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mike -d mike"]
+      interval: 5s
+      timeout: 5s
+      retries: 10

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,3 +1,1 @@
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-supabase-anon-key
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3001

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -54,7 +54,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         const {
             data: { subscription },
-        } = supabase.auth.onAuthStateChange(async (_event, session) => {
+        } = supabase.auth.onAuthStateChange(async (_event: string, session: { user?: SupabaseUser } | null) => {
             if (session?.user) {
                 setUser(toUser(session.user));
             } else {

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,54 +1,16 @@
-import { NextRequest } from 'next/server';
+import { NextRequest } from "next/server";
 
 /**
- * Extract and validate user from Supabase JWT token
- * Returns user info if valid, null if invalid or missing
- * 
- * @param request NextRequest with Authorization header
- * @returns User object with email and id, or null
+ * Auth is disabled in the local / OSS setup — every request resolves to the
+ * single hardcoded local user. Kept for signature compatibility; no token is
+ * validated and no Supabase call is made.
  */
-export async function getUserFromRequest(request: NextRequest): Promise<{
+export async function getUserFromRequest(_request: NextRequest): Promise<{
   email: string;
   id: string;
 } | null> {
-  try {
-    const authHeader = request.headers.get('Authorization');
-    
-    if (!authHeader?.startsWith('Bearer ')) {
-      return null;
-    }
-
-    const token = authHeader.substring(7);
-    
-    if (!token) {
-      return null;
-    }
-    
-    // Validate with Supabase
-    const { createClient } = await import('@supabase/supabase-js');
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!
-    );
-
-    const { data: { user }, error } = await supabase.auth.getUser(token);
-    
-    if (error || !user) {
-      console.warn('[Auth] Invalid or expired token:', error?.message);
-      return null;
-    }
-
-    if (!user.email) {
-      console.warn('[Auth] User has no email');
-      return null;
-    }
-
-    return {
-      email: user.email,
-      id: user.id
-    };
-  } catch (error) {
-    console.error('[Auth] Error validating token:', error);
-    return null;
-  }
+  return {
+    email: "local@localhost",
+    id: "00000000-0000-0000-0000-000000000001",
+  };
 }

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1,7 +1,82 @@
-import { createClient } from "@supabase/supabase-js";
+/**
+ * Local auth stub — Supabase is not used in the local / OSS setup.
+ *
+ * Authentication is disabled: the whole app runs as a single hardcoded local
+ * user, with no login screen and no external auth service. To avoid touching
+ * the many components that import `supabase`, we expose an object with the
+ * same shape that always resolves to that local user and a dummy session.
+ *
+ * The backend ignores the bearer token entirely (see backend auth middleware),
+ * so the token value here is cosmetic.
+ */
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
-const supabaseAnonKey =
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY || "";
+const LOCAL_USER = {
+  id: "00000000-0000-0000-0000-000000000001",
+  email: "local@localhost",
+  new_email: null as string | null,
+  app_metadata: {},
+  user_metadata: {},
+  aud: "authenticated",
+  created_at: new Date(0).toISOString(),
+};
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+const LOCAL_SESSION = {
+  access_token: "local-dev-token",
+  refresh_token: "local-dev-token",
+  token_type: "bearer",
+  expires_in: 3600,
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
+  user: LOCAL_USER,
+};
+
+const ok = <T>(data: T) => Promise.resolve({ data, error: null });
+
+const mfa = {
+  getAuthenticatorAssuranceLevel: async () =>
+    ok({ currentLevel: "aal1", nextLevel: "aal1" }),
+  listFactors: async () => ok({ totp: [], phone: [], all: [] }),
+  challenge: async () => ok({ id: "local", type: "totp" }),
+  verify: async () => ok({ ...LOCAL_SESSION }),
+  challengeAndVerify: async () => ok({ ...LOCAL_SESSION }),
+  enroll: async () =>
+    ok({
+      id: "local",
+      type: "totp",
+      totp: { qr_code: "", secret: "", uri: "" },
+    }),
+  unenroll: async () => ok({}),
+};
+
+const auth = {
+  getSession: async () => ok({ session: LOCAL_SESSION }),
+  getUser: async () => ok({ user: LOCAL_USER }),
+  onAuthStateChange: (
+    callback: (event: string, session: typeof LOCAL_SESSION | null) => void,
+  ) => {
+    // Fire once so listeners immediately see the local session.
+    Promise.resolve().then(() => callback("SIGNED_IN", LOCAL_SESSION));
+    return {
+      data: {
+        subscription: {
+          id: "local",
+          callback,
+          unsubscribe() {},
+        },
+      },
+    };
+  },
+  signInWithPassword: async () =>
+    ok({ session: LOCAL_SESSION, user: LOCAL_USER }),
+  signUp: async () => ok({ session: LOCAL_SESSION, user: LOCAL_USER }),
+  signOut: async () => ({ error: null }),
+  updateUser: async (attributes: { email?: string }) =>
+    ok({
+      user: { ...LOCAL_USER, email: attributes?.email ?? LOCAL_USER.email },
+    }),
+  mfa,
+};
+
+// Typed as `any` so the many call sites that destructure provider-specific
+// response shapes keep compiling against this stub.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const supabase: any = { auth };


### PR DESCRIPTION
Replace the external service dependencies with local equivalents so the app runs with zero accounts/credentials, no login wall, and on-disk file storage.

- DB: swap the Supabase client for a `pg`-backed, PostgREST-compatible query builder in backend/src/lib/supabase.ts. `createServerSupabase()` keeps its name/signature and supports the subset the codebase uses (from/select/insert/ update/delete/upsert, eq/neq/in/is/not/or/filter(cs), order/limit/range, single/maybeSingle, count/head, and auth.admin.{getUserById,listUsers, deleteUser}). Connection via DATABASE_URL.
- Auth: requireAuth/requireMfaIfEnrolled become passthroughs injecting a single hardcoded local user (fixed UUID, since user_id columns are uuid).
- Storage: rewrite storage.ts to read/write under backend/uploads/ instead of R2/S3, same function signatures; getSignedUrl returns an absolute /download token link; add an /uploads static route and create the dir on startup.
- Postgres via Docker Compose; one-shot migration wraps the existing schema with an auth-schema shim (auth.users + anon/authenticated/service_role roles) and seeds the local user.
- Frontend: stub lib/supabase.ts and lib/auth.ts to a fixed local session so no login screen appears and components keep working unchanged.
- Env examples updated; LOCAL_SETUP.md documents the workflow.