### PR TITLE
fix(db): add missing chat_messages.workflow column (user prompts dropped on reload)

### DIFF
--- a/backend/migrations/20260716_01_chat_messages_workflow.sql
+++ b/backend/migrations/20260716_01_chat_messages_workflow.sql
@@ -1,0 +1,12 @@
+-- Add chat_messages.workflow.
+--
+-- The app persists a `workflow` field on user messages
+-- (backend/src/routes/chat.ts, projectChat.ts) and reads it back when rendering
+-- chat history (frontend ChatView -> UserMessage, to show which workflow the
+-- message was sent under). The column was referenced in code but never created
+-- by schema.sql or any migration, so every user-message insert failed with
+-- PostgREST PGRST204 ("Could not find the 'workflow' column") and was dropped
+-- silently — user prompts vanished on reload while the assistant reply
+-- persisted. Mirrors the existing content/files jsonb columns.
+alter table public.chat_messages
+  add column if not exists workflow jsonb;

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -524,6 +524,7 @@ create table if not exists public.chat_messages (
   role text not null,
   content jsonb,
   files jsonb,
+  workflow jsonb,
   citations jsonb,
   created_at timestamptz not null default now()
 );


### PR DESCRIPTION
## Problem

User reloading a thread shows the assistant reply but **not the user's own prompt** — the prompt only ever existed in the browser's in-memory state during the live turn.

User messages are inserted with a `workflow` field:

- `backend/src/routes/chat.ts` — the `role: "user"` insert
- `backend/src/routes/projectChat.ts` — same

and it is read back when rendering chat history (`ChatView` → `UserMessage`) to show which workflow a message was sent under.

But `chat_messages.workflow` is never created — it is absent from `backend/schema.sql` and no migration adds it. On a fresh self-hosted install, **every user-message insert fails** with:

```
PostgREST PGRST204: Could not find the 'workflow' column of 'chat_messages' in the schema cache
```

The insert result isn't checked, so the failure is silent. The assistant-message insert has no `workflow` column, so it succeeds. Net effect: reloading a thread shows the assistant reply but **not the user's own prompt** — the prompt only ever existed in the browser's in-memory state during the live turn.

## Reproduction

On a DB built from `schema.sql`:

```sql
insert into chat_messages (chat_id, role, content, files, workflow)
values ('<existing-chat-id>', 'user', '"hi"'::jsonb, null, null);
-- ERROR: PGRST204 — column "workflow" does not exist
```

The same insert without `workflow` succeeds. Querying `chat_messages` afterwards shows only `assistant` rows.

## Fix

Add the `workflow jsonb` column, mirroring the adjacent `content`/`files` jsonb columns:

- `schema.sql` — for fresh installs
- `migrations/20260716_01_chat_messages_workflow.sql` — idempotent `add column if not exists`, for existing installs

After applying, user-message inserts succeed and prompts persist across reloads.

## My Setup

Mike and all components were installed on a single VM using: Docker 29.6, Node 20, nginx, MinIO (S3 storage) and Supabase. 

🤖 Generated with [Claude Code](https://claude.com/claude-code). Reviewed by a human, me. :)
