### PR TITLE
feat(backend): Word add-in compatibility — CORS + documentContext

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -111,10 +111,28 @@ app.use(
   }),
 );
 
+// The Office.js add-in (Word task pane) runs at https://localhost:3000 during
+// development — office-addin tooling forces HTTPS even locally, so the HTTPS
+// variant must be allowed alongside the regular frontend origin.
+const allowedOrigins = new Set<string>([
+  process.env.FRONTEND_URL ?? "http://localhost:3000",
+  "https://localhost:3000",
+]);
+
 app.use(
   cors({
-    origin: process.env.FRONTEND_URL ?? "http://localhost:3000",
+    origin: (origin, callback) => {
+      // Allow server-to-server requests (no Origin header) and any
+      // explicitly listed origin.
+      if (!origin || allowedOrigins.has(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error("Not allowed by CORS"));
+      }
+    },
     credentials: true,
+    allowedHeaders: ["Authorization", "Content-Type"],
+    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
   }),
 );
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -122,13 +122,13 @@ const allowedOrigins = new Set<string>([
 app.use(
   cors({
     origin: (origin, callback) => {
-      // Allow server-to-server requests (no Origin header) and any
-      // explicitly listed origin.
-      if (!origin || allowedOrigins.has(origin)) {
-        callback(null, true);
-      } else {
-        callback(new Error("Not allowed by CORS"));
-      }
+      // Allow server-to-server requests (no Origin header) and any explicitly
+      // listed origin. A disallowed origin resolves to `false` (cors simply
+      // omits the Access-Control-Allow-Origin header and the browser blocks the
+      // response) rather than calling back with an Error — throwing here would
+      // propagate to Express's default handler and turn every disallowed
+      // cross-origin request, including preflight, into an HTTP 500.
+      callback(null, !origin || allowedOrigins.has(origin));
     },
     credentials: true,
     allowedHeaders: ["Authorization", "Content-Type"],

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -445,6 +445,19 @@ chatRouter.post("/", requireAuth, async (req, res) => {
     const project_id = parsedProjectId.projectId;
     const model = parsedModel.model;
 
+    // Optional plain-text document context supplied by the Word Office.js add-in.
+    // The add-in reads the active document body via Word.run() and posts it here
+    // as `documentContext` rather than uploading a file — there is no stored
+    // document record and no upload step. The text is injected into the LLM
+    // system prompt via buildMessages's systemPromptExtra parameter, so a
+    // separate from-text document endpoint is unnecessary.
+    const documentContext =
+        typeof (req.body as Record<string, unknown>).documentContext ===
+            "string" &&
+        ((req.body as Record<string, unknown>).documentContext as string).trim()
+            ? ((req.body as Record<string, unknown>).documentContext as string).trim()
+            : undefined;
+
     devLog("[chat/stream] incoming request", {
         userId,
         chat_id,
@@ -539,10 +552,16 @@ chatRouter.post("/", requireAuth, async (req, res) => {
         api_keys: apiKeys,
         legal_research_us: legalResearchUs,
     } = await getUserModelSettings(userId, db);
+    // If the add-in sent document text, surface it to the model as extra
+    // system context, fenced in a tag so the model treats it as the body of
+    // the user's active Word document rather than instructions.
+    const systemPromptExtra = documentContext
+        ? `The user is working in Microsoft Word. The text below is the body of their active document:\n<word-document>\n${documentContext}\n</word-document>`
+        : undefined;
     const apiMessages = buildMessages(
         enrichedMessages,
         docAvailability,
-        undefined,
+        systemPromptExtra,
         undefined,
         legalResearchUs,
     );

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -451,11 +451,14 @@ chatRouter.post("/", requireAuth, async (req, res) => {
     // document record and no upload step. The text is injected into the LLM
     // system prompt via buildMessages's systemPromptExtra parameter, so a
     // separate from-text document endpoint is unnecessary.
+    // Cap the injected document text so an oversized body (the JSON limit is
+    // 50 MB) can't blow past the model's context window or run up token cost.
+    const MAX_DOCUMENT_CONTEXT_CHARS = 200_000;
+    const rawDocumentContext = (req.body as Record<string, unknown>)
+        .documentContext;
     const documentContext =
-        typeof (req.body as Record<string, unknown>).documentContext ===
-            "string" &&
-        ((req.body as Record<string, unknown>).documentContext as string).trim()
-            ? ((req.body as Record<string, unknown>).documentContext as string).trim()
+        typeof rawDocumentContext === "string" && rawDocumentContext.trim()
+            ? rawDocumentContext.trim().slice(0, MAX_DOCUMENT_CONTEXT_CHARS)
             : undefined;
 
     devLog("[chat/stream] incoming request", {

--- a/backend/src/routes/projectChat.ts
+++ b/backend/src/routes/projectChat.ts
@@ -36,14 +36,23 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
     const userId = res.locals.userId as string;
     const userEmail = res.locals.userEmail as string | undefined;
     const { projectId } = req.params;
-    const { messages, chat_id, model, displayed_doc, attached_documents } =
-        req.body as {
-            messages: ChatMessage[];
-            chat_id?: string;
-            model?: string;
-            displayed_doc?: { filename: string; document_id: string };
-            attached_documents?: { filename: string; document_id: string }[];
-        };
+    const {
+        messages,
+        chat_id,
+        model,
+        displayed_doc,
+        attached_documents,
+        documentContext,
+    } = req.body as {
+        messages: ChatMessage[];
+        chat_id?: string;
+        model?: string;
+        displayed_doc?: { filename: string; document_id: string };
+        attached_documents?: { filename: string; document_id: string }[];
+        // Plain-text body of the active Word document, posted by the Office.js
+        // add-in instead of uploading a file (see chat.ts for the rationale).
+        documentContext?: string;
+    };
 
     const db = createServerSupabase();
 
@@ -141,6 +150,13 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
             return slug ? `- ${slug}: ${d.filename}` : `- ${d.filename}`;
         });
         systemPromptExtra += `\n\nUSER-ATTACHED DOCUMENTS FOR THIS TURN:\nThe user has attached the following document(s) directly to their latest message. Treat these as the primary focus of the request unless their message clearly says otherwise.\n${lines.join("\n")}`;
+    }
+
+    // Plain-text Word document body from the Office.js add-in, appended to the
+    // project system context so the model can reason over the user's open file.
+    if (documentContext && documentContext.trim()) {
+        systemPromptExtra +=
+            `\n\nThe user is working in Microsoft Word. The text below is the body of their active document:\n<word-document>\n${documentContext.trim()}\n</word-document>`;
     }
 
     const {

--- a/backend/src/routes/projectChat.ts
+++ b/backend/src/routes/projectChat.ts
@@ -154,9 +154,14 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
 
     // Plain-text Word document body from the Office.js add-in, appended to the
     // project system context so the model can reason over the user's open file.
-    if (documentContext && documentContext.trim()) {
+    // Runtime-checked (a non-string would otherwise throw on .trim()) and capped
+    // so an oversized body can't blow past the context window / token budget.
+    const MAX_DOCUMENT_CONTEXT_CHARS = 200_000;
+    const docContext =
+        typeof documentContext === "string" ? documentContext.trim() : "";
+    if (docContext) {
         systemPromptExtra +=
-            `\n\nThe user is working in Microsoft Word. The text below is the body of their active document:\n<word-document>\n${documentContext.trim()}\n</word-document>`;
+            `\n\nThe user is working in Microsoft Word. The text below is the body of their active document:\n<word-document>\n${docContext.slice(0, MAX_DOCUMENT_CONTEXT_CHARS)}\n</word-document>`;
     }
 
     const {


### PR DESCRIPTION
**Layer 1 of 6** of the Word add-in, split for review. Supersedes #195.

> ⚠️ **Review this PR's own commits, not the "Files changed" tab.** The head is a fork branch and the per-layer base branches can't be pushed to this repo, so GitHub shows a **cumulative** diff (it includes the layers below). This layer's actual changes are only:
- fix(backend): review fixes — CORS 500, documentContext guard + length cap (`bf203b7`)
- feat(backend): Word add-in compatibility — CORS + documentContext (`1b8bec4`)

A true base-chained version with small per-layer diffs also exists as a stack in the `amal66/mike` fork.