### PR TITLE
Restrict project folder deletion to owners

### DIFF
--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -783,6 +783,7 @@ projectsRouter.delete("/:projectId/folders/:folderId", requireAuth, async (req, 
 
   const access = await checkProjectAccess(projectId, userId, userEmail, db);
   if (!access.ok) return void res.status(404).json({ detail: "Project not found" });
+  if (!access.isOwner) return void res.status(404).json({ detail: "Project not found" });
 
   const { data: allFolders, error: foldersError } = await db
     .from("project_subfolders")


### PR DESCRIPTION
## Summary
- Require project ownership before deleting a project folder
- Prevent shared project members from deleting folders and nested documents

## Verification
- git diff --check