### PR TITLE
fix(frontend): snap smoothed reveal to full text when the stream ends

### DIFF
--- a/frontend/src/app/components/assistant/message/useSmoothedReveal.ts
+++ b/frontend/src/app/components/assistant/message/useSmoothedReveal.ts
@@ -18,7 +18,15 @@ export function useSmoothedReveal(text: string, active: boolean): string {
 
     useEffect(() => {
         if (!active) {
+            // Snap to full text. We must update BOTH the float ref (used as the
+            // animation's resume point) and the rendered `revealedInt` state.
+            // If the stream ends while the reveal is still mid-animation — as
+            // Deep Research always does, delivering its entire report in a
+            // single content chunk at the very end — `revealedInt` would
+            // otherwise stay frozen at whatever partial prefix the animation
+            // had reached, permanently truncating the visible answer.
             revealedFloat.current = text.length;
+            setRevealedInt((cur) => (cur === text.length ? cur : text.length));
             return;
         }
 
@@ -57,4 +65,3 @@ export function useSmoothedReveal(text: string, active: boolean): string {
 
     return text.slice(0, Math.min(revealedInt, text.length));
 }
-


### PR DESCRIPTION
## Problem

User experience: an assistant answer can appear to stop mid-sentence or miss its ending after streaming finishes.

`useSmoothedReveal` animates the last assistant content event by rendering `text.slice(0, revealedInt)` while `revealedInt` catches up to `text.length`.

The hook’s docstring says inactive messages snap to the full text immediately, but the `!active` branch only updates `revealedFloat.current`. It does not update `revealedInt`, which is the state used for rendering.

If streaming ends while the reveal animation is still behind the latest text length, `active` becomes false and the animation stops. Since `revealedInt` is never snapped to `text.length`, the message can remain stuck on a partial prefix and the rest of the assistant response is not shown.

## Fix

When `active` is false, also set `revealedInt` to `text.length`, guarded to avoid redundant renders. This makes completed or replayed messages render the full text immediately, while leaving the active streaming animation unchanged.

After the fix, once streaming ends, the message immediately shows the complete assistant response. During active streaming, the smooth reveal behavior stays the same.
