### PR TITLE
Add Matter OS workspace

### DIFF
--- a/backend/migrations/20260619_01_knowledge_entries.sql
+++ b/backend/migrations/20260619_01_knowledge_entries.sql
@@ -1,0 +1,44 @@
+-- Migration date: 2026-06-19
+
+-- Adds the Matter OS knowledge base used by project workspaces and
+-- project-chat knowledge tools. Rows with project_id null are personal
+-- library entries; rows with project_id set are matter-scoped entries.
+
+create table if not exists public.knowledge_entries (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null,
+  project_id uuid references public.projects(id) on delete cascade,
+  library_origin_id uuid references public.knowledge_entries(id) on delete set null,
+  entry_type text not null check (entry_type in (
+    'fact',
+    'party',
+    'date',
+    'clause',
+    'position',
+    'playbook',
+    'source'
+  )),
+  title text not null,
+  body text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  source_refs jsonb not null default '[]'::jsonb,
+  status text not null default 'active' check (status in ('active', 'archived')),
+  include_in_agent_context boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists knowledge_entries_user_library_idx
+  on public.knowledge_entries(user_id, updated_at desc)
+  where project_id is null and status = 'active';
+
+create index if not exists knowledge_entries_project_idx
+  on public.knowledge_entries(project_id, updated_at desc)
+  where project_id is not null and status = 'active';
+
+create index if not exists knowledge_entries_library_origin_idx
+  on public.knowledge_entries(library_origin_id);
+
+alter table public.knowledge_entries enable row level security;
+
+revoke all on public.knowledge_entries from anon, authenticated;

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -198,6 +198,43 @@ create index if not exists idx_projects_user
 create index if not exists projects_shared_with_idx
   on public.projects using gin (shared_with);
 
+create table if not exists public.knowledge_entries (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null,
+  project_id uuid references public.projects(id) on delete cascade,
+  library_origin_id uuid references public.knowledge_entries(id) on delete set null,
+  entry_type text not null check (entry_type in (
+    'fact',
+    'party',
+    'date',
+    'clause',
+    'position',
+    'playbook',
+    'source'
+  )),
+  title text not null,
+  body text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  source_refs jsonb not null default '[]'::jsonb,
+  status text not null default 'active' check (status in ('active', 'archived')),
+  include_in_agent_context boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists knowledge_entries_user_library_idx
+  on public.knowledge_entries(user_id, updated_at desc)
+  where project_id is null and status = 'active';
+
+create index if not exists knowledge_entries_project_idx
+  on public.knowledge_entries(project_id, updated_at desc)
+  where project_id is not null and status = 'active';
+
+create index if not exists knowledge_entries_library_origin_idx
+  on public.knowledge_entries(library_origin_id);
+
+alter table public.knowledge_entries enable row level security;
+
 create table if not exists public.project_subfolders (
   id uuid primary key default gen_random_uuid(),
   project_id uuid not null references public.projects(id) on delete cascade,
@@ -799,6 +836,7 @@ alter table public.courtlistener_opinion_cluster_index enable row level security
 
 revoke all on public.user_profiles from anon, authenticated;
 revoke all on public.projects from anon, authenticated;
+revoke all on public.knowledge_entries from anon, authenticated;
 revoke all on public.project_subfolders from anon, authenticated;
 revoke all on public.documents from anon, authenticated;
 revoke all on public.document_versions from anon, authenticated;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,7 @@ import { workflowsRouter } from "./routes/workflows";
 import { userRouter } from "./routes/user";
 import { downloadsRouter } from "./routes/downloads";
 import { caseLawRouter } from "./routes/caseLaw";
+import { knowledgeRouter } from "./routes/knowledge";
 
 const app = express();
 const PORT = process.env.PORT ?? 3001;
@@ -151,6 +152,8 @@ app.use("/projects/:projectId/chat", projectChatRouter);
 app.use("/single-documents", documentsRouter);
 app.use("/tabular-review", tabularRouter);
 app.use("/workflows", workflowsRouter);
+app.use("/knowledge", knowledgeRouter);
+app.use("/projects/:projectId/knowledge", knowledgeRouter);
 app.use("/user", userRouter);
 app.use("/users", userRouter);
 app.use("/download", downloadsRouter);

--- a/backend/src/lib/chatTools.ts
+++ b/backend/src/lib/chatTools.ts
@@ -43,6 +43,15 @@ import {
   type OpenAIToolSchema,
 } from "./llm";
 import { safeErrorMessage } from "./safeError";
+import {
+  getKnowledgeForAgent,
+  isKnowledgeEntryType,
+  knowledgeEntryForTool,
+  listKnowledgeForAgent,
+  parseKnowledgeSuggestion,
+  type KnowledgeEntryType,
+  type KnowledgeSuggestion,
+} from "./knowledge";
 
 const STANDARD_FONT_DATA_URL = (() => {
   try {
@@ -292,6 +301,141 @@ export const WORKFLOW_TOOLS = [
           },
         },
         required: ["workflow_id"],
+      },
+    },
+  },
+];
+
+export const KNOWLEDGE_TOOLS = [
+  {
+    type: "function",
+    function: {
+      name: "list_knowledge_entries",
+      description:
+        "List matter knowledge entries and/or personal library entries. Use this to understand stored facts, parties, key dates, clauses, positions, playbooks, and sources before answering.",
+      parameters: {
+        type: "object",
+        properties: {
+          scope: {
+            type: "string",
+            enum: ["project", "library", "all"],
+            description:
+              "Which knowledge scope to list. Defaults to all available entries.",
+          },
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 50,
+            description: "Maximum entries to return. Defaults to 20.",
+          },
+        },
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "search_knowledge_entries",
+      description:
+        "Search matter knowledge and the user's personal library for a word or phrase. Use this when the prompt needs stored matter context, positions, clauses, or playbooks.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Word or phrase to search for.",
+          },
+          scope: {
+            type: "string",
+            enum: ["project", "library", "all"],
+            description:
+              "Which knowledge scope to search. Defaults to all available entries.",
+          },
+          entry_types: {
+            type: "array",
+            items: {
+              type: "string",
+              enum: [
+                "fact",
+                "party",
+                "date",
+                "clause",
+                "position",
+                "playbook",
+                "source",
+              ],
+            },
+            description: "Optional entry types to include.",
+          },
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 50,
+            description: "Maximum entries to return. Defaults to 20.",
+          },
+        },
+        required: ["query"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "read_knowledge_entry",
+      description:
+        "Read a single knowledge entry by ID. Use after list_knowledge_entries or search_knowledge_entries when more detail is needed.",
+      parameters: {
+        type: "object",
+        properties: {
+          entry_id: {
+            type: "string",
+            description: "Knowledge entry ID to read.",
+          },
+        },
+        required: ["entry_id"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "suggest_knowledge_entries",
+      description:
+        "Suggest entries the user may want to save to the Matter OS knowledge base. This does not save anything; it only creates reviewable suggestions for the user.",
+      parameters: {
+        type: "object",
+        properties: {
+          entries: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                entry_type: {
+                  type: "string",
+                  enum: [
+                    "fact",
+                    "party",
+                    "date",
+                    "clause",
+                    "position",
+                    "playbook",
+                    "source",
+                  ],
+                },
+                title: { type: "string" },
+                body: { type: "string" },
+                metadata: { type: "object" },
+                source_refs: {
+                  type: "array",
+                  items: {},
+                },
+              },
+              required: ["entry_type", "title", "body"],
+            },
+            description: "Up to 8 suggested knowledge entries.",
+          },
+        },
+        required: ["entries"],
       },
     },
   },
@@ -2308,6 +2452,7 @@ export async function runToolCalls(
   courtlistenerEvents: CourtlistenerToolEvent[];
   caseCitationEvents: CaseCitationEvent[];
   mcpEvents: McpToolEvent[];
+  knowledgeEvents: Extract<AssistantEvent, { type: "knowledge_suggestion" }>[];
 }> {
   const toolResults: unknown[] = [];
   const docsRead: { filename: string; document_id?: string }[] = [];
@@ -2323,6 +2468,10 @@ export async function runToolCalls(
   const courtlistenerEvents: CourtlistenerToolEvent[] = [];
   const caseCitationEvents: CaseCitationEvent[] = [];
   const mcpEvents: McpToolEvent[] = [];
+  const knowledgeEvents: Extract<
+    AssistantEvent,
+    { type: "knowledge_suggestion" }
+  >[] = [];
   const courtState: CourtlistenerTurnState =
     courtlistenerState ??
     {
@@ -2511,6 +2660,88 @@ export async function runToolCalls(
         role: "tool",
         tool_call_id: tc.id,
         content: wf ? wf.prompt_md : `Workflow '${wfId}' not found.`,
+      });
+    } else if (tc.function.name === "list_knowledge_entries") {
+      const scope =
+        args.scope === "project" || args.scope === "library" || args.scope === "all"
+          ? args.scope
+          : "all";
+      const limit =
+        typeof args.limit === "number"
+          ? Math.max(1, Math.min(50, Math.floor(args.limit)))
+          : 20;
+      const entries = await listKnowledgeForAgent({
+        db,
+        userId,
+        projectId,
+        scope,
+        limit,
+      });
+      toolResults.push({
+        role: "tool",
+        tool_call_id: tc.id,
+        content: JSON.stringify(entries.map(knowledgeEntryForTool)),
+      });
+    } else if (tc.function.name === "search_knowledge_entries") {
+      const scope =
+        args.scope === "project" || args.scope === "library" || args.scope === "all"
+          ? args.scope
+          : "all";
+      const limit =
+        typeof args.limit === "number"
+          ? Math.max(1, Math.min(50, Math.floor(args.limit)))
+          : 20;
+      const entryTypes = Array.isArray(args.entry_types)
+        ? args.entry_types.filter(isKnowledgeEntryType)
+        : undefined;
+      const entries = await listKnowledgeForAgent({
+        db,
+        userId,
+        projectId,
+        scope,
+        query: typeof args.query === "string" ? args.query : "",
+        entryTypes,
+        limit,
+      });
+      toolResults.push({
+        role: "tool",
+        tool_call_id: tc.id,
+        content: JSON.stringify(entries.map(knowledgeEntryForTool)),
+      });
+    } else if (tc.function.name === "read_knowledge_entry") {
+      const entryId = typeof args.entry_id === "string" ? args.entry_id : "";
+      const entry = entryId
+        ? await getKnowledgeForAgent({ db, userId, entryId, projectId })
+        : null;
+      toolResults.push({
+        role: "tool",
+        tool_call_id: tc.id,
+        content: entry
+          ? JSON.stringify(knowledgeEntryForTool(entry))
+          : "Knowledge entry not found.",
+      });
+    } else if (tc.function.name === "suggest_knowledge_entries") {
+      const suggestions = Array.isArray(args.entries)
+        ? args.entries
+            .map(parseKnowledgeSuggestion)
+            .filter((entry): entry is KnowledgeSuggestion => !!entry)
+            .slice(0, 8)
+        : [];
+      const event = {
+        type: "knowledge_suggestion" as const,
+        entries: suggestions,
+      };
+      if (suggestions.length > 0) {
+        knowledgeEvents.push(event);
+        write(`data: ${JSON.stringify(event)}\n\n`);
+      }
+      toolResults.push({
+        role: "tool",
+        tool_call_id: tc.id,
+        content:
+          suggestions.length > 0
+            ? `Suggested ${suggestions.length} knowledge entr${suggestions.length === 1 ? "y" : "ies"} for user review.`
+            : "No valid knowledge suggestions were provided.",
       });
     } else if (tc.function.name === "read_table_cells" && tabularStore) {
       const colIndices = args.col_indices as number[] | undefined;
@@ -3659,6 +3890,7 @@ export async function runToolCalls(
     courtlistenerEvents,
     caseCitationEvents,
     mcpEvents,
+    knowledgeEvents,
   };
 }
 
@@ -3841,8 +4073,23 @@ export type EditAnnotation = {
   status: "pending" | "accepted" | "rejected";
 };
 
+type KnowledgeContextEntry = {
+  id: string;
+  entry_type: KnowledgeEntryType;
+  title: string;
+  scope?: "project" | "library";
+};
+
 type AssistantEvent =
   | { type: "reasoning"; text: string }
+  | {
+      type: "knowledge_context";
+      entries: KnowledgeContextEntry[];
+    }
+  | {
+      type: "knowledge_suggestion";
+      entries: KnowledgeSuggestion[];
+    }
   | { type: "doc_read"; filename: string; document_id?: string }
   | {
       type: "doc_find";
@@ -3943,6 +4190,7 @@ export async function runLLMStream(params: {
    * generated docs still get persisted, but as standalone documents.
    */
   projectId?: string | null;
+  knowledgeContext?: KnowledgeContextEntry[];
 }): Promise<{
   fullText: string;
   events: AssistantEvent[];
@@ -3964,10 +4212,16 @@ export async function runLLMStream(params: {
     apiKeys,
     signal,
     projectId,
+    knowledgeContext = [],
   } = params;
   const researchTools = includeResearchTools ? COURTLISTENER_TOOLS : [];
   const mcpTools = await buildUserMcpTools(userId, db);
-  const baseTools = [...TOOLS, ...researchTools, ...WORKFLOW_TOOLS];
+  const baseTools = [
+    ...TOOLS,
+    ...researchTools,
+    ...WORKFLOW_TOOLS,
+    ...KNOWLEDGE_TOOLS,
+  ];
   const activeTools = extraTools?.length
     ? [...baseTools, ...mcpTools, ...extraTools]
     : [...baseTools, ...mcpTools];
@@ -3985,6 +4239,14 @@ export async function runLLMStream(params: {
     }));
 
   const events: AssistantEvent[] = [];
+  if (knowledgeContext.length > 0) {
+    const event: Extract<AssistantEvent, { type: "knowledge_context" }> = {
+      type: "knowledge_context",
+      entries: knowledgeContext,
+    };
+    events.push(event);
+    write(`data: ${JSON.stringify(event)}\n\n`);
+  }
   // One assistant turn produces at most one document_versions row per
   // edited doc. `runToolCalls` fires once per tool-call batch; the model
   // may emit multiple batches in a single turn, so this map persists
@@ -4174,6 +4436,7 @@ export async function runLLMStream(params: {
           courtlistenerEvents,
           caseCitationEvents,
           mcpEvents,
+          knowledgeEvents,
         } = await runToolCalls(
           toolCalls,
           docStore,
@@ -4244,6 +4507,9 @@ export async function runLLMStream(params: {
           events.push(event);
         }
         for (const event of mcpEvents) {
+          events.push(event);
+        }
+        for (const event of knowledgeEvents) {
           events.push(event);
         }
         for (const event of caseCitationEvents) {

--- a/backend/src/lib/knowledge.ts
+++ b/backend/src/lib/knowledge.ts
@@ -1,0 +1,234 @@
+import { createServerSupabase } from "./supabase";
+
+type Db = ReturnType<typeof createServerSupabase>;
+
+export const KNOWLEDGE_ENTRY_TYPES = [
+    "fact",
+    "party",
+    "date",
+    "clause",
+    "position",
+    "playbook",
+    "source",
+] as const;
+
+export type KnowledgeEntryType = (typeof KNOWLEDGE_ENTRY_TYPES)[number];
+export type KnowledgeEntryStatus = "active" | "archived";
+
+export type KnowledgeEntry = {
+    id: string;
+    user_id: string;
+    project_id: string | null;
+    library_origin_id: string | null;
+    entry_type: KnowledgeEntryType;
+    title: string;
+    body: string;
+    metadata: Record<string, unknown>;
+    source_refs: unknown[];
+    status: KnowledgeEntryStatus;
+    include_in_agent_context: boolean;
+    created_at: string;
+    updated_at: string;
+};
+
+export type KnowledgeSuggestion = {
+    entry_type: KnowledgeEntryType;
+    title: string;
+    body: string;
+    metadata?: Record<string, unknown>;
+    source_refs?: unknown[];
+};
+
+const ENTRY_TYPE_SET = new Set<string>(KNOWLEDGE_ENTRY_TYPES);
+
+export function isKnowledgeEntryType(
+    value: unknown,
+): value is KnowledgeEntryType {
+    return typeof value === "string" && ENTRY_TYPE_SET.has(value);
+}
+
+export function normalizeKnowledgeEntryType(
+    value: unknown,
+): KnowledgeEntryType | null {
+    return isKnowledgeEntryType(value) ? value : null;
+}
+
+export function isPlainRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export function coerceMetadata(value: unknown): Record<string, unknown> {
+    return isPlainRecord(value) ? value : {};
+}
+
+export function coerceSourceRefs(value: unknown): unknown[] {
+    return Array.isArray(value) ? value : [];
+}
+
+export function sanitizeKnowledgeTitle(value: unknown): string {
+    return typeof value === "string" ? value.trim().slice(0, 180) : "";
+}
+
+export function sanitizeKnowledgeBody(value: unknown): string {
+    return typeof value === "string" ? value.trim().slice(0, 12000) : "";
+}
+
+export function mapKnowledgeEntry(row: Record<string, unknown>): KnowledgeEntry {
+    return {
+        id: String(row.id ?? ""),
+        user_id: String(row.user_id ?? ""),
+        project_id:
+            typeof row.project_id === "string" ? row.project_id : null,
+        library_origin_id:
+            typeof row.library_origin_id === "string"
+                ? row.library_origin_id
+                : null,
+        entry_type:
+            normalizeKnowledgeEntryType(row.entry_type) ?? "fact",
+        title: typeof row.title === "string" ? row.title : "",
+        body: typeof row.body === "string" ? row.body : "",
+        metadata: coerceMetadata(row.metadata),
+        source_refs: coerceSourceRefs(row.source_refs),
+        status: row.status === "archived" ? "archived" : "active",
+        include_in_agent_context: row.include_in_agent_context !== false,
+        created_at: typeof row.created_at === "string" ? row.created_at : "",
+        updated_at: typeof row.updated_at === "string" ? row.updated_at : "",
+    };
+}
+
+export function parseKnowledgeSuggestion(value: unknown): KnowledgeSuggestion | null {
+    if (!isPlainRecord(value)) return null;
+    const entryType = normalizeKnowledgeEntryType(value.entry_type);
+    const title = sanitizeKnowledgeTitle(value.title);
+    const body = sanitizeKnowledgeBody(value.body);
+    if (!entryType || !title || !body) return null;
+    return {
+        entry_type: entryType,
+        title,
+        body,
+        metadata: coerceMetadata(value.metadata),
+        source_refs: coerceSourceRefs(value.source_refs),
+    };
+}
+
+export async function listProjectKnowledgeContext(
+    db: Db,
+    projectId: string,
+    limit = 20,
+): Promise<KnowledgeEntry[]> {
+    const { data } = await db
+        .from("knowledge_entries")
+        .select("*")
+        .eq("project_id", projectId)
+        .eq("status", "active")
+        .eq("include_in_agent_context", true)
+        .order("updated_at", { ascending: false })
+        .limit(limit);
+
+    return ((data ?? []) as Record<string, unknown>[]).map(mapKnowledgeEntry);
+}
+
+export async function listKnowledgeForAgent(args: {
+    db: Db;
+    userId: string;
+    projectId?: string | null;
+    scope?: "project" | "library" | "all";
+    query?: string | null;
+    entryTypes?: KnowledgeEntryType[];
+    limit?: number;
+}): Promise<KnowledgeEntry[]> {
+    const {
+        db,
+        userId,
+        projectId,
+        scope = "all",
+        query,
+        entryTypes,
+        limit = 20,
+    } = args;
+    const shouldLoadProject = !!projectId && scope !== "library";
+    const shouldLoadLibrary = scope !== "project";
+    const normalizedQuery = query?.trim().toLowerCase() ?? "";
+    const types = entryTypes?.length ? new Set(entryTypes) : null;
+    const results: KnowledgeEntry[] = [];
+
+    if (shouldLoadProject && projectId) {
+        const { data } = await db
+            .from("knowledge_entries")
+            .select("*")
+            .eq("project_id", projectId)
+            .eq("status", "active")
+            .order("updated_at", { ascending: false })
+            .limit(limit);
+        results.push(
+            ...((data ?? []) as Record<string, unknown>[]).map(mapKnowledgeEntry),
+        );
+    }
+
+    if (shouldLoadLibrary) {
+        const { data } = await db
+            .from("knowledge_entries")
+            .select("*")
+            .eq("user_id", userId)
+            .is("project_id", null)
+            .eq("status", "active")
+            .order("updated_at", { ascending: false })
+            .limit(limit);
+        results.push(
+            ...((data ?? []) as Record<string, unknown>[]).map(mapKnowledgeEntry),
+        );
+    }
+
+    return results
+        .filter((entry) => !types || types.has(entry.entry_type))
+        .filter((entry) => {
+            if (!normalizedQuery) return true;
+            return `${entry.title}\n${entry.body}\n${entry.entry_type}`
+                .toLowerCase()
+                .includes(normalizedQuery);
+        })
+        .slice(0, limit);
+}
+
+export async function getKnowledgeForAgent(args: {
+    db: Db;
+    userId: string;
+    entryId: string;
+    projectId?: string | null;
+}): Promise<KnowledgeEntry | null> {
+    const { data } = await args.db
+        .from("knowledge_entries")
+        .select("*")
+        .eq("id", args.entryId)
+        .eq("status", "active")
+        .maybeSingle();
+    if (!data) return null;
+    const entry = mapKnowledgeEntry(data as Record<string, unknown>);
+    if (entry.project_id && entry.project_id === args.projectId) return entry;
+    if (!entry.project_id && entry.user_id === args.userId) return entry;
+    return null;
+}
+
+export function formatKnowledgeDigest(entries: KnowledgeEntry[]): string {
+    if (entries.length === 0) return "";
+    return entries
+        .map((entry, index) => {
+            const type = entry.entry_type.toUpperCase();
+            const body = entry.body.replace(/\s+/g, " ").trim().slice(0, 900);
+            return `${index + 1}. [${type}] ${entry.title}: ${body}`;
+        })
+        .join("\n");
+}
+
+export function knowledgeEntryForTool(entry: KnowledgeEntry) {
+    return {
+        id: entry.id,
+        scope: entry.project_id ? "project" : "library",
+        entry_type: entry.entry_type,
+        title: entry.title,
+        body: entry.body,
+        metadata: entry.metadata,
+        source_refs: entry.source_refs,
+        updated_at: entry.updated_at,
+    };
+}

--- a/backend/src/lib/userDataCleanup.ts
+++ b/backend/src/lib/userDataCleanup.ts
@@ -328,6 +328,7 @@ export async function deleteUserAccountData(
                   .delete()
                   .eq("shared_with_email", userEmail.trim().toLowerCase())
             : Promise.resolve({ error: null }),
+        db.from("knowledge_entries").delete().eq("user_id", userId),
         db.from("workflows").delete().eq("user_id", userId),
         db.from("projects").delete().eq("user_id", userId),
     ];

--- a/backend/src/routes/knowledge.ts
+++ b/backend/src/routes/knowledge.ts
@@ -1,0 +1,268 @@
+import { Router, type Response } from "express";
+import { requireAuth } from "../middleware/auth";
+import { checkProjectAccess } from "../lib/access";
+import { createServerSupabase } from "../lib/supabase";
+import {
+    coerceMetadata,
+    coerceSourceRefs,
+    isPlainRecord,
+    mapKnowledgeEntry,
+    normalizeKnowledgeEntryType,
+    sanitizeKnowledgeBody,
+    sanitizeKnowledgeTitle,
+} from "../lib/knowledge";
+
+export const knowledgeRouter = Router({ mergeParams: true });
+
+type Db = ReturnType<typeof createServerSupabase>;
+
+type KnowledgeEntryRow = {
+    id: string;
+    user_id: string;
+    project_id: string | null;
+    [key: string]: unknown;
+};
+
+function bad(res: Response, detail: string) {
+    return void res.status(400).json({ detail });
+}
+
+function normalizeCreatePayload(body: unknown) {
+    if (!isPlainRecord(body)) return { ok: false as const, detail: "Invalid body" };
+    const entryType = normalizeKnowledgeEntryType(body.entry_type);
+    const title = sanitizeKnowledgeTitle(body.title);
+    const entryBody = sanitizeKnowledgeBody(body.body);
+    if (!entryType) return { ok: false as const, detail: "Invalid entry_type" };
+    if (!title) return { ok: false as const, detail: "title is required" };
+    if (!entryBody) return { ok: false as const, detail: "body is required" };
+    return {
+        ok: true as const,
+        values: {
+            entry_type: entryType,
+            title,
+            body: entryBody,
+            metadata: coerceMetadata(body.metadata),
+            source_refs: coerceSourceRefs(body.source_refs),
+            include_in_agent_context: body.include_in_agent_context !== false,
+        },
+    };
+}
+
+function normalizePatchPayload(body: unknown) {
+    if (!isPlainRecord(body)) return { ok: false as const, detail: "Invalid body" };
+    const updates: Record<string, unknown> = {};
+    if ("entry_type" in body) {
+        const entryType = normalizeKnowledgeEntryType(body.entry_type);
+        if (!entryType) return { ok: false as const, detail: "Invalid entry_type" };
+        updates.entry_type = entryType;
+    }
+    if ("title" in body) {
+        const title = sanitizeKnowledgeTitle(body.title);
+        if (!title) return { ok: false as const, detail: "title is required" };
+        updates.title = title;
+    }
+    if ("body" in body) {
+        const entryBody = sanitizeKnowledgeBody(body.body);
+        if (!entryBody) return { ok: false as const, detail: "body is required" };
+        updates.body = entryBody;
+    }
+    if ("metadata" in body) updates.metadata = coerceMetadata(body.metadata);
+    if ("source_refs" in body) updates.source_refs = coerceSourceRefs(body.source_refs);
+    if ("include_in_agent_context" in body) {
+        updates.include_in_agent_context = body.include_in_agent_context !== false;
+    }
+    if ("status" in body) {
+        if (body.status !== "active" && body.status !== "archived") {
+            return { ok: false as const, detail: "Invalid status" };
+        }
+        updates.status = body.status;
+    }
+    updates.updated_at = new Date().toISOString();
+    return { ok: true as const, updates };
+}
+
+async function canEditEntry(
+    db: Db,
+    entry: KnowledgeEntryRow,
+    userId: string,
+    userEmail: string | undefined,
+) {
+    if (!entry.project_id) return entry.user_id === userId;
+    const access = await checkProjectAccess(entry.project_id, userId, userEmail, db);
+    if (!access.ok) return false;
+    return access.isOwner || entry.user_id === userId;
+}
+
+async function getEntry(db: Db, entryId: string) {
+    const { data } = await db
+        .from("knowledge_entries")
+        .select("*")
+        .eq("id", entryId)
+        .maybeSingle();
+    return data as KnowledgeEntryRow | null;
+}
+
+// GET /knowledge/library
+knowledgeRouter.get("/library", requireAuth, async (_req, res) => {
+    const userId = res.locals.userId as string;
+    const db = createServerSupabase();
+    const { data, error } = await db
+        .from("knowledge_entries")
+        .select("*")
+        .eq("user_id", userId)
+        .is("project_id", null)
+        .eq("status", "active")
+        .order("updated_at", { ascending: false });
+    if (error) return void res.status(500).json({ detail: error.message });
+    res.json(((data ?? []) as Record<string, unknown>[]).map(mapKnowledgeEntry));
+});
+
+// POST /knowledge/library
+knowledgeRouter.post("/library", requireAuth, async (req, res) => {
+    const userId = res.locals.userId as string;
+    const parsed = normalizeCreatePayload(req.body);
+    if (!parsed.ok) return bad(res, parsed.detail);
+    const db = createServerSupabase();
+    const { data, error } = await db
+        .from("knowledge_entries")
+        .insert({
+            ...parsed.values,
+            user_id: userId,
+            project_id: null,
+            library_origin_id: null,
+            status: "active",
+        })
+        .select("*")
+        .single();
+    if (error || !data)
+        return void res.status(500).json({ detail: error?.message ?? "Failed to create entry" });
+    res.status(201).json(mapKnowledgeEntry(data as Record<string, unknown>));
+});
+
+// GET /projects/:projectId/knowledge
+knowledgeRouter.get("/", requireAuth, async (req, res) => {
+    const userId = res.locals.userId as string;
+    const userEmail = res.locals.userEmail as string | undefined;
+    const { projectId } = req.params;
+    const db = createServerSupabase();
+    const access = await checkProjectAccess(projectId, userId, userEmail, db);
+    if (!access.ok) return void res.status(404).json({ detail: "Project not found" });
+    const { data, error } = await db
+        .from("knowledge_entries")
+        .select("*")
+        .eq("project_id", projectId)
+        .eq("status", "active")
+        .order("updated_at", { ascending: false });
+    if (error) return void res.status(500).json({ detail: error.message });
+    res.json(((data ?? []) as Record<string, unknown>[]).map(mapKnowledgeEntry));
+});
+
+// POST /projects/:projectId/knowledge
+knowledgeRouter.post("/", requireAuth, async (req, res) => {
+    const userId = res.locals.userId as string;
+    const userEmail = res.locals.userEmail as string | undefined;
+    const { projectId } = req.params;
+    const parsed = normalizeCreatePayload(req.body);
+    if (!parsed.ok) return bad(res, parsed.detail);
+    const db = createServerSupabase();
+    const access = await checkProjectAccess(projectId, userId, userEmail, db);
+    if (!access.ok) return void res.status(404).json({ detail: "Project not found" });
+    const { data, error } = await db
+        .from("knowledge_entries")
+        .insert({
+            ...parsed.values,
+            user_id: userId,
+            project_id: projectId,
+            library_origin_id: null,
+            status: "active",
+        })
+        .select("*")
+        .single();
+    if (error || !data)
+        return void res.status(500).json({ detail: error?.message ?? "Failed to create entry" });
+    res.status(201).json(mapKnowledgeEntry(data as Record<string, unknown>));
+});
+
+// POST /projects/:projectId/knowledge/link-library
+knowledgeRouter.post("/link-library", requireAuth, async (req, res) => {
+    const userId = res.locals.userId as string;
+    const userEmail = res.locals.userEmail as string | undefined;
+    const { projectId } = req.params;
+    const entryId = isPlainRecord(req.body) && typeof req.body.entry_id === "string"
+        ? req.body.entry_id
+        : "";
+    if (!entryId) return void res.status(400).json({ detail: "entry_id is required" });
+    const db = createServerSupabase();
+    const access = await checkProjectAccess(projectId, userId, userEmail, db);
+    if (!access.ok) return void res.status(404).json({ detail: "Project not found" });
+    const { data: source } = await db
+        .from("knowledge_entries")
+        .select("*")
+        .eq("id", entryId)
+        .eq("user_id", userId)
+        .is("project_id", null)
+        .eq("status", "active")
+        .maybeSingle();
+    if (!source) return void res.status(404).json({ detail: "Library entry not found" });
+    const src = mapKnowledgeEntry(source as Record<string, unknown>);
+    const { data, error } = await db
+        .from("knowledge_entries")
+        .insert({
+            user_id: userId,
+            project_id: projectId,
+            library_origin_id: src.id,
+            entry_type: src.entry_type,
+            title: src.title,
+            body: src.body,
+            metadata: src.metadata,
+            source_refs: src.source_refs,
+            status: "active",
+            include_in_agent_context: src.include_in_agent_context,
+        })
+        .select("*")
+        .single();
+    if (error || !data)
+        return void res.status(500).json({ detail: error?.message ?? "Failed to link entry" });
+    res.status(201).json(mapKnowledgeEntry(data as Record<string, unknown>));
+});
+
+// PATCH /knowledge/:entryId
+knowledgeRouter.patch("/:entryId", requireAuth, async (req, res) => {
+    const userId = res.locals.userId as string;
+    const userEmail = res.locals.userEmail as string | undefined;
+    const { entryId } = req.params;
+    const parsed = normalizePatchPayload(req.body);
+    if (!parsed.ok) return bad(res, parsed.detail);
+    const db = createServerSupabase();
+    const entry = await getEntry(db, entryId);
+    if (!entry || !(await canEditEntry(db, entry, userId, userEmail))) {
+        return void res.status(404).json({ detail: "Knowledge entry not found" });
+    }
+    const { data, error } = await db
+        .from("knowledge_entries")
+        .update(parsed.updates)
+        .eq("id", entryId)
+        .select("*")
+        .single();
+    if (error || !data)
+        return void res.status(500).json({ detail: error?.message ?? "Failed to update entry" });
+    res.json(mapKnowledgeEntry(data as Record<string, unknown>));
+});
+
+// DELETE /knowledge/:entryId
+knowledgeRouter.delete("/:entryId", requireAuth, async (req, res) => {
+    const userId = res.locals.userId as string;
+    const userEmail = res.locals.userEmail as string | undefined;
+    const { entryId } = req.params;
+    const db = createServerSupabase();
+    const entry = await getEntry(db, entryId);
+    if (!entry || !(await canEditEntry(db, entry, userId, userEmail))) {
+        return void res.status(404).json({ detail: "Knowledge entry not found" });
+    }
+    const { error } = await db
+        .from("knowledge_entries")
+        .update({ status: "archived", updated_at: new Date().toISOString() })
+        .eq("id", entryId);
+    if (error) return void res.status(500).json({ detail: error.message });
+    res.status(204).send();
+});

--- a/backend/src/routes/projectChat.ts
+++ b/backend/src/routes/projectChat.ts
@@ -20,6 +20,10 @@ import {
 } from "../lib/userSettings";
 import { checkProjectAccess } from "../lib/access";
 import { safeErrorLog, safeErrorMessage } from "../lib/safeError";
+import {
+    formatKnowledgeDigest,
+    listProjectKnowledgeContext,
+} from "../lib/knowledge";
 
 const PROJECT_SYSTEM_PROMPT_EXTRA = `PROJECT CONTEXT:
 You are operating within a project folder that contains a collection of legal documents the user has organised for a single matter. The user's questions will usually refer to one or more documents in this project — your job is to find the relevant files to work on. Use list_documents to see what is available and fetch_documents / read_document to pull in any documents you need before answering.
@@ -130,6 +134,11 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
     // knows which docs the user is highlighting *now*, distinct from
     // the broader project doc list.
     let systemPromptExtra = PROJECT_SYSTEM_PROMPT_EXTRA;
+    const knowledgeContext = await listProjectKnowledgeContext(db, projectId);
+    const knowledgeDigest = formatKnowledgeDigest(knowledgeContext);
+    if (knowledgeDigest) {
+        systemPromptExtra += `\n\nMATTER KNOWLEDGE:\nThe following curated project knowledge is approved for agent context. Treat it as useful matter context, but still cite documents/cases for evidentiary claims when needed.\n${knowledgeDigest}`;
+    }
     if (attached_documents?.length) {
         const slugByDocumentId = new Map<string, string>();
         for (const [slug, info] of Object.entries(docIndex)) {
@@ -187,6 +196,12 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
             apiKeys,
             signal: streamAbort.signal,
             projectId,
+            knowledgeContext: knowledgeContext.map((entry) => ({
+                id: entry.id,
+                entry_type: entry.entry_type,
+                title: entry.title,
+                scope: "project" as const,
+            })),
         });
 
         const persistedEvents = stripTransientAssistantEvents(events);

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -136,6 +136,146 @@ async function attachChatCreatorLabels(
   }
 }
 
+type ProjectActivityItem = {
+  id: string;
+  type: string;
+  title: string;
+  detail: string | null;
+  created_at: string;
+  href?: string;
+  metadata?: Record<string, unknown>;
+};
+
+function activityDetail(value: unknown, max = 180) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.replace(/\s+/g, " ").trim();
+  if (!trimmed) return null;
+  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed;
+}
+
+function assistantEventActivity(args: {
+  event: Record<string, unknown>;
+  chatId: string;
+  messageId: string;
+  createdAt: string;
+  index: number;
+  projectId: string;
+}): ProjectActivityItem | null {
+  const { event, chatId, messageId, createdAt, index, projectId } = args;
+  const type = typeof event.type === "string" ? event.type : "";
+  const id = `${messageId}:${index}:${type}`;
+  const href = `/projects/${projectId}/assistant/chat/${chatId}`;
+  if (type === "doc_read") {
+    return {
+      id,
+      type,
+      title: `Read ${event.filename ?? "document"}`,
+      detail: null,
+      created_at: createdAt,
+      href,
+    };
+  }
+  if (type === "doc_find") {
+    return {
+      id,
+      type,
+      title: `Searched ${event.filename ?? "document"}`,
+      detail: activityDetail(event.query),
+      created_at: createdAt,
+      href,
+      metadata: { total_matches: event.total_matches },
+    };
+  }
+  if (type === "doc_created") {
+    return {
+      id,
+      type,
+      title: `Created ${event.filename ?? "document"}`,
+      detail: null,
+      created_at: createdAt,
+      href,
+    };
+  }
+  if (type === "doc_replicated") {
+    return {
+      id,
+      type,
+      title: `Copied ${event.filename ?? "document"}`,
+      detail: `${event.count ?? 1} copied document${event.count === 1 ? "" : "s"}`,
+      created_at: createdAt,
+      href,
+    };
+  }
+  if (type === "doc_edited") {
+    return {
+      id,
+      type,
+      title: `Proposed edits to ${event.filename ?? "document"}`,
+      detail: Array.isArray(event.annotations)
+        ? `${event.annotations.length} tracked change${event.annotations.length === 1 ? "" : "s"}`
+        : null,
+      created_at: createdAt,
+      href,
+    };
+  }
+  if (type === "workflow_applied") {
+    return {
+      id,
+      type,
+      title: `Applied workflow ${event.title ?? ""}`.trim(),
+      detail: null,
+      created_at: createdAt,
+      href,
+    };
+  }
+  if (type === "mcp_tool_call") {
+    return {
+      id,
+      type,
+      title: `Used connector ${event.connector_name ?? ""}`.trim(),
+      detail: activityDetail(event.tool_name),
+      created_at: createdAt,
+      href,
+      metadata: { status: event.status },
+    };
+  }
+  if (type.startsWith("courtlistener_")) {
+    return {
+      id,
+      type,
+      title: "Used legal research",
+      detail: activityDetail(event.query ?? event.citation_count),
+      created_at: createdAt,
+      href,
+    };
+  }
+  if (type === "knowledge_context") {
+    return {
+      id,
+      type,
+      title: "Used matter knowledge",
+      detail: Array.isArray(event.entries)
+        ? `${event.entries.length} context entr${event.entries.length === 1 ? "y" : "ies"}`
+        : null,
+      created_at: createdAt,
+      href,
+    };
+  }
+  if (type === "knowledge_suggestion") {
+    return {
+      id,
+      type,
+      title: "Suggested knowledge entries",
+      detail: Array.isArray(event.entries)
+        ? `${event.entries.length} suggested entr${event.entries.length === 1 ? "y" : "ies"}`
+        : null,
+      created_at: createdAt,
+      href,
+    };
+  }
+  return null;
+}
+
 // GET /projects
 projectsRouter.get("/", requireAuth, async (req, res) => {
   const userId = res.locals.userId as string;
@@ -324,6 +464,176 @@ projectsRouter.get("/:projectId/people", requireAuth, async (req, res) => {
   });
 
   res.json({ owner, members });
+});
+
+// GET /projects/:projectId/activity
+projectsRouter.get("/:projectId/activity", requireAuth, async (req, res) => {
+  const userId = res.locals.userId as string;
+  const userEmail = res.locals.userEmail as string | undefined;
+  const { projectId } = req.params;
+  const db = createServerSupabase();
+
+  const access = await checkProjectAccess(projectId, userId, userEmail, db);
+  if (!access.ok)
+    return void res.status(404).json({ detail: "Project not found" });
+
+  const [{ data: chats }, { data: docs }, { data: reviews }] =
+    await Promise.all([
+      db
+        .from("chats")
+        .select("id, title, user_id, created_at")
+        .eq("project_id", projectId)
+        .order("created_at", { ascending: false })
+        .limit(20),
+      db.from("documents").select("id").eq("project_id", projectId),
+      db
+        .from("tabular_reviews")
+        .select("id, title, created_at, updated_at")
+        .eq("project_id", projectId)
+        .order("updated_at", { ascending: false })
+        .limit(20),
+    ]);
+
+  const chatRows = (chats ?? []) as {
+    id: string;
+    title: string | null;
+    user_id: string;
+    created_at: string;
+  }[];
+  const chatIds = chatRows.map((chat) => chat.id);
+  const documentIds = ((docs ?? []) as { id: string }[]).map((doc) => doc.id);
+
+  const [{ data: messages }, { data: versions }, { data: edits }] =
+    await Promise.all([
+      chatIds.length
+        ? db
+            .from("chat_messages")
+            .select("id, chat_id, role, content, created_at")
+            .in("chat_id", chatIds)
+            .eq("role", "assistant")
+            .order("created_at", { ascending: false })
+            .limit(80)
+        : Promise.resolve({ data: [] }),
+      documentIds.length
+        ? db
+            .from("document_versions")
+            .select("id, document_id, source, filename, version_number, created_at")
+            .in("document_id", documentIds)
+            .order("created_at", { ascending: false })
+            .limit(40)
+        : Promise.resolve({ data: [] }),
+      documentIds.length
+        ? db
+            .from("document_edits")
+            .select("id, document_id, status, inserted_text, deleted_text, created_at, resolved_at")
+            .in("document_id", documentIds)
+            .order("created_at", { ascending: false })
+            .limit(40)
+        : Promise.resolve({ data: [] }),
+    ]);
+
+  const items: ProjectActivityItem[] = [];
+  for (const chat of chatRows) {
+    items.push({
+      id: `chat:${chat.id}`,
+      type: "chat_created",
+      title: chat.title ? `Started chat ${chat.title}` : "Started assistant chat",
+      detail: null,
+      created_at: chat.created_at,
+      href: `/projects/${projectId}/assistant/chat/${chat.id}`,
+    });
+  }
+
+  for (const message of (messages ?? []) as {
+    id: string;
+    chat_id: string;
+    content: unknown;
+    created_at: string;
+  }[]) {
+    if (!Array.isArray(message.content)) continue;
+    message.content.forEach((event, index) => {
+      if (!event || typeof event !== "object" || Array.isArray(event)) return;
+      const item = assistantEventActivity({
+        event: event as Record<string, unknown>,
+        chatId: message.chat_id,
+        messageId: message.id,
+        createdAt: message.created_at,
+        index,
+        projectId,
+      });
+      if (item) items.push(item);
+    });
+  }
+
+  for (const version of (versions ?? []) as {
+    id: string;
+    document_id: string;
+    source: string | null;
+    filename: string | null;
+    version_number: number | null;
+    created_at: string;
+  }[]) {
+    const sourceLabel =
+      version.source === "assistant_edit"
+        ? "Edited"
+        : version.source === "generated"
+          ? "Generated"
+          : version.source === "user_upload"
+            ? "Uploaded new version of"
+            : "Uploaded";
+    items.push({
+      id: `version:${version.id}`,
+      type: "document_version",
+      title: `${sourceLabel} ${version.filename ?? "document"}`,
+      detail:
+        typeof version.version_number === "number"
+          ? `Version ${version.version_number}`
+          : null,
+      created_at: version.created_at,
+      metadata: { document_id: version.document_id, source: version.source },
+    });
+  }
+
+  for (const edit of (edits ?? []) as {
+    id: string;
+    document_id: string;
+    status: string;
+    inserted_text: string | null;
+    deleted_text: string | null;
+    created_at: string;
+    resolved_at: string | null;
+  }[]) {
+    items.push({
+      id: `edit:${edit.id}`,
+      type: "document_edit",
+      title:
+        edit.status === "pending"
+          ? "Tracked edit pending"
+          : `Tracked edit ${edit.status}`,
+      detail: activityDetail(edit.inserted_text || edit.deleted_text),
+      created_at: edit.resolved_at ?? edit.created_at,
+      metadata: { document_id: edit.document_id, status: edit.status },
+    });
+  }
+
+  for (const review of (reviews ?? []) as {
+    id: string;
+    title: string | null;
+    created_at: string;
+    updated_at: string;
+  }[]) {
+    items.push({
+      id: `review:${review.id}`,
+      type: "tabular_review",
+      title: review.title ? `Updated review ${review.title}` : "Updated tabular review",
+      detail: null,
+      created_at: review.updated_at ?? review.created_at,
+      href: `/projects/${projectId}/tabular-reviews/${review.id}`,
+    });
+  }
+
+  items.sort((a, b) => b.created_at.localeCompare(a.created_at));
+  res.json(items.slice(0, 80));
 });
 
 // PATCH /projects/:projectId

--- a/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.tsx
+++ b/frontend/src/app/(pages)/projects/[id]/assistant/chat/[chatId]/page.tsx
@@ -31,6 +31,7 @@ import {
     deleteProjectFolder,
     moveDocumentToFolder,
     moveSubfolderToFolder,
+    createProjectKnowledgeEntry,
 } from "@/app/lib/mikeApi";
 import { useAssistantChat } from "@/app/hooks/useAssistantChat";
 import { useChatHistoryContext } from "@/app/contexts/ChatHistoryContext";
@@ -53,6 +54,7 @@ import type {
     CitationAnnotation,
     Document,
     EditAnnotation,
+    KnowledgeSuggestion,
     Message,
     Project,
 } from "@/app/components/shared/types";
@@ -544,6 +546,20 @@ export default function ProjectAssistantChatPage({ params }: Props) {
     const handleEditError = (args: { documentId: string; message: string }) => {
         patchTab(args.documentId, { warning: args.message });
     };
+
+    const handleSaveKnowledgeSuggestion = useCallback(
+        async (entry: KnowledgeSuggestion) => {
+            await createProjectKnowledgeEntry(projectId, {
+                entry_type: entry.entry_type,
+                title: entry.title,
+                body: entry.body,
+                metadata: entry.metadata,
+                source_refs: entry.source_refs,
+                include_in_agent_context: true,
+            });
+        },
+        [projectId],
+    );
 
     const dismissTabWarning = (documentId: string) => {
         patchTab(documentId, { warning: null });
@@ -1217,6 +1233,9 @@ export default function ProjectAssistantChatPage({ params }: Props) {
                                                 handleEditViewClick
                                             }
                                             onOpenDocument={handleOpenDocument}
+                                            onSaveKnowledgeSuggestion={
+                                                handleSaveKnowledgeSuggestion
+                                            }
                                             onEditResolved={handleEditResolved}
                                             onEditError={handleEditError}
                                             isDocReloading={(docId) =>

--- a/frontend/src/app/(pages)/projects/[id]/workspace/page.tsx
+++ b/frontend/src/app/(pages)/projects/[id]/workspace/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { ProjectMatterWorkspace } from "@/app/components/projects/ProjectMatterWorkspace";
+
+interface Props {
+    params: Promise<{ id: string }>;
+}
+
+export default function ProjectWorkspacePage({ params }: Props) {
+    const { id } = use(params);
+    return <ProjectMatterWorkspace projectId={id} />;
+}

--- a/frontend/src/app/components/assistant/AssistantMessage.tsx
+++ b/frontend/src/app/components/assistant/AssistantMessage.tsx
@@ -13,8 +13,10 @@ import {
     Download,
     File,
     FileText,
+    Library,
     Loader2,
     Scale,
+    Sparkles,
 } from "lucide-react";
 import { MikeIcon } from "@/components/chat/mike-icon";
 import { displayCitationQuote, formatCitationPage } from "../shared/types";
@@ -22,6 +24,7 @@ import type {
     AssistantEvent,
     CitationAnnotation,
     EditAnnotation,
+    KnowledgeSuggestion,
 } from "../shared/types";
 import { EditCard, applyOptimisticResolution } from "./EditCard";
 import { PreResponseWrapper } from "../shared/PreResponseWrapper";
@@ -42,6 +45,11 @@ function toolCallLabel(name: string): string {
     if (name === "read_workflow") return "Loading workflow...";
     if (name === "list_workflows") return "Loading workflows...";
     if (name === "list_documents") return "Loading documents...";
+    if (name === "list_knowledge_entries") return "Loading knowledge...";
+    if (name === "search_knowledge_entries") return "Searching knowledge...";
+    if (name === "read_knowledge_entry") return "Reading knowledge...";
+    if (name === "suggest_knowledge_entries")
+        return "Suggesting knowledge...";
     if (name === "courtlistener_search_case_law")
         return "Searching case law...";
     if (name === "courtlistener_get_cases") return "Fetching cases...";
@@ -865,6 +873,142 @@ function WorkflowAppliedBlock({
     );
 }
 
+function knowledgeTypeLabel(type: string) {
+    return type.replace(/_/g, " ");
+}
+
+function KnowledgeContextBlock({
+    entries,
+    showConnector,
+}: {
+    entries: Extract<AssistantEvent, { type: "knowledge_context" }>["entries"];
+    showConnector?: boolean;
+}) {
+    const titles = entries.map((entry) => entry.title).filter(Boolean);
+    const visibleTitles = titles.slice(0, 3).join(", ");
+    const extraCount = Math.max(0, titles.length - 3);
+
+    return (
+        <div className="flex items-start text-sm font-serif text-gray-500 relative">
+            {showConnector && (
+                <div className="absolute bottom-0 w-[1px] bg-gray-300 top-[13px] left-[2.5px] h-[calc(100%+11px)]" />
+            )}
+            <div className="mt-1.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-500">
+                <Library className="h-2.5 w-2.5" />
+            </div>
+            <div className="ml-2 min-w-0 flex-1 whitespace-normal break-words">
+                <span className="font-medium">Used matter knowledge</span>
+                {visibleTitles ? (
+                    <span>
+                        {" "}
+                        {visibleTitles}
+                        {extraCount > 0 ? ` +${extraCount}` : ""}
+                    </span>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+function knowledgeSuggestionKey(entry: KnowledgeSuggestion, index: number) {
+    return `${entry.entry_type}:${entry.title}:${entry.body.slice(0, 64)}:${index}`;
+}
+
+function KnowledgeSuggestionBlock({
+    entries,
+    showConnector,
+    onSave,
+}: {
+    entries: KnowledgeSuggestion[];
+    showConnector?: boolean;
+    onSave?: (entry: KnowledgeSuggestion) => Promise<void> | void;
+}) {
+    const [savingKeys, setSavingKeys] = useState<Record<string, boolean>>({});
+    const [savedKeys, setSavedKeys] = useState<Record<string, boolean>>({});
+
+    const handleSave = async (
+        entry: KnowledgeSuggestion,
+        key: string,
+    ) => {
+        if (!onSave || savingKeys[key] || savedKeys[key]) return;
+        setSavingKeys((prev) => ({ ...prev, [key]: true }));
+        try {
+            await onSave(entry);
+            setSavedKeys((prev) => ({ ...prev, [key]: true }));
+        } catch (error) {
+            console.error("[AssistantMessage] failed to save knowledge", error);
+        } finally {
+            setSavingKeys((prev) => ({ ...prev, [key]: false }));
+        }
+    };
+
+    return (
+        <div className="relative">
+            {showConnector && (
+                <div className="absolute bottom-0 w-[1px] bg-gray-300 top-[13px] left-[2.5px] h-[calc(100%+11px)]" />
+            )}
+            <div className="flex items-start text-sm font-serif text-gray-500">
+                <div className="mt-1.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-500">
+                    <Sparkles className="h-2.5 w-2.5" />
+                </div>
+                <div className="ml-2 min-w-0 flex-1">
+                    <div className="font-medium">Suggested knowledge</div>
+                    <div className="mt-2 flex flex-col gap-2">
+                        {entries.map((entry, index) => {
+                            const key = knowledgeSuggestionKey(entry, index);
+                            const isSaving = !!savingKeys[key];
+                            const isSaved = !!savedKeys[key];
+                            return (
+                                <div
+                                    key={key}
+                                    className={`${RESPONSE_GLASS_SURFACE} px-3 py-2 font-sans text-gray-700`}
+                                >
+                                    <div className="flex min-w-0 items-start justify-between gap-3">
+                                        <div className="min-w-0">
+                                            <div className="flex items-center gap-2">
+                                                <span className="rounded border border-gray-200 bg-white/70 px-1.5 py-0.5 text-[10px] font-medium uppercase text-gray-500">
+                                                    {knowledgeTypeLabel(
+                                                        entry.entry_type,
+                                                    )}
+                                                </span>
+                                                <span className="truncate text-sm font-medium text-gray-900">
+                                                    {entry.title}
+                                                </span>
+                                            </div>
+                                            <p className="mt-1 line-clamp-2 text-xs leading-5 text-gray-600">
+                                                {entry.body}
+                                            </p>
+                                        </div>
+                                        {onSave && (
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    void handleSave(entry, key)
+                                                }
+                                                disabled={isSaving || isSaved}
+                                                className="inline-flex h-7 shrink-0 items-center gap-1 rounded border border-gray-200 bg-white px-2 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-60"
+                                            >
+                                                {isSaving ? (
+                                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                                ) : isSaved ? (
+                                                    <Check className="h-3 w-3" />
+                                                ) : (
+                                                    <Library className="h-3 w-3" />
+                                                )}
+                                                {isSaved ? "Saved" : "Save"}
+                                            </button>
+                                        )}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 type CourtListenerBlockItem = {
     caseName: string | null;
     citation: string | null;
@@ -1583,6 +1727,9 @@ interface Props {
     ) => void;
     minHeight?: string;
     onWorkflowClick?: (workflowId: string) => void;
+    onSaveKnowledgeSuggestion?: (
+        entry: KnowledgeSuggestion,
+    ) => Promise<void> | void;
     onEditViewClick?: (ann: EditAnnotation, filename: string) => void;
     /**
      * Opens the editor panel for a document without auto-highlighting any
@@ -1648,6 +1795,7 @@ export function AssistantMessage({
     onCaseClick,
     minHeight = "0px",
     onWorkflowClick,
+    onSaveKnowledgeSuggestion,
     onEditViewClick,
     onOpenDocument,
     onEditResolveStart,
@@ -2046,6 +2194,25 @@ export function AssistantMessage({
                             ? () => onWorkflowClick(event.workflow_id)
                             : undefined
                     }
+                />
+            );
+        }
+        if (event.type === "knowledge_context") {
+            return (
+                <KnowledgeContextBlock
+                    key={globalIdx}
+                    entries={event.entries}
+                    showConnector={showConnector}
+                />
+            );
+        }
+        if (event.type === "knowledge_suggestion") {
+            return (
+                <KnowledgeSuggestionBlock
+                    key={globalIdx}
+                    entries={event.entries}
+                    showConnector={showConnector}
+                    onSave={onSaveKnowledgeSuggestion}
                 />
             );
         }

--- a/frontend/src/app/components/projects/ProjectMatterWorkspace.tsx
+++ b/frontend/src/app/components/projects/ProjectMatterWorkspace.tsx
@@ -1,0 +1,1131 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Dispatch, ReactNode, SetStateAction } from "react";
+import { useRouter } from "next/navigation";
+import {
+    Archive,
+    Bot,
+    CalendarDays,
+    Check,
+    Database,
+    FileText,
+    Library,
+    Link as LinkIcon,
+    Loader2,
+    MessageSquare,
+    Plus,
+    RefreshCw,
+    Scale,
+    Search,
+    Sparkles,
+    Table2,
+    Wand2,
+} from "lucide-react";
+import {
+    createLibraryKnowledgeEntry,
+    createProjectKnowledgeEntry,
+    deleteKnowledgeEntry,
+    linkLibraryKnowledgeEntryToProject,
+    listLibraryKnowledgeEntries,
+    listProjectActivity,
+    listProjectKnowledgeEntries,
+    updateKnowledgeEntry,
+} from "@/app/lib/mikeApi";
+import {
+    ProjectSectionToolbar,
+    useProjectWorkspace,
+} from "@/app/components/projects/ProjectWorkspace";
+import { useChatHistoryContext } from "@/app/contexts/ChatHistoryContext";
+import type {
+    KnowledgeEntry,
+    KnowledgeEntryType,
+    Message,
+    ProjectActivityItem,
+} from "@/app/components/shared/types";
+
+type KnowledgeScope = "project" | "library";
+
+type KnowledgeDraft = {
+    scope: KnowledgeScope;
+    entry_type: KnowledgeEntryType;
+    title: string;
+    body: string;
+    include_in_agent_context: boolean;
+};
+
+const KNOWLEDGE_TYPES: { value: KnowledgeEntryType; label: string }[] = [
+    { value: "fact", label: "Fact" },
+    { value: "party", label: "Party" },
+    { value: "date", label: "Date" },
+    { value: "clause", label: "Clause" },
+    { value: "position", label: "Position" },
+    { value: "playbook", label: "Playbook" },
+    { value: "source", label: "Source" },
+];
+
+const OUTPUT_ACTIVITY_TYPES = new Set([
+    "doc_created",
+    "doc_replicated",
+    "doc_edited",
+    "document_version",
+    "document_edit",
+    "workflow_applied",
+    "tabular_review",
+    "knowledge_suggestion",
+]);
+
+function dateMs(value: string | null | undefined) {
+    if (!value) return 0;
+    const ms = Date.parse(value);
+    return Number.isNaN(ms) ? 0 : ms;
+}
+
+function formatDateTime(value: string | null | undefined) {
+    if (!value) return "No date";
+    const date = new Date(value);
+    if (Number.isNaN(date.valueOf())) return "No date";
+    return date.toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+    });
+}
+
+function entryTypeLabel(type: KnowledgeEntryType) {
+    return KNOWLEDGE_TYPES.find((item) => item.value === type)?.label ?? type;
+}
+
+function matchesQuery(
+    value: {
+        title?: string | null;
+        body?: string | null;
+        detail?: string | null;
+        type?: string | null;
+    },
+    query: string,
+) {
+    const q = query.trim().toLowerCase();
+    if (!q) return true;
+    return [value.title, value.body, value.detail, value.type]
+        .filter(Boolean)
+        .some((part) => String(part).toLowerCase().includes(q));
+}
+
+export function ProjectMatterWorkspace({ projectId }: { projectId: string }) {
+    const router = useRouter();
+    const workspace = useProjectWorkspace();
+    const {
+        project,
+        projectLoading,
+        projectChats,
+        projectReviews,
+        ensureProjectChats,
+        ensureProjectReviews,
+        openNewReview,
+        search,
+    } = workspace;
+    const { saveChat, setNewChatMessages } = useChatHistoryContext();
+
+    const [projectKnowledge, setProjectKnowledge] = useState<
+        KnowledgeEntry[] | null
+    >(null);
+    const [libraryKnowledge, setLibraryKnowledge] = useState<
+        KnowledgeEntry[] | null
+    >(null);
+    const [activity, setActivity] = useState<ProjectActivityItem[] | null>(
+        null,
+    );
+    const [refreshing, setRefreshing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [draft, setDraft] = useState<KnowledgeDraft>({
+        scope: "project",
+        entry_type: "fact",
+        title: "",
+        body: "",
+        include_in_agent_context: true,
+    });
+    const [savingDraft, setSavingDraft] = useState(false);
+    const [mutatingEntryId, setMutatingEntryId] = useState<string | null>(null);
+    const [launchingAction, setLaunchingAction] = useState<string | null>(null);
+
+    const refreshWorkspace = useCallback(async () => {
+        setRefreshing(true);
+        setError(null);
+        try {
+            const [matterEntries, libraryEntries, activityItems] =
+                await Promise.all([
+                    listProjectKnowledgeEntries(projectId),
+                    listLibraryKnowledgeEntries(),
+                    listProjectActivity(projectId),
+                    ensureProjectChats(),
+                    ensureProjectReviews(),
+                ]);
+            setProjectKnowledge(matterEntries);
+            setLibraryKnowledge(libraryEntries);
+            setActivity(activityItems);
+        } catch (err) {
+            console.error("[Matter OS] failed to load workspace", err);
+            setError("Unable to load Matter OS data.");
+        } finally {
+            setRefreshing(false);
+        }
+    }, [ensureProjectChats, ensureProjectReviews, projectId]);
+
+    useEffect(() => {
+        const handle = window.setTimeout(() => {
+            void refreshWorkspace();
+        }, 0);
+        return () => window.clearTimeout(handle);
+    }, [refreshWorkspace]);
+
+    const documents = project?.documents ?? [];
+    const readyDocuments = documents.filter((doc) => doc.status === "ready");
+    const matterKnowledge = projectKnowledge ?? [];
+    const personalLibrary = libraryKnowledge ?? [];
+    const activityItems = activity ?? [];
+    const chats = useMemo(() => projectChats ?? [], [projectChats]);
+    const reviews = useMemo(() => projectReviews ?? [], [projectReviews]);
+    const contextEntries = matterKnowledge.filter(
+        (entry) => entry.include_in_agent_context,
+    );
+    const linkedLibraryIds = new Set(
+        matterKnowledge
+            .map((entry) => entry.library_origin_id)
+            .filter((id): id is string => !!id),
+    );
+    const latestReview = useMemo(
+        () =>
+            [...reviews].sort(
+                (a, b) => dateMs(b.updated_at) - dateMs(a.updated_at),
+            )[0] ?? null,
+        [reviews],
+    );
+    const latestActivity = activityItems[0] ?? null;
+    const connectorActivityCount = activityItems.filter(
+        (item) =>
+            item.type === "mcp_tool_call" ||
+            item.type.startsWith("courtlistener_"),
+    ).length;
+
+    const filteredMatterKnowledge = matterKnowledge.filter((entry) =>
+        matchesQuery(
+            {
+                title: entry.title,
+                body: entry.body,
+                type: entry.entry_type,
+            },
+            search,
+        ),
+    );
+    const filteredLibrary = personalLibrary.filter((entry) =>
+        matchesQuery(
+            {
+                title: entry.title,
+                body: entry.body,
+                type: entry.entry_type,
+            },
+            search,
+        ),
+    );
+    const filteredActivity = activityItems.filter((item) =>
+        matchesQuery(item, search),
+    );
+    const recentOutputs = activityItems
+        .filter((item) => OUTPUT_ACTIVITY_TYPES.has(item.type))
+        .slice(0, 6);
+    const recentDocuments = [...documents]
+        .sort(
+            (a, b) =>
+                dateMs(b.updated_at ?? b.created_at) -
+                dateMs(a.updated_at ?? a.created_at),
+        )
+        .slice(0, 4);
+
+    const launchChat = useCallback(
+        async (actionId: string, prompt: string) => {
+            if (launchingAction) return;
+            setLaunchingAction(actionId);
+            const message: Message = { role: "user", content: prompt };
+            setNewChatMessages([message]);
+            try {
+                const chatId = await saveChat(projectId);
+                if (chatId) {
+                    router.push(`/projects/${projectId}/assistant/chat/${chatId}`);
+                } else {
+                    setNewChatMessages(null);
+                    setError("Unable to create assistant chat.");
+                }
+            } finally {
+                setLaunchingAction(null);
+            }
+        },
+        [
+            launchingAction,
+            projectId,
+            router,
+            saveChat,
+            setNewChatMessages,
+        ],
+    );
+
+    const handleCreateKnowledge = async () => {
+        const title = draft.title.trim();
+        const body = draft.body.trim();
+        if (!title || !body || savingDraft) return;
+        setSavingDraft(true);
+        setError(null);
+        try {
+            const payload = {
+                entry_type: draft.entry_type,
+                title,
+                body,
+                include_in_agent_context: draft.include_in_agent_context,
+            };
+            if (draft.scope === "library") {
+                const created = await createLibraryKnowledgeEntry(payload);
+                setLibraryKnowledge((prev) => [created, ...(prev ?? [])]);
+            } else {
+                const created = await createProjectKnowledgeEntry(
+                    projectId,
+                    payload,
+                );
+                setProjectKnowledge((prev) => [created, ...(prev ?? [])]);
+            }
+            setDraft((prev) => ({ ...prev, title: "", body: "" }));
+        } catch (err) {
+            console.error("[Matter OS] create knowledge failed", err);
+            setError("Unable to save knowledge entry.");
+        } finally {
+            setSavingDraft(false);
+        }
+    };
+
+    const handleLinkLibrary = async (entry: KnowledgeEntry) => {
+        if (linkedLibraryIds.has(entry.id) || mutatingEntryId) return;
+        setMutatingEntryId(entry.id);
+        setError(null);
+        try {
+            const linked = await linkLibraryKnowledgeEntryToProject(
+                projectId,
+                entry.id,
+            );
+            setProjectKnowledge((prev) => [linked, ...(prev ?? [])]);
+        } catch (err) {
+            console.error("[Matter OS] link library failed", err);
+            setError("Unable to link library entry.");
+        } finally {
+            setMutatingEntryId(null);
+        }
+    };
+
+    const handleArchiveEntry = async (entry: KnowledgeEntry) => {
+        if (mutatingEntryId) return;
+        setMutatingEntryId(entry.id);
+        setError(null);
+        try {
+            await deleteKnowledgeEntry(entry.id);
+            if (entry.project_id) {
+                setProjectKnowledge((prev) =>
+                    (prev ?? []).filter((item) => item.id !== entry.id),
+                );
+            } else {
+                setLibraryKnowledge((prev) =>
+                    (prev ?? []).filter((item) => item.id !== entry.id),
+                );
+            }
+        } catch (err) {
+            console.error("[Matter OS] archive knowledge failed", err);
+            setError("Unable to archive knowledge entry.");
+        } finally {
+            setMutatingEntryId(null);
+        }
+    };
+
+    const handleToggleContext = async (entry: KnowledgeEntry) => {
+        if (mutatingEntryId) return;
+        setMutatingEntryId(entry.id);
+        setError(null);
+        try {
+            const updated = await updateKnowledgeEntry(entry.id, {
+                include_in_agent_context: !entry.include_in_agent_context,
+            });
+            const applyUpdate = (items: KnowledgeEntry[] | null) =>
+                (items ?? []).map((item) =>
+                    item.id === updated.id ? updated : item,
+                );
+            if (updated.project_id) {
+                setProjectKnowledge(applyUpdate);
+            } else {
+                setLibraryKnowledge(applyUpdate);
+            }
+        } catch (err) {
+            console.error("[Matter OS] update knowledge failed", err);
+            setError("Unable to update knowledge entry.");
+        } finally {
+            setMutatingEntryId(null);
+        }
+    };
+
+    const guidedActions = [
+        {
+            id: "matter-brief",
+            label: "Matter brief",
+            detail: "Assistant chat",
+            icon: Bot,
+            onClick: () =>
+                launchChat(
+                    "matter-brief",
+                    "Create a concise matter brief from the project documents, chats, reviews, and active matter knowledge. Include key parties, posture, issues, open questions, and immediate next actions.",
+                ),
+        },
+        {
+            id: "chronology",
+            label: "Chronology",
+            detail: "Assistant chat",
+            icon: CalendarDays,
+            onClick: () =>
+                launchChat(
+                    "chronology",
+                    "Build a matter chronology from the uploaded documents and active matter knowledge. Flag uncertain dates and cite supporting material where available.",
+                ),
+        },
+        {
+            id: "document-review",
+            label: latestReview ? "Open review" : "New review",
+            detail: latestReview?.title ?? "Tabular review",
+            icon: Table2,
+            disabled: readyDocuments.length === 0,
+            onClick: () => {
+                if (latestReview) {
+                    router.push(
+                        `/projects/${projectId}/tabular-reviews/${latestReview.id}`,
+                    );
+                    return;
+                }
+                openNewReview();
+            },
+        },
+        {
+            id: "workflow",
+            label: "Apply workflow",
+            detail: "Assistant chat",
+            icon: Wand2,
+            onClick: () =>
+                launchChat(
+                    "workflow",
+                    "Review available assistant workflows and apply the best fit for this matter. Ask before making document edits, and use tracked-change approvals for document mutations.",
+                ),
+        },
+        {
+            id: "research",
+            label: "Legal research",
+            detail: "Research prompt",
+            icon: Scale,
+            onClick: () =>
+                launchChat(
+                    "research",
+                    "Start a legal research pass for this matter. Use the matter knowledge as context, identify the governing questions first, then search for authorities and summarize findings with citations.",
+                ),
+        },
+    ];
+
+    const loadingInitial =
+        projectLoading ||
+        projectKnowledge === null ||
+        libraryKnowledge === null ||
+        activity === null;
+
+    return (
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-white">
+            <ProjectSectionToolbar
+                actions={
+                    <button
+                        type="button"
+                        onClick={() => void refreshWorkspace()}
+                        disabled={refreshing}
+                        className="inline-flex h-7 items-center gap-1 rounded border border-gray-200 bg-white px-2 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-60"
+                        title="Refresh Matter OS"
+                    >
+                        {refreshing ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                            <RefreshCw className="h-3.5 w-3.5" />
+                        )}
+                        <span className="hidden sm:inline">Refresh</span>
+                    </button>
+                }
+            />
+
+            <div className="min-h-0 flex-1 overflow-auto px-4 py-4 md:px-10">
+                {error && (
+                    <div className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                        {error}
+                    </div>
+                )}
+
+                <section className="border-b border-gray-200 pb-4">
+                    <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                        <div className="min-w-0">
+                            <div className="flex items-center gap-2 text-xs font-medium text-gray-500">
+                                <Sparkles className="h-3.5 w-3.5" />
+                                Matter OS
+                            </div>
+                            <h1 className="mt-1 truncate text-2xl font-serif font-medium text-gray-950">
+                                {project?.name ?? "Loading matter"}
+                            </h1>
+                            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-gray-500">
+                                {project?.cm_number && (
+                                    <span>{project.cm_number}</span>
+                                )}
+                                {latestActivity && (
+                                    <span>
+                                        Latest: {formatDateTime(latestActivity.created_at)}
+                                    </span>
+                                )}
+                            </div>
+                        </div>
+                        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                            <MetricTile
+                                icon={<FileText className="h-4 w-4" />}
+                                label="Documents"
+                                value={`${readyDocuments.length}/${documents.length}`}
+                                detail="ready"
+                            />
+                            <MetricTile
+                                icon={<Library className="h-4 w-4" />}
+                                label="Knowledge"
+                                value={`${contextEntries.length}`}
+                                detail="in context"
+                            />
+                            <MetricTile
+                                icon={<MessageSquare className="h-4 w-4" />}
+                                label="Chats"
+                                value={`${chats.length}`}
+                                detail="matter"
+                            />
+                            <MetricTile
+                                icon={<Table2 className="h-4 w-4" />}
+                                label="Reviews"
+                                value={`${reviews.length}`}
+                                detail="tabular"
+                            />
+                        </div>
+                    </div>
+                </section>
+
+                {loadingInitial ? (
+                    <div className="grid gap-3 py-6 md:grid-cols-3">
+                        {Array.from({ length: 6 }).map((_, index) => (
+                            <div
+                                key={index}
+                                className="h-24 rounded border border-gray-200 bg-gray-50"
+                            >
+                                <div className="h-full animate-pulse bg-gradient-to-r from-gray-50 via-gray-100 to-gray-50 bg-[length:200%_100%]" />
+                            </div>
+                        ))}
+                    </div>
+                ) : (
+                    <div className="grid gap-6 py-6 xl:grid-cols-[minmax(0,1fr)_360px]">
+                        <div className="min-w-0 space-y-6">
+                            <section>
+                                <SectionHeader
+                                    title="Guided Actions"
+                                    detail={`${readyDocuments.length} ready document${readyDocuments.length === 1 ? "" : "s"}`}
+                                />
+                                <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+                                    {guidedActions.map((action) => {
+                                        const Icon = action.icon;
+                                        return (
+                                            <GuidedActionButton
+                                                key={action.id}
+                                                label={action.label}
+                                                detail={action.detail}
+                                                icon={
+                                                    <Icon className="h-4 w-4" />
+                                                }
+                                                loading={
+                                                    launchingAction ===
+                                                    action.id
+                                                }
+                                                disabled={action.disabled}
+                                                onClick={action.onClick}
+                                            />
+                                        );
+                                    })}
+                                </div>
+                            </section>
+
+                            <section>
+                                <SectionHeader
+                                    title="Knowledge Base"
+                                    detail={`${matterKnowledge.length} matter, ${personalLibrary.length} personal`}
+                                />
+                                <KnowledgeDraftForm
+                                    draft={draft}
+                                    onDraftChange={setDraft}
+                                    onSubmit={handleCreateKnowledge}
+                                    saving={savingDraft}
+                                />
+                                <div className="mt-4 grid gap-4 lg:grid-cols-2">
+                                    <KnowledgeList
+                                        title="Matter Knowledge"
+                                        entries={filteredMatterKnowledge}
+                                        emptyLabel="No matter knowledge"
+                                        mutatingEntryId={mutatingEntryId}
+                                        onArchive={handleArchiveEntry}
+                                        onToggleContext={handleToggleContext}
+                                    />
+                                    <KnowledgeList
+                                        title="Personal Library"
+                                        entries={filteredLibrary}
+                                        emptyLabel="No personal library entries"
+                                        linkedLibraryIds={linkedLibraryIds}
+                                        mutatingEntryId={mutatingEntryId}
+                                        onArchive={handleArchiveEntry}
+                                        onLink={handleLinkLibrary}
+                                    />
+                                </div>
+                            </section>
+                        </div>
+
+                        <aside className="min-w-0 space-y-6">
+                            <section>
+                                <SectionHeader title="Connected Sources" />
+                                <div className="mt-3 divide-y divide-gray-100 rounded border border-gray-200 bg-white">
+                                    <SourceRow
+                                        icon={<FileText className="h-4 w-4" />}
+                                        title="Documents"
+                                        detail={`${readyDocuments.length} ready`}
+                                        onClick={() => router.push(`/projects/${projectId}`)}
+                                    />
+                                    <SourceRow
+                                        icon={<Library className="h-4 w-4" />}
+                                        title="Matter knowledge"
+                                        detail={`${contextEntries.length} active`}
+                                    />
+                                    <SourceRow
+                                        icon={<MessageSquare className="h-4 w-4" />}
+                                        title="Assistant chats"
+                                        detail={`${chats.length} saved`}
+                                        onClick={() =>
+                                            router.push(
+                                                `/projects/${projectId}/assistant`,
+                                            )
+                                        }
+                                    />
+                                    <SourceRow
+                                        icon={<Table2 className="h-4 w-4" />}
+                                        title="Tabular reviews"
+                                        detail={`${reviews.length} saved`}
+                                        onClick={() =>
+                                            router.push(
+                                                `/projects/${projectId}/tabular-reviews`,
+                                            )
+                                        }
+                                    />
+                                    <SourceRow
+                                        icon={<Database className="h-4 w-4" />}
+                                        title="Connectors"
+                                        detail={`${connectorActivityCount} calls`}
+                                    />
+                                </div>
+                            </section>
+
+                            <section>
+                                <SectionHeader title="Agent Activity" />
+                                <div className="mt-3 space-y-2">
+                                    {filteredActivity.slice(0, 8).length > 0 ? (
+                                        filteredActivity
+                                            .slice(0, 8)
+                                            .map((item) => (
+                                                <ActivityRow
+                                                    key={item.id}
+                                                    item={item}
+                                                    onOpen={
+                                                        item.href
+                                                            ? () =>
+                                                                  router.push(
+                                                                      item.href!,
+                                                                  )
+                                                            : undefined
+                                                    }
+                                                />
+                                            ))
+                                    ) : (
+                                        <EmptyState label="No activity" />
+                                    )}
+                                </div>
+                            </section>
+
+                            <section>
+                                <SectionHeader title="Recent Outputs" />
+                                <div className="mt-3 space-y-2">
+                                    {recentOutputs.length > 0 ? (
+                                        recentOutputs.map((item) => (
+                                            <ActivityRow
+                                                key={item.id}
+                                                item={item}
+                                                onOpen={
+                                                    item.href
+                                                        ? () =>
+                                                              router.push(
+                                                                  item.href!,
+                                                              )
+                                                        : undefined
+                                                }
+                                            />
+                                        ))
+                                    ) : recentDocuments.length > 0 ? (
+                                        recentDocuments.map((doc) => (
+                                            <OutputRow
+                                                key={doc.id}
+                                                title={doc.filename}
+                                                detail={formatDateTime(
+                                                    doc.updated_at ??
+                                                        doc.created_at,
+                                                )}
+                                            />
+                                        ))
+                                    ) : (
+                                        <EmptyState label="No outputs" />
+                                    )}
+                                </div>
+                            </section>
+                        </aside>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function SectionHeader({
+    title,
+    detail,
+}: {
+    title: string;
+    detail?: string;
+}) {
+    return (
+        <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-medium text-gray-950">{title}</h2>
+            {detail && <span className="text-xs text-gray-500">{detail}</span>}
+        </div>
+    );
+}
+
+function MetricTile({
+    icon,
+    label,
+    value,
+    detail,
+}: {
+    icon: ReactNode;
+    label: string;
+    value: string;
+    detail: string;
+}) {
+    return (
+        <div className="min-w-[120px] rounded border border-gray-200 bg-white px-3 py-2">
+            <div className="flex items-center gap-2 text-xs text-gray-500">
+                {icon}
+                {label}
+            </div>
+            <div className="mt-1 flex items-baseline gap-1">
+                <span className="text-lg font-medium text-gray-950">{value}</span>
+                <span className="text-xs text-gray-500">{detail}</span>
+            </div>
+        </div>
+    );
+}
+
+function GuidedActionButton({
+    icon,
+    label,
+    detail,
+    loading,
+    disabled,
+    onClick,
+}: {
+    icon: ReactNode;
+    label: string;
+    detail: string;
+    loading?: boolean;
+    disabled?: boolean;
+    onClick: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            disabled={disabled || loading}
+            className="flex min-h-[72px] items-center gap-3 rounded border border-gray-200 bg-white px-3 py-3 text-left transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-55"
+        >
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded border border-gray-200 bg-gray-50 text-gray-700">
+                {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : icon}
+            </span>
+            <span className="min-w-0">
+                <span className="block truncate text-sm font-medium text-gray-950">
+                    {label}
+                </span>
+                <span className="block truncate text-xs text-gray-500">
+                    {detail}
+                </span>
+            </span>
+        </button>
+    );
+}
+
+function KnowledgeDraftForm({
+    draft,
+    onDraftChange,
+    onSubmit,
+    saving,
+}: {
+    draft: KnowledgeDraft;
+    onDraftChange: Dispatch<SetStateAction<KnowledgeDraft>>;
+    onSubmit: () => void;
+    saving: boolean;
+}) {
+    const setField = <K extends keyof KnowledgeDraft>(
+        key: K,
+        value: KnowledgeDraft[K],
+    ) => onDraftChange((prev) => ({ ...prev, [key]: value }));
+    const canSubmit = draft.title.trim().length > 0 && draft.body.trim().length > 0;
+
+    return (
+        <div className="mt-3 rounded border border-gray-200 bg-gray-50 p-3">
+            <div className="grid gap-2 md:grid-cols-[150px_160px_minmax(0,1fr)]">
+                <select
+                    value={draft.scope}
+                    onChange={(event) =>
+                        setField(
+                            "scope",
+                            event.target.value as KnowledgeScope,
+                        )
+                    }
+                    className="h-9 rounded border border-gray-200 bg-white px-2 text-sm text-gray-800 outline-none focus:border-gray-400"
+                >
+                    <option value="project">Matter</option>
+                    <option value="library">Personal Library</option>
+                </select>
+                <select
+                    value={draft.entry_type}
+                    onChange={(event) =>
+                        setField(
+                            "entry_type",
+                            event.target.value as KnowledgeEntryType,
+                        )
+                    }
+                    className="h-9 rounded border border-gray-200 bg-white px-2 text-sm text-gray-800 outline-none focus:border-gray-400"
+                >
+                    {KNOWLEDGE_TYPES.map((type) => (
+                        <option key={type.value} value={type.value}>
+                            {type.label}
+                        </option>
+                    ))}
+                </select>
+                <input
+                    value={draft.title}
+                    onChange={(event) => setField("title", event.target.value)}
+                    placeholder="Title"
+                    className="h-9 rounded border border-gray-200 bg-white px-3 text-sm text-gray-900 outline-none placeholder:text-gray-400 focus:border-gray-400"
+                />
+            </div>
+            <textarea
+                value={draft.body}
+                onChange={(event) => setField("body", event.target.value)}
+                placeholder="Knowledge"
+                className="mt-2 h-24 w-full resize-none rounded border border-gray-200 bg-white px-3 py-2 text-sm leading-5 text-gray-900 outline-none placeholder:text-gray-400 focus:border-gray-400"
+            />
+            <div className="mt-2 flex items-center justify-between gap-3">
+                <label className="inline-flex items-center gap-2 text-xs text-gray-600">
+                    <input
+                        type="checkbox"
+                        checked={draft.include_in_agent_context}
+                        onChange={(event) =>
+                            setField(
+                                "include_in_agent_context",
+                                event.target.checked,
+                            )
+                        }
+                        className="h-3.5 w-3.5 rounded border-gray-300"
+                    />
+                    Include in agent context
+                </label>
+                <button
+                    type="button"
+                    onClick={onSubmit}
+                    disabled={!canSubmit || saving}
+                    className="inline-flex h-8 items-center gap-1.5 rounded border border-gray-900 bg-gray-900 px-3 text-xs font-medium text-white transition-colors hover:bg-gray-800 disabled:border-gray-300 disabled:bg-gray-300"
+                >
+                    {saving ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                        <Plus className="h-3.5 w-3.5" />
+                    )}
+                    Add
+                </button>
+            </div>
+        </div>
+    );
+}
+
+function KnowledgeList({
+    title,
+    entries,
+    emptyLabel,
+    linkedLibraryIds,
+    mutatingEntryId,
+    onArchive,
+    onLink,
+    onToggleContext,
+}: {
+    title: string;
+    entries: KnowledgeEntry[];
+    emptyLabel: string;
+    linkedLibraryIds?: Set<string>;
+    mutatingEntryId: string | null;
+    onArchive: (entry: KnowledgeEntry) => void;
+    onLink?: (entry: KnowledgeEntry) => void;
+    onToggleContext?: (entry: KnowledgeEntry) => void;
+}) {
+    return (
+        <div className="min-w-0 rounded border border-gray-200 bg-white">
+            <div className="flex h-10 items-center justify-between border-b border-gray-100 px-3">
+                <h3 className="text-xs font-medium text-gray-700">{title}</h3>
+                <span className="text-xs text-gray-400">{entries.length}</span>
+            </div>
+            <div className="max-h-[420px] overflow-auto p-2">
+                {entries.length > 0 ? (
+                    <div className="space-y-2">
+                        {entries.map((entry) => (
+                            <KnowledgeRow
+                                key={entry.id}
+                                entry={entry}
+                                linked={linkedLibraryIds?.has(entry.id)}
+                                busy={mutatingEntryId === entry.id}
+                                onArchive={() => onArchive(entry)}
+                                onLink={onLink ? () => onLink(entry) : undefined}
+                                onToggleContext={
+                                    onToggleContext
+                                        ? () => onToggleContext(entry)
+                                        : undefined
+                                }
+                            />
+                        ))}
+                    </div>
+                ) : (
+                    <EmptyState label={emptyLabel} />
+                )}
+            </div>
+        </div>
+    );
+}
+
+function KnowledgeRow({
+    entry,
+    linked,
+    busy,
+    onArchive,
+    onLink,
+    onToggleContext,
+}: {
+    entry: KnowledgeEntry;
+    linked?: boolean;
+    busy?: boolean;
+    onArchive: () => void;
+    onLink?: () => void;
+    onToggleContext?: () => void;
+}) {
+    return (
+        <div className="rounded border border-gray-100 bg-gray-50 px-3 py-2">
+            <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                        <span className="rounded border border-gray-200 bg-white px-1.5 py-0.5 text-[10px] font-medium uppercase text-gray-500">
+                            {entryTypeLabel(entry.entry_type)}
+                        </span>
+                        {entry.include_in_agent_context && (
+                            <span className="inline-flex items-center gap-1 text-[11px] text-green-700">
+                                <Check className="h-3 w-3" />
+                                Context
+                            </span>
+                        )}
+                    </div>
+                    <div className="mt-1 truncate text-sm font-medium text-gray-950">
+                        {entry.title}
+                    </div>
+                    <p className="mt-1 line-clamp-2 text-xs leading-5 text-gray-600">
+                        {entry.body}
+                    </p>
+                </div>
+                {busy && (
+                    <Loader2 className="mt-1 h-4 w-4 shrink-0 animate-spin text-gray-400" />
+                )}
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+                {onToggleContext && (
+                    <button
+                        type="button"
+                        onClick={onToggleContext}
+                        disabled={busy}
+                        className="inline-flex h-7 items-center gap-1 rounded border border-gray-200 bg-white px-2 text-xs text-gray-600 transition-colors hover:bg-gray-50 disabled:opacity-60"
+                    >
+                        {entry.include_in_agent_context ? "Mute" : "Use"}
+                    </button>
+                )}
+                {onLink && (
+                    <button
+                        type="button"
+                        onClick={onLink}
+                        disabled={busy || linked}
+                        className="inline-flex h-7 items-center gap-1 rounded border border-gray-200 bg-white px-2 text-xs text-gray-600 transition-colors hover:bg-gray-50 disabled:opacity-60"
+                    >
+                        {linked ? (
+                            <Check className="h-3 w-3" />
+                        ) : (
+                            <LinkIcon className="h-3 w-3" />
+                        )}
+                        {linked ? "Linked" : "Link"}
+                    </button>
+                )}
+                <button
+                    type="button"
+                    onClick={onArchive}
+                    disabled={busy}
+                    className="inline-flex h-7 items-center gap-1 rounded border border-gray-200 bg-white px-2 text-xs text-gray-500 transition-colors hover:bg-gray-50 disabled:opacity-60"
+                    title="Archive"
+                >
+                    <Archive className="h-3 w-3" />
+                </button>
+            </div>
+        </div>
+    );
+}
+
+function SourceRow({
+    icon,
+    title,
+    detail,
+    onClick,
+}: {
+    icon: ReactNode;
+    title: string;
+    detail: string;
+    onClick?: () => void;
+}) {
+    const content = (
+        <>
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded border border-gray-200 bg-gray-50 text-gray-600">
+                {icon}
+            </span>
+            <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium text-gray-800">
+                    {title}
+                </span>
+                <span className="block truncate text-xs text-gray-500">
+                    {detail}
+                </span>
+            </span>
+        </>
+    );
+
+    if (onClick) {
+        return (
+            <button
+                type="button"
+                onClick={onClick}
+                className="flex w-full items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-gray-50"
+            >
+                {content}
+            </button>
+        );
+    }
+    return <div className="flex items-center gap-3 px-3 py-2">{content}</div>;
+}
+
+function ActivityRow({
+    item,
+    onOpen,
+}: {
+    item: ProjectActivityItem;
+    onOpen?: () => void;
+}) {
+    const body = (
+        <>
+            <span className="mt-1 flex h-6 w-6 shrink-0 items-center justify-center rounded border border-gray-200 bg-white text-gray-500">
+                <ActivityIcon type={item.type} />
+            </span>
+            <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium text-gray-800">
+                    {item.title}
+                </span>
+                <span className="block truncate text-xs text-gray-500">
+                    {item.detail
+                        ? `${item.detail} - ${formatDateTime(item.created_at)}`
+                        : formatDateTime(item.created_at)}
+                </span>
+            </span>
+        </>
+    );
+
+    if (onOpen) {
+        return (
+            <button
+                type="button"
+                onClick={onOpen}
+                className="flex w-full items-start gap-2 rounded border border-gray-100 bg-gray-50 px-2 py-2 text-left transition-colors hover:bg-gray-100"
+            >
+                {body}
+            </button>
+        );
+    }
+
+    return (
+        <div className="flex items-start gap-2 rounded border border-gray-100 bg-gray-50 px-2 py-2">
+            {body}
+        </div>
+    );
+}
+
+function OutputRow({ title, detail }: { title: string; detail: string }) {
+    return (
+        <div className="flex items-start gap-2 rounded border border-gray-100 bg-gray-50 px-2 py-2">
+            <span className="mt-1 flex h-6 w-6 shrink-0 items-center justify-center rounded border border-gray-200 bg-white text-gray-500">
+                <FileText className="h-3.5 w-3.5" />
+            </span>
+            <span className="min-w-0">
+                <span className="block truncate text-sm font-medium text-gray-800">
+                    {title}
+                </span>
+                <span className="block truncate text-xs text-gray-500">
+                    {detail}
+                </span>
+            </span>
+        </div>
+    );
+}
+
+function ActivityIcon({ type }: { type: string }) {
+    if (type.includes("knowledge")) return <Library className="h-3.5 w-3.5" />;
+    if (type.includes("chat")) return <MessageSquare className="h-3.5 w-3.5" />;
+    if (type.includes("review")) return <Table2 className="h-3.5 w-3.5" />;
+    if (type.includes("courtlistener") || type.includes("connector")) {
+        return <Scale className="h-3.5 w-3.5" />;
+    }
+    if (type.includes("find") || type.includes("search")) {
+        return <Search className="h-3.5 w-3.5" />;
+    }
+    return <FileText className="h-3.5 w-3.5" />;
+}
+
+function EmptyState({ label }: { label: string }) {
+    return (
+        <div className="rounded border border-dashed border-gray-200 bg-white px-3 py-6 text-center text-sm text-gray-400">
+            {label}
+        </div>
+    );
+}

--- a/frontend/src/app/components/projects/ProjectPageParts.tsx
+++ b/frontend/src/app/components/projects/ProjectPageParts.tsx
@@ -20,7 +20,11 @@ import { RowActions } from "@/app/components/shared/RowActions";
 import { HeaderActionsMenu } from "@/app/components/shared/HeaderActionsMenu";
 import { TABLE_PRIMARY_CELL_WIDTH_CLASS } from "@/app/components/shared/TablePrimitive";
 
-export type ProjectWorkspaceSection = "documents" | "assistant" | "reviews";
+export type ProjectWorkspaceSection =
+    | "workspace"
+    | "documents"
+    | "assistant"
+    | "reviews";
 
 export type ProjectContextMenu = {
     x: number;

--- a/frontend/src/app/components/projects/ProjectWorkspace.tsx
+++ b/frontend/src/app/components/projects/ProjectWorkspace.tsx
@@ -90,6 +90,7 @@ export function useProjectWorkspaceOptional() {
 function activeSectionFromSegments(
     segments: string[],
 ): ProjectWorkspaceSection {
+    if (segments[0] === "workspace") return "workspace";
     if (segments[0] === "assistant") return "assistant";
     if (segments[0] === "tabular-reviews") return "reviews";
     return "documents";
@@ -98,7 +99,11 @@ function activeSectionFromSegments(
 function shouldShowWorkspaceShell(segments: string[]) {
     if (segments.length === 0) return true;
     if (segments.length !== 1) return false;
-    return segments[0] === "assistant" || segments[0] === "tabular-reviews";
+    return (
+        segments[0] === "workspace" ||
+        segments[0] === "assistant" ||
+        segments[0] === "tabular-reviews"
+    );
 }
 
 export function ProjectWorkspaceProvider({
@@ -113,7 +118,7 @@ export function ProjectWorkspaceProvider({
     const [projectLoading, setProjectLoading] = useState(true);
     const [searchBySection, setSearchBySection] = useState<
         Record<ProjectWorkspaceSection, string>
-    >({ documents: "", assistant: "", reviews: "" });
+    >({ workspace: "", documents: "", assistant: "", reviews: "" });
     const [projectChats, setProjectChats] = useState<Chat[] | null>(null);
     const [projectReviews, setProjectReviews] = useState<
         TabularReview[] | null
@@ -533,6 +538,7 @@ export function ProjectSectionToolbar({
     return (
         <TableToolbar
             items={[
+                { id: "workspace", label: "Matter OS" },
                 { id: "documents", label: "Documents" },
                 { id: "assistant", label: "Assistant Chats" },
                 { id: "reviews", label: "Tabular Reviews" },
@@ -540,7 +546,9 @@ export function ProjectSectionToolbar({
             active={activeSection}
             onChange={(next) => {
                 const href =
-                    next === "documents"
+                    next === "workspace"
+                        ? `/projects/${projectId}/workspace`
+                        : next === "documents"
                         ? `/projects/${projectId}`
                         : next === "assistant"
                           ? `/projects/${projectId}/assistant`

--- a/frontend/src/app/components/shared/types.ts
+++ b/frontend/src/app/components/shared/types.ts
@@ -87,8 +87,66 @@ export interface EditAnnotation {
   status: "pending" | "accepted" | "rejected";
 }
 
+export type KnowledgeEntryType =
+  | "fact"
+  | "party"
+  | "date"
+  | "clause"
+  | "position"
+  | "playbook"
+  | "source";
+
+export interface KnowledgeSuggestion {
+  entry_type: KnowledgeEntryType;
+  title: string;
+  body: string;
+  metadata?: Record<string, unknown>;
+  source_refs?: unknown[];
+}
+
+export interface KnowledgeEntry {
+  id: string;
+  user_id: string;
+  project_id: string | null;
+  library_origin_id: string | null;
+  entry_type: KnowledgeEntryType;
+  title: string;
+  body: string;
+  metadata: Record<string, unknown>;
+  source_refs: unknown[];
+  status: "active" | "archived";
+  include_in_agent_context: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProjectActivityItem {
+  id: string;
+  type: string;
+  title: string;
+  detail: string | null;
+  created_at: string;
+  href?: string;
+  metadata?: Record<string, unknown>;
+}
+
 export type AssistantEvent =
   | { type: "reasoning"; text: string; isStreaming?: boolean }
+  | {
+      type: "knowledge_context";
+      entries: {
+        id: string;
+        entry_type: KnowledgeEntryType;
+        title: string;
+        scope?: "project" | "library";
+      }[];
+      isStreaming?: boolean;
+    }
+  | {
+      type: "knowledge_suggestion";
+      entries: KnowledgeSuggestion[];
+      isStreaming?: boolean;
+    }
   | { type: "error"; message: string }
   | {
       type: "tool_call_start";

--- a/frontend/src/app/hooks/useAssistantChat.ts
+++ b/frontend/src/app/hooks/useAssistantChat.ts
@@ -582,6 +582,32 @@ export function useAssistantChat({
               continue;
             }
 
+            if (data.type === "knowledge_context") {
+              pushEvent({
+                type: "knowledge_context",
+                entries: Array.isArray(data.entries)
+                  ? (data.entries as Extract<
+                      AssistantEvent,
+                      { type: "knowledge_context" }
+                    >["entries"])
+                  : [],
+              });
+              continue;
+            }
+
+            if (data.type === "knowledge_suggestion") {
+              pushEvent({
+                type: "knowledge_suggestion",
+                entries: Array.isArray(data.entries)
+                  ? (data.entries as Extract<
+                      AssistantEvent,
+                      { type: "knowledge_suggestion" }
+                    >["entries"])
+                  : [],
+              });
+              continue;
+            }
+
             if (data.type === "case_citation") {
               pushEvent({
                 type: "case_citation",

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -11,7 +11,10 @@ import type {
     CitationAnnotation,
     Document,
     Folder,
+    KnowledgeEntry,
+    KnowledgeEntryType,
     Message,
+    ProjectActivityItem,
     Project,
     Workflow,
     TabularReview,
@@ -432,6 +435,89 @@ export interface ProjectPeople {
         display_name: string | null;
     };
     members: { email: string; display_name: string | null }[];
+}
+
+// ---------------------------------------------------------------------------
+// Matter OS knowledge and activity
+// ---------------------------------------------------------------------------
+
+export type KnowledgeEntryPayload = {
+    entry_type: KnowledgeEntryType;
+    title: string;
+    body: string;
+    metadata?: Record<string, unknown>;
+    source_refs?: unknown[];
+    include_in_agent_context?: boolean;
+};
+
+export async function listLibraryKnowledgeEntries(): Promise<KnowledgeEntry[]> {
+    return apiRequest<KnowledgeEntry[]>("/knowledge/library");
+}
+
+export async function createLibraryKnowledgeEntry(
+    payload: KnowledgeEntryPayload,
+): Promise<KnowledgeEntry> {
+    return apiRequest<KnowledgeEntry>("/knowledge/library", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+    });
+}
+
+export async function listProjectKnowledgeEntries(
+    projectId: string,
+): Promise<KnowledgeEntry[]> {
+    return apiRequest<KnowledgeEntry[]>(`/projects/${projectId}/knowledge`);
+}
+
+export async function createProjectKnowledgeEntry(
+    projectId: string,
+    payload: KnowledgeEntryPayload,
+): Promise<KnowledgeEntry> {
+    return apiRequest<KnowledgeEntry>(`/projects/${projectId}/knowledge`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+    });
+}
+
+export async function linkLibraryKnowledgeEntryToProject(
+    projectId: string,
+    entryId: string,
+): Promise<KnowledgeEntry> {
+    return apiRequest<KnowledgeEntry>(
+        `/projects/${projectId}/knowledge/link-library`,
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ entry_id: entryId }),
+        },
+    );
+}
+
+export async function updateKnowledgeEntry(
+    entryId: string,
+    payload: Partial<KnowledgeEntryPayload> & {
+        status?: KnowledgeEntry["status"];
+    },
+): Promise<KnowledgeEntry> {
+    return apiRequest<KnowledgeEntry>(`/knowledge/${entryId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+    });
+}
+
+export async function deleteKnowledgeEntry(entryId: string): Promise<void> {
+    return apiRequest<void>(`/knowledge/${entryId}`, { method: "DELETE" });
+}
+
+export async function listProjectActivity(
+    projectId: string,
+): Promise<ProjectActivityItem[]> {
+    return apiRequest<ProjectActivityItem[]>(
+        `/projects/${projectId}/activity`,
+    );
 }
 
 export async function getProjectPeople(


### PR DESCRIPTION
## Summary

Adds an additive Matter OS workspace to Mike, inspired by Legora aOS, without replacing or moving any existing project screens.

## What Changed

- Keeps `/projects/:id` as the existing Documents view.
- Adds a new `Matter OS` tab and `/projects/:id/workspace` route.
- Adds `knowledge_entries` schema, migration, backend helpers, and CRUD/link APIs for matter-scoped and personal-library knowledge.
- Adds project activity API for assistant events, chats, document versions/edits, and tabular reviews.
- Injects active matter knowledge into project chat context.
- Adds assistant knowledge tools for list, search, read, and review-only suggestions.
- Renders knowledge context and saveable knowledge suggestions in assistant messages.
- Adds the Matter OS UI with matter brief, guided legal actions, knowledge base, connected sources, agent activity, and recent outputs.

## Validation

- `git diff --check`
- Backend `tsc`
- Frontend `tsc --noEmit`
- ESLint for `ProjectMatterWorkspace` and `/projects/[id]/workspace/page.tsx`
- `next build --webpack`
- Browser sanity check for `/login`