### PR TITLE
feat: replace LLM provider with Sakana Fugu (straight swap)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,3 +21,20 @@ USER_API_KEYS_ENCRYPTION_SECRET=your-long-random-secret
 
 # Optional: enables higher-rate CourtListener case law/citation lookup tools.
 COURTLISTENER_API_TOKEN=your-courtlistener-token
+
+# ---------------------------------------------------------------------------
+# Sakana Fugu LLM (required — server will refuse to start without SAKANA_API_KEY)
+# ---------------------------------------------------------------------------
+# All LLM calls are routed through Sakana Fugu. Obtain your key at:
+# https://sakana.ai/fugu/
+# Add via your hosting provider's secrets manager (e.g. Railway → Settings → Variables).
+# NEVER commit the actual key to the repository.
+# SAKANA_API_KEY=your-sakana-key
+
+# Sakana API base URL — override only if routing through a private/proxy endpoint.
+# Default: https://api.sakana.ai/v1
+# SAKANA_BASE_URL=https://api.sakana.ai/v1
+
+# Fugu model to use. Default: fugu-ultra-20260615
+# Pricing: $5/M input + $30/M output (Fugu Ultra, standard context)
+# SAKANA_MODEL=fugu-ultra-20260615

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,92 @@
+# Mike — Backend
+
+Node.js / Express / TypeScript backend for the Mike legal AI platform.
+
+## Local development
+
+```bash
+cd backend
+cp .env.example .env   # fill in your keys — minimum: SAKANA_API_KEY
+npm install
+npm run dev
+```
+
+The server starts on `http://localhost:3001` by default.
+
+---
+
+## LLM Provider — Sakana Fugu
+
+All LLM calls are routed through **Sakana Fugu** (`fugu-ultra-20260615`). This is a straight swap — no feature flag, no per-request routing. Every `streamChatWithTools()` and `completeText()` call in `src/lib/llm/index.ts` targets the Sakana API.
+
+### Why Fugu?
+
+Fugu Ultra achieves top-tier performance on legal reasoning benchmarks while offering a predictable cost model, making it a strong fit for the Mike platform's document-intensive workloads.
+
+### Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `SAKANA_API_KEY` | **Yes** | — | Sakana API key. The server exits at startup if this is missing. Set it in Railway → Service → Variables. Never commit the value. |
+| `SAKANA_BASE_URL` | No | `https://api.sakana.ai/v1` | Sakana API base URL. Override only when using a private endpoint or proxy. |
+| `SAKANA_MODEL` | No | `fugu-ultra-20260615` | Which Fugu model to use. Applies to all requests. |
+
+### How it works
+
+`src/lib/llm/index.ts` unconditionally delegates to `streamSakana()` / `completeSakanaText()` in `sakana.ts`. The adapter:
+
+1. Resolves the model from `SAKANA_MODEL` (or the default).
+2. Builds an OpenAI Chat Completions-style request and streams it from `https://api.sakana.ai/v1/chat/completions`.
+3. Runs an agentic tool loop (up to 10 iterations) to handle function calls.
+4. Returns `{ fullText, providerMetadata }` — where `providerMetadata` carries `provider_name: "sakana_fugu"`, `model_name`, and the response ID.
+
+**Fugu uses the standard OpenAI Chat Completions API** (`POST /v1/chat/completions`), not the OpenAI Responses API used by the existing `openai.ts`. Key differences:
+- **Stateless**: full message history sent on every request.
+- **Streaming**: standard SSE chunks with `choices[].delta.content`.
+
+### Provenance logging
+
+Every assistant message written to `chat_messages` includes:
+
+```jsonc
+{
+  "provider_metadata": {
+    "provider_name": "sakana_fugu",
+    "model_name": "fugu-ultra-20260615"
+  }
+}
+```
+
+This requires a `provider_metadata JSONB` column in the `chat_messages` table. Apply the included Supabase migration before deploying:
+
+```bash
+supabase db push   # or apply supabase/migrations/20260623000000_add_provider_metadata.sql manually
+```
+
+### Known gaps
+
+- **Tool calling**: Fugu's function-calling support has not been verified against a live endpoint. If document-editing tools fail silently, check whether the API returns `finish_reason: "tool_calls"` in streaming chunks.
+- **Thinking / reasoning**: The `enableThinking` parameter is currently ignored.
+
+### Pricing (as of 2026-06-23)
+
+| Model | Input | Output |
+|---|---|---|
+| `fugu-ultra-20260615` | $5 / M tokens | $30 / M tokens |
+| `fugu-20260615` | (see Sakana pricing page) | |
+
+### Running the tests
+
+```bash
+cd backend
+npx vitest run src/lib/llm/__tests__/sakana.test.ts
+```
+
+> Tests mock the `fetch` global — no API keys required.
+
+### Railway deployment
+
+1. In Railway → Service → Variables, set `SAKANA_API_KEY` to your key from the Sakana dashboard.
+2. Optionally set `SAKANA_MODEL` to override the default model.
+3. Remove any legacy `FUGU_API_KEY` and `LLM_PROVIDER` variables after this PR merges — they are no longer read.
+4. Apply the Supabase migration to add the `provider_metadata` column before the first deploy.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,6 +13,18 @@ import { userRouter } from "./routes/user";
 import { downloadsRouter } from "./routes/downloads";
 import { caseLawRouter } from "./routes/caseLaw";
 
+// ---------------------------------------------------------------------------
+// Required environment variable check — fail fast before binding the port.
+// ---------------------------------------------------------------------------
+
+if (!process.env.SAKANA_API_KEY?.trim()) {
+    console.error(
+        "FATAL: SAKANA_API_KEY is required. " +
+        "Add it to your Railway environment variables (Settings → Variables).",
+    );
+    process.exit(1);
+}
+
 const app = express();
 const PORT = process.env.PORT ?? 3001;
 const isProduction = process.env.NODE_ENV === "production";

--- a/backend/src/lib/llm/__tests__/sakana.test.ts
+++ b/backend/src/lib/llm/__tests__/sakana.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Minimal mocks — set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+// Helper: build a minimal streaming response from an array of SSE data lines
+function makeSseResponse(lines: string[]): Response {
+    const body = lines.map((l) => `data: ${l}\n\n`).join("") + "data: [DONE]\n\n";
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+        start(controller) {
+            controller.enqueue(encoder.encode(body));
+            controller.close();
+        },
+    });
+    return new Response(stream, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+}
+
+// Helper: build a non-streaming (JSON) response
+function makeJsonResponse(json: unknown): Response {
+    return new Response(JSON.stringify(json), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Module under test
+// ---------------------------------------------------------------------------
+
+import { streamSakana, completeSakanaText } from "../sakana";
+import { DEFAULT_SAKANA_MODEL } from "../models";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("streamSakana", () => {
+    const apiKey = "test-key-abc";
+    const baseEnv = { SAKANA_API_KEY: apiKey };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        for (const [k, v] of Object.entries(baseEnv)) process.env[k] = v;
+    });
+
+    afterEach(() => {
+        delete process.env.SAKANA_API_KEY;
+        delete process.env.SAKANA_MODEL;
+        delete process.env.SAKANA_BASE_URL;
+    });
+
+    it("uses DEFAULT_SAKANA_MODEL as fallback model", async () => {
+        const chunk = JSON.stringify({
+            id: "resp-1",
+            choices: [{ delta: { content: "hello" }, finish_reason: "stop" }],
+        });
+        fetchMock.mockResolvedValueOnce(makeSseResponse([chunk]));
+
+        await streamSakana({
+            model: DEFAULT_SAKANA_MODEL,
+            systemPrompt: "sys",
+            messages: [{ role: "user", content: "hi" }],
+        });
+
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+        expect(body.model).toBe(DEFAULT_SAKANA_MODEL);
+    });
+
+    it("SAKANA_MODEL env var overrides requested model", async () => {
+        process.env.SAKANA_MODEL = "fugu-mini-test";
+        const chunk = JSON.stringify({
+            id: "resp-2",
+            choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+        });
+        fetchMock.mockResolvedValueOnce(makeSseResponse([chunk]));
+
+        await streamSakana({
+            model: DEFAULT_SAKANA_MODEL,
+            systemPrompt: "sys",
+            messages: [{ role: "user", content: "hi" }],
+        });
+
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+        expect(body.model).toBe("fugu-mini-test");
+    });
+
+    it("returns providerMetadata with provider_name === sakana_fugu", async () => {
+        const chunk = JSON.stringify({
+            id: "resp-3",
+            choices: [{ delta: { content: "world" }, finish_reason: "stop" }],
+        });
+        fetchMock.mockResolvedValueOnce(makeSseResponse([chunk]));
+
+        const result = await streamSakana({
+            model: DEFAULT_SAKANA_MODEL,
+            systemPrompt: "sys",
+            messages: [{ role: "user", content: "hi" }],
+        });
+
+        expect(result.providerMetadata?.provider_name).toBe("sakana_fugu");
+        expect(result.providerMetadata?.model_name).toBe(DEFAULT_SAKANA_MODEL);
+        expect(result.providerMetadata?.provider_response_id).toBe("resp-3");
+    });
+
+    it("accumulates SSE content deltas into fullText", async () => {
+        const chunks = [
+            JSON.stringify({ id: "r", choices: [{ delta: { content: "Hello" }, finish_reason: null }] }),
+            JSON.stringify({ id: "r", choices: [{ delta: { content: ", " }, finish_reason: null }] }),
+            JSON.stringify({ id: "r", choices: [{ delta: { content: "world!" }, finish_reason: "stop" }] }),
+        ];
+        fetchMock.mockResolvedValueOnce(makeSseResponse(chunks));
+
+        const result = await streamSakana({
+            model: DEFAULT_SAKANA_MODEL,
+            systemPrompt: "sys",
+            messages: [{ role: "user", content: "hi" }],
+        });
+
+        expect(result.fullText).toBe("Hello, world!");
+    });
+
+    it("throws when SAKANA_API_KEY is missing", async () => {
+        delete process.env.SAKANA_API_KEY;
+
+        await expect(
+            streamSakana({
+                model: DEFAULT_SAKANA_MODEL,
+                systemPrompt: "sys",
+                messages: [{ role: "user", content: "hi" }],
+            }),
+        ).rejects.toThrow(/SAKANA_API_KEY/);
+    });
+
+    it("throws on 401 response", async () => {
+        fetchMock.mockResolvedValueOnce(
+            new Response("Unauthorized", { status: 401, statusText: "Unauthorized" }),
+        );
+
+        await expect(
+            streamSakana({
+                model: DEFAULT_SAKANA_MODEL,
+                systemPrompt: "sys",
+                messages: [{ role: "user", content: "hi" }],
+            }),
+        ).rejects.toThrow(/401/);
+    });
+
+    it("all fugu- model IDs route through streamSakana (providerMetadata is set)", async () => {
+        const chunk = JSON.stringify({
+            id: "resp-x",
+            choices: [{ delta: { content: "resp" }, finish_reason: "stop" }],
+        });
+        fetchMock.mockResolvedValueOnce(makeSseResponse([chunk]));
+
+        const result = await streamSakana({
+            model: "fugu-ultra-20260615",
+            systemPrompt: "sys",
+            messages: [{ role: "user", content: "hi" }],
+        });
+
+        expect(result.providerMetadata?.provider_name).toBe("sakana_fugu");
+    });
+});
+
+describe("completeSakanaText", () => {
+    const apiKey = "test-key-abc";
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        process.env.SAKANA_API_KEY = apiKey;
+    });
+
+    afterEach(() => {
+        delete process.env.SAKANA_API_KEY;
+        delete process.env.SAKANA_MODEL;
+    });
+
+    it("returns the assistant message content", async () => {
+        fetchMock.mockResolvedValueOnce(
+            makeJsonResponse({
+                choices: [{ message: { content: "The answer is 42." } }],
+            }),
+        );
+
+        const text = await completeSakanaText({
+            model: DEFAULT_SAKANA_MODEL,
+            user: "What is 6 * 7?",
+        });
+
+        expect(text).toBe("The answer is 42.");
+    });
+
+    it("throws when SAKANA_API_KEY is missing", async () => {
+        delete process.env.SAKANA_API_KEY;
+
+        await expect(
+            completeSakanaText({ model: DEFAULT_SAKANA_MODEL, user: "hello" }),
+        ).rejects.toThrow(/SAKANA_API_KEY/);
+    });
+});

--- a/backend/src/lib/llm/index.ts
+++ b/backend/src/lib/llm/index.ts
@@ -1,19 +1,26 @@
-import { streamClaude, completeClaudeText } from "./claude";
-import { streamGemini, completeGeminiText } from "./gemini";
-import { streamOpenAI, completeOpenAIText } from "./openai";
-import { providerForModel } from "./models";
+import { streamSakana, completeSakanaText } from "./sakana";
+import { DEFAULT_SAKANA_MODEL } from "./models";
 import type { StreamChatParams, StreamChatResult, UserApiKeys } from "./types";
 
 export * from "./types";
 export * from "./models";
 
+/**
+ * Route ALL chat completions through Sakana Fugu (fugu-ultra-20260615).
+ *
+ * This is a straight provider swap — no feature flag, no per-request model
+ * routing. The model can be overridden at the environment level via
+ * SAKANA_MODEL but always targets the Sakana API.
+ *
+ * Pricing: $5/M input · $30/M output (Fugu Ultra, as of 2026-06-23).
+ */
 export async function streamChatWithTools(
     params: StreamChatParams,
 ): Promise<StreamChatResult> {
-    const provider = providerForModel(params.model);
-    if (provider === "claude") return streamClaude(params);
-    if (provider === "openai") return streamOpenAI(params);
-    return streamGemini(params);
+    return streamSakana({
+        ...params,
+        model: process.env.SAKANA_MODEL?.trim() || DEFAULT_SAKANA_MODEL,
+    });
 }
 
 export async function completeText(params: {
@@ -23,8 +30,8 @@ export async function completeText(params: {
     maxTokens?: number;
     apiKeys?: UserApiKeys;
 }): Promise<string> {
-    const provider = providerForModel(params.model);
-    if (provider === "claude") return completeClaudeText(params);
-    if (provider === "openai") return completeOpenAIText(params);
-    return completeGeminiText(params);
+    return completeSakanaText({
+        ...params,
+        model: process.env.SAKANA_MODEL?.trim() || DEFAULT_SAKANA_MODEL,
+    });
 }

--- a/backend/src/lib/llm/models.ts
+++ b/backend/src/lib/llm/models.ts
@@ -16,6 +16,13 @@ export const GEMINI_MAIN_MODELS = [
     "gemini-3-flash-preview",
 ] as const;
 export const OPENAI_MAIN_MODELS = ["gpt-5.5", "gpt-5.4"] as const;
+export const FUGU_MAIN_MODELS = [
+    "fugu-ultra-20260615",
+    "fugu-20260615",
+] as const;
+
+// Default Sakana Fugu model.
+export const DEFAULT_SAKANA_MODEL = "fugu-ultra-20260615";
 
 // Mid-tier (used for tabular review) — user picks one in account settings.
 export const CLAUDE_MID_MODELS = ["claude-sonnet-4-6"] as const;
@@ -36,6 +43,7 @@ const ALL_MODELS = new Set<string>([
     ...CLAUDE_MAIN_MODELS,
     ...GEMINI_MAIN_MODELS,
     ...OPENAI_MAIN_MODELS,
+    ...FUGU_MAIN_MODELS,
     ...CLAUDE_MID_MODELS,
     ...GEMINI_MID_MODELS,
     ...OPENAI_MID_MODELS,
@@ -52,6 +60,7 @@ export function providerForModel(model: string): Provider {
     if (model.startsWith("claude")) return "claude";
     if (model.startsWith("gemini")) return "gemini";
     if (model.startsWith("gpt-")) return "openai";
+    if (model.startsWith("fugu-")) return "sakana";
     throw new Error(`Unknown model id: ${model}`);
 }
 

--- a/backend/src/lib/llm/sakana.ts
+++ b/backend/src/lib/llm/sakana.ts
@@ -1,0 +1,340 @@
+/**
+ * Sakana Fugu LLM provider adapter.
+ *
+ * Fugu exposes a standard OpenAI Chat Completions-compatible API, which is
+ * DIFFERENT from the OpenAI Responses API used by openai.ts. Key differences:
+ *   - Endpoint: /v1/chat/completions (not /v1/responses)
+ *   - Stateless: full message history sent on every request (no previousResponseId)
+ *   - Streaming: standard SSE chunks with `choices[].delta.content`
+ *
+ * ⚠️  Tool-calling gap: Fugu claims OpenAI compatibility. Function calling is
+ * implemented here using the standard Chat Completions format, but has not been
+ * verified against a live Fugu endpoint. If tools silently fail, check whether
+ * Fugu returns `finish_reason: "tool_calls"` and populates `delta.tool_calls`.
+ */
+
+import type {
+    LlmMessage,
+    NormalizedToolCall,
+    OpenAIToolSchema,
+    StreamChatParams,
+    StreamChatResult,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SAKANA_BASE_URL = "https://api.sakana.ai/v1";
+const DEFAULT_SAKANA_MODEL = "fugu-ultra-20260615";
+const MAX_OUTPUT_TOKENS = 16384;
+
+// ---------------------------------------------------------------------------
+// Config helpers
+// ---------------------------------------------------------------------------
+
+function sakanaApiKey(override?: string | null): string {
+    const key = override?.trim() || process.env.SAKANA_API_KEY?.trim() || "";
+    if (!key) {
+        throw new Error(
+            "Sakana API key is not configured. Set SAKANA_API_KEY in your Railway environment variables.",
+        );
+    }
+    return key;
+}
+
+function sakanaBaseUrl(): string {
+    return (process.env.SAKANA_BASE_URL?.trim() || DEFAULT_SAKANA_BASE_URL).replace(/\/$/, "");
+}
+
+/**
+ * Resolve the model to use. The caller (index.ts) already overrides with
+ * process.env.SAKANA_MODEL, but we apply it again here for robustness in case
+ * streamSakana is called directly.
+ */
+function sakanaModel(requestedModel: string): string {
+    return process.env.SAKANA_MODEL?.trim() || requestedModel || DEFAULT_SAKANA_MODEL;
+}
+
+// ---------------------------------------------------------------------------
+// Internal Chat Completions types
+// ---------------------------------------------------------------------------
+
+type AssistantToolCall = {
+    id: string;
+    type: "function";
+    function: { name: string; arguments: string };
+};
+
+type ChatMessage =
+    | { role: "system"; content: string }
+    | { role: "user"; content: string }
+    | { role: "assistant"; content: string | null; tool_calls?: AssistantToolCall[] }
+    | { role: "tool"; tool_call_id: string; content: string };
+
+type ChatCompletionsTool = {
+    type: "function";
+    function: {
+        name: string;
+        description?: string;
+        parameters: Record<string, unknown>;
+    };
+};
+
+type ChatCompletionsChunk = {
+    id?: string;
+    choices?: {
+        delta?: {
+            content?: string | null;
+            tool_calls?: {
+                index: number;
+                id?: string;
+                type?: string;
+                function?: { name?: string; arguments?: string };
+            }[];
+        };
+        finish_reason?: string | null;
+    }[];
+};
+
+// ---------------------------------------------------------------------------
+// SSE parsing helpers
+// ---------------------------------------------------------------------------
+
+function extractSseEvents(buffer: string): { events: ChatCompletionsChunk[]; rest: string } {
+    const events: ChatCompletionsChunk[] = [];
+    const chunks = buffer.split(/\n\n/);
+    const rest = chunks.pop() ?? "";
+    for (const chunk of chunks) {
+        const dataLines = chunk
+            .split("\n")
+            .map((l) => l.trim())
+            .filter((l) => l.startsWith("data:"))
+            .map((l) => l.slice(5).trim());
+        for (const data of dataLines) {
+            if (!data || data === "[DONE]") continue;
+            try {
+                events.push(JSON.parse(data) as ChatCompletionsChunk);
+            } catch {
+                // incomplete chunk — ignore and let the next buffer flush handle it
+            }
+        }
+    }
+    return { events, rest };
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+    if (signal?.aborted) {
+        const err = new Error("Stream aborted.");
+        err.name = "AbortError";
+        throw err;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming chat with agentic tool loop
+// ---------------------------------------------------------------------------
+
+export async function streamSakana(params: StreamChatParams): Promise<StreamChatResult> {
+    const { tools = [], callbacks = {}, runTools, apiKeys } = params;
+    const maxIter = params.maxIterations ?? 10;
+    const key = sakanaApiKey(apiKeys?.sakana);
+    const baseUrl = sakanaBaseUrl();
+    const model = sakanaModel(params.model);
+
+    // Build initial message list (system + history)
+    const systemMessage: ChatMessage = { role: "system", content: params.systemPrompt };
+    let messages: ChatMessage[] = [
+        systemMessage,
+        ...params.messages.map((m): ChatMessage => ({ role: m.role, content: m.content })),
+    ];
+
+    const chatTools: ChatCompletionsTool[] = tools.map((t: OpenAIToolSchema) => ({
+        type: "function",
+        function: {
+            name: t.function.name,
+            description: t.function.description,
+            parameters: t.function.parameters,
+        },
+    }));
+
+    let fullText = "";
+    let responseId: string | undefined;
+
+    for (let iter = 0; iter < maxIter; iter++) {
+        throwIfAborted(params.abortSignal);
+
+        const response = await fetch(`${baseUrl}/chat/completions`, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${key}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                model,
+                messages,
+                stream: true,
+                max_tokens: MAX_OUTPUT_TOKENS,
+                ...(chatTools.length ? { tools: chatTools, tool_choice: "auto" } : {}),
+            }),
+            signal: params.abortSignal,
+        });
+
+        if (!response.ok) {
+            const errText = await response.text().catch(() => "");
+            throw new Error(
+                `Sakana request failed (${response.status}): ${errText || response.statusText}`,
+            );
+        }
+        if (!response.body) throw new Error("Sakana response had no body");
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        const toolCallAcc = new Map<
+            number,
+            { id: string; name: string; argumentsStr: string }
+        >();
+        let finishReason: string | null = null;
+        let iterText = "";
+
+        while (true) {
+            throwIfAborted(params.abortSignal);
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            const { events, rest } = extractSseEvents(buffer);
+            buffer = rest;
+
+            for (const chunk of events) {
+                if (chunk.id) responseId = chunk.id;
+                const choice = chunk.choices?.[0];
+                if (!choice) continue;
+                if (choice.finish_reason) finishReason = choice.finish_reason;
+
+                const delta = choice.delta;
+                if (!delta) continue;
+
+                if (typeof delta.content === "string" && delta.content) {
+                    iterText += delta.content;
+                    fullText += delta.content;
+                    callbacks.onContentDelta?.(delta.content);
+                }
+
+                if (delta.tool_calls) {
+                    for (const tc of delta.tool_calls) {
+                        const idx = tc.index;
+                        if (!toolCallAcc.has(idx)) {
+                            toolCallAcc.set(idx, {
+                                id: tc.id ?? "",
+                                name: tc.function?.name ?? "",
+                                argumentsStr: "",
+                            });
+                        }
+                        const acc = toolCallAcc.get(idx)!;
+                        if (tc.id) acc.id = tc.id;
+                        if (tc.function?.name) acc.name = tc.function.name;
+                        if (tc.function?.arguments) acc.argumentsStr += tc.function.arguments;
+                    }
+                }
+            }
+        }
+
+        if (finishReason !== "tool_calls" || toolCallAcc.size === 0 || !runTools) break;
+
+        const normalizedCalls: NormalizedToolCall[] = [];
+        const assistantToolCalls: AssistantToolCall[] = [];
+
+        for (const [, acc] of toolCallAcc) {
+            let input: Record<string, unknown> = {};
+            try {
+                const parsed: unknown = JSON.parse(acc.argumentsStr || "{}");
+                if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+                    input = parsed as Record<string, unknown>;
+                }
+            } catch {
+                // malformed JSON — proceed with empty input
+            }
+            const call: NormalizedToolCall = { id: acc.id, name: acc.name, input };
+            callbacks.onToolCallStart?.(call);
+            normalizedCalls.push(call);
+            assistantToolCalls.push({
+                id: acc.id,
+                type: "function",
+                function: { name: acc.name, arguments: acc.argumentsStr },
+            });
+        }
+
+        messages.push({
+            role: "assistant",
+            content: iterText || null,
+            tool_calls: assistantToolCalls,
+        });
+
+        const results = await runTools(normalizedCalls);
+        throwIfAborted(params.abortSignal);
+        for (const result of results) {
+            messages.push({
+                role: "tool",
+                tool_call_id: result.tool_use_id,
+                content: result.content,
+            });
+        }
+    }
+
+    const providerMetadata = {
+        provider_name: "sakana_fugu" as const,
+        model_name: model,
+        provider_response_id: responseId,
+    };
+
+    console.log("[sakana] provider_metadata", JSON.stringify(providerMetadata));
+
+    return { fullText, providerMetadata };
+}
+
+// ---------------------------------------------------------------------------
+// One-shot text completion (no streaming, no tools)
+// ---------------------------------------------------------------------------
+
+export async function completeSakanaText(params: {
+    model: string;
+    systemPrompt?: string;
+    user: string;
+    maxTokens?: number;
+    apiKeys?: { sakana?: string | null };
+}): Promise<string> {
+    const key = sakanaApiKey(params.apiKeys?.sakana);
+    const baseUrl = sakanaBaseUrl();
+    const model = sakanaModel(params.model);
+
+    const messages: ChatMessage[] = [];
+    if (params.systemPrompt) messages.push({ role: "system", content: params.systemPrompt });
+    messages.push({ role: "user", content: params.user });
+
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${key}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            model,
+            messages,
+            max_tokens: params.maxTokens ?? 512,
+            stream: false,
+        }),
+    });
+
+    if (!response.ok) {
+        const errText = await response.text().catch(() => "");
+        throw new Error(`Sakana request failed (${response.status}): ${errText || response.statusText}`);
+    }
+
+    const json = (await response.json()) as {
+        choices?: { message?: { content?: string } }[];
+    };
+    return json.choices?.[0]?.message?.content ?? "";
+}

--- a/backend/src/lib/llm/types.ts
+++ b/backend/src/lib/llm/types.ts
@@ -2,7 +2,7 @@
 // Callers always speak OpenAI-style tools + { role, content } messages; each
 // provider translates internally.
 
-export type Provider = "claude" | "gemini" | "openai";
+export type Provider = "claude" | "gemini" | "openai" | "sakana";
 
 export type OpenAIToolSchema = {
     type: "function";
@@ -42,6 +42,13 @@ export type UserApiKeys = {
     openai?: string | null;
     openrouter?: string | null;
     courtlistener?: string | null;
+    sakana?: string | null;
+};
+
+export type ProviderMetadata = {
+    provider_name: string;
+    model_name: string;
+    provider_response_id?: string;
 };
 
 export type StreamChatParams = {
@@ -65,4 +72,6 @@ export type StreamChatParams = {
 
 export type StreamChatResult = {
     fullText: string;
+    /** Populated by providers that expose response IDs and model routing metadata. */
+    providerMetadata?: ProviderMetadata;
 };

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -31,6 +31,13 @@ const devLog = (...args: Parameters<typeof console.log>) => {
 
 const TITLE_FALLBACK = "Misc. Query";
 
+// Provenance metadata stamped on every assistant message.
+// Always Sakana Fugu after the straight-swap migration.
+const SAKANA_PROVIDER_METADATA = {
+    provider_name: "sakana_fugu",
+    model_name: process.env.SAKANA_MODEL?.trim() || "fugu-ultra-20260615",
+} as const;
+
 function normalizeGeneratedTitle(raw: string): string {
     const title = raw.trim().replace(/^["'`]+|["'`.,:;!?]+$/g, "").trim();
     if (!title) return TITLE_FALLBACK;
@@ -597,6 +604,7 @@ chatRouter.post("/", requireAuth, async (req, res) => {
             role: "assistant",
             content: persistedEvents.length ? persistedEvents : null,
             annotations: annotations.length ? annotations : null,
+            provider_metadata: SAKANA_PROVIDER_METADATA,
         });
 
         if (!chatTitle && lastUser?.content) {
@@ -622,6 +630,7 @@ chatRouter.post("/", requireAuth, async (req, res) => {
                     annotations: partial.annotations.length
                         ? partial.annotations
                         : null,
+                    provider_metadata: SAKANA_PROVIDER_METADATA,
                 });
                 if (saveError) {
                     console.error(
@@ -650,6 +659,7 @@ chatRouter.post("/", requireAuth, async (req, res) => {
                 role: "assistant",
                 content: errorEvents.length ? errorEvents : null,
                 annotations: annotations.length ? annotations : null,
+                provider_metadata: SAKANA_PROVIDER_METADATA,
             });
             if (saveError)
                 console.error("[chat/stream] failed to save error", saveError);

--- a/supabase/migrations/20260623000000_add_provider_metadata.sql
+++ b/supabase/migrations/20260623000000_add_provider_metadata.sql
@@ -1,0 +1,10 @@
+-- Migration: add provider_metadata to chat_messages
+-- Stores which LLM provider and model generated each assistant response.
+-- Apply before deploying the Sakana Fugu provider swap.
+
+ALTER TABLE chat_messages
+  ADD COLUMN IF NOT EXISTS provider_metadata JSONB DEFAULT NULL;
+
+COMMENT ON COLUMN chat_messages.provider_metadata IS
+  'LLM provenance: { provider_name, model_name, provider_response_id? }. '
+  'Populated for every assistant message after the Sakana Fugu migration.';


### PR DESCRIPTION
## Summary

Replaces the existing LLM provider with Sakana AI's Fugu model — a straight permanent swap, no feature flag.

### Changes

- **`backend/src/lib/llm/sakana.ts`** — Sakana Fugu adapter (OpenAI Chat Completions-compatible, streaming SSE)
- **`backend/src/lib/llm/{types,models,index}.ts`** — provider abstraction layer; `completeText` and streaming route to Sakana
- **`backend/src/routes/chat.ts`** — stamps `provider_metadata: { provider_name, model_name }` on every assistant `chat_messages` insert (success, abort, and error paths) via `SAKANA_PROVIDER_METADATA` constant
- **`backend/src/index.ts`** — startup guard: server refuses to boot without `SAKANA_API_KEY`
- **`supabase/migrations/20260623000000_add_provider_metadata.sql`** — adds `provider_metadata JSONB` column to `chat_messages`
- **`backend/src/lib/llm/__tests__/sakana.test.ts`** — unit tests for the adapter
- **`backend/.env.example`** and **`backend/README.md`** updated

### Deployment checklist

1. Run the migration before deploying the new backend
2. Set `SAKANA_API_KEY` in Railway (Settings → Variables)
3. Optionally set `SAKANA_MODEL` (defaults to `fugu-ultra-20260615`)
4. Remove any legacy `FUGU_API_KEY` or `LLM_PROVIDER` env vars after merge

### Cost note

Sakana Fugu is priced at **$5 / M input tokens** and **$30 / M output tokens**.

---

*Do not merge — opening for review only.*