### PR TITLE
feat: server-side citation verification against source text

### DIFF
--- a/backend/src/lib/chat/streaming.ts
+++ b/backend/src/lib/chat/streaming.ts
@@ -25,6 +25,7 @@ import {
   type AskInputsEvent,
   type EditAnnotation,
   devLog,
+  resolveDocLabel,
 } from "./types";
 import { TOOLS, WORKFLOW_TOOLS } from "./tools/toolSchemas";
 import {
@@ -38,9 +39,11 @@ import {
   type CourtlistenerTurnState,
 } from "./tools/toolDispatcher";
 import {
+  readDocumentContent,
   type TurnEditState,
   type TurnReadState,
 } from "./tools/documentOps";
+import { verifyDocumentCitations } from "./verifyCitations";
 
 
 export type AssistantEvent =
@@ -527,15 +530,39 @@ export async function runLLMStream(params: {
   // Parse and emit citations from <CITATIONS> block
   const { citations: parsedCitations, diagnostics: citationDiagnostics } =
     parseCitationsWithDiagnostics(fullText);
-  const citations = buildCitations
-    ? buildCitations(fullText)
-    : parsedCitations.map((c) =>
-        createCitation(
-          c,
-          docIndex,
-          courtlistenerTurnState.casesByClusterId,
-        ),
-      );
+  let citations: unknown[];
+  if (buildCitations) {
+    // Custom builders (tabular) bypass verification; annotations carry no
+    // verification_status and the UI treats a missing status as untrusted.
+    citations = buildCitations(fullText);
+  } else {
+    const rawCitations = parsedCitations.map((c) =>
+      createCitation(
+        c,
+        docIndex,
+        courtlistenerTurnState.casesByClusterId,
+      ),
+    );
+    // Server-side document-quote verification. Fetch each document's extracted
+    // source text at most once per turn (memoized by doc_id), reading only the
+    // bytes already in storage with emitEvents:false so no new events fire and
+    // the air-gap guarantee holds. Case citations pass through untouched.
+    const sourceTextByDocId = new Map<string, Promise<string>>();
+    const getSourceText = (docId: string): Promise<string> => {
+      let pending = sourceTextByDocId.get(docId);
+      if (!pending) {
+        const label = resolveDocLabel(docId, docStore, docIndex);
+        pending = label
+          ? readDocumentContent(label, docStore, () => {}, docIndex, db, {
+              emitEvents: false,
+            })
+          : Promise.resolve("");
+        sourceTextByDocId.set(docId, pending);
+      }
+      return pending;
+    };
+    citations = await verifyDocumentCitations(rawCitations, getSourceText);
+  }
   devLog("[chat/stream] final citations", {
     hasCitationsBlock: citationDiagnostics.hasBlock,
     citationsBlockLength: citationDiagnostics.rawLength,

--- a/backend/src/lib/chat/tools/documentOps.ts
+++ b/backend/src/lib/chat/tools/documentOps.ts
@@ -1578,14 +1578,30 @@ export async function readDocumentContent(
   }
 }
 
+/** A character is "punctuation" for tolerant matching if it is not a letter,
+ *  number, or whitespace. Dropped entirely (not replaced with a space) so
+ *  "U.S." collapses to "us" and "plaintiff's" to "plaintiffs". */
+function isPunctuation(ch: string): boolean {
+  return !/[\p{L}\p{N}\s]/u.test(ch);
+}
+
 /**
  * Build a whitespace-collapsed, lowercased copy of `text`, plus a map from
  * each character index in the normalized form back to the corresponding
- * index in the original text. Used by `findInDocumentContent` so matches
- * are tolerant of case + whitespace variance but can still return the
- * exact original excerpt.
+ * index in the original text. Used by `findInDocumentContent` (and server-side
+ * citation verification) so matches are tolerant of case + whitespace variance
+ * but can still return the exact original excerpt.
+ *
+ * With `stripPunctuation`, punctuation characters are removed from the
+ * normalized form too, making matching tolerant of punctuation drift (e.g. a
+ * model that adds a stray comma or drops a period). The index map still points
+ * back at the surviving original characters so the recovered excerpt is exact.
  */
-function normalizeWithMap(text: string): { norm: string; origIdx: number[] } {
+export function normalizeWithMap(
+  text: string,
+  opts: { stripPunctuation?: boolean } = {},
+): { norm: string; origIdx: number[] } {
+  const stripPunctuation = opts.stripPunctuation ?? false;
   const norm: string[] = [];
   const origIdx: number[] = [];
   let prevSpace = false;
@@ -1597,6 +1613,10 @@ function normalizeWithMap(text: string): { norm: string; origIdx: number[] } {
         origIdx.push(i);
         prevSpace = true;
       }
+    } else if (stripPunctuation && isPunctuation(ch)) {
+      // Drop punctuation without disturbing the space-collapsing state so
+      // "foo, bar" -> "foo bar" but "U.S." -> "us".
+      continue;
     } else {
       norm.push(ch.toLowerCase());
       origIdx.push(i);

--- a/backend/src/lib/chat/types.ts
+++ b/backend/src/lib/chat/types.ts
@@ -57,6 +57,32 @@ export type ChatMessage = {
   workflow?: { id: string; title: string };
 };
 
+/**
+ * Result of server-side verification of a document quote against the extracted
+ * source text.
+ * - `verified`   — the quote was found and is character-identical to the source.
+ * - `repaired`   — the quote was found under whitespace/case/punctuation-tolerant
+ *                  matching but drifted from the source; `source_excerpt` holds the
+ *                  exact source text and has been swapped into the displayed quote.
+ * - `unverified` — no tolerant match; the model's quote is preserved but untrusted.
+ *
+ * A MISSING status (undefined) must be treated as untrusted by the UI — some
+ * paths (tabular, abort/error persistence) do not run verification.
+ */
+export type CitationVerificationStatus = "verified" | "unverified" | "repaired";
+
+/**
+ * Per-quote verification result. `start_char`/`end_char` index into the
+ * EXTRACTED source text (not the raw file bytes) and are only present for
+ * single-segment quotes that matched.
+ */
+export type QuoteVerification = {
+  status: CitationVerificationStatus;
+  start_char?: number;
+  end_char?: number;
+  source_excerpt?: string;
+};
+
 // ---------------------------------------------------------------------------
 // Doc resolution helpers (used by citations + documentOps)
 // ---------------------------------------------------------------------------

--- a/backend/src/lib/chat/verifyCitations.test.ts
+++ b/backend/src/lib/chat/verifyCitations.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from "vitest";
+
+// verifyCitations only reuses the pure normalizeWithMap matcher from
+// documentOps, but importing documentOps pulls in its storage/supabase graph.
+// Keep those module side-effects offline — this test injects source text
+// directly and never touches storage, proving verification adds no egress
+// (air-gap safe).
+vi.mock("../supabase", () => ({ createServerSupabase: vi.fn() }));
+vi.mock("../storage", () => ({ downloadFile: vi.fn() }));
+
+import {
+  locateQuote,
+  verifyQuoteAgainstSource,
+  verifyDocumentCitationAnnotation,
+  verifyDocumentCitations,
+} from "./verifyCitations";
+
+// Deterministic in-memory source text — no storage/model/network. Proves
+// verification only reads bytes handed to it (air-gap safe).
+const SOURCE = [
+  "## Page 1",
+  "The Tenant shall pay rent on the first day of each month.",
+  "The Landlord may terminate this Lease upon written notice.",
+].join("\n");
+
+function fetcherFor(map: Record<string, string>) {
+  return async (docId: string) => map[docId] ?? "";
+}
+
+function docAnnotation(quotes: { page: number | string; quote: string }[]) {
+  return {
+    type: "citation_data",
+    kind: "document" as const,
+    ref: 1,
+    doc_id: "doc-1",
+    document_id: "uuid-1",
+    filename: "lease.pdf",
+    page: quotes[0]?.page ?? 1,
+    quote: quotes[0]?.quote ?? "",
+    quotes,
+  };
+}
+
+describe("locateQuote", () => {
+  it("returns exact offsets for an exact substring match", () => {
+    const quote = "pay rent on the first day";
+    const loc = locateQuote(SOURCE, quote);
+    expect(loc).not.toBeNull();
+    expect(SOURCE.slice(loc!.start, loc!.end)).toBe(quote);
+    expect(loc!.excerpt).toBe(quote);
+  });
+
+  it("returns null when the quote is absent", () => {
+    expect(locateQuote(SOURCE, "the Tenant shall vacate immediately")).toBeNull();
+  });
+});
+
+describe("verifyQuoteAgainstSource", () => {
+  it("exact match → verified with correct offsets into the source", () => {
+    const quote = "The Landlord may terminate this Lease";
+    const v = verifyQuoteAgainstSource(SOURCE, quote);
+    expect(v.status).toBe("verified");
+    expect(v.source_excerpt).toBe(quote);
+    expect(SOURCE.slice(v.start_char, v.end_char)).toBe(quote);
+  });
+
+  it("whitespace + case drift → repaired with the exact source excerpt", () => {
+    const drifted = "the  landlord   MAY terminate this lease";
+    const v = verifyQuoteAgainstSource(SOURCE, drifted);
+    expect(v.status).toBe("repaired");
+    expect(v.source_excerpt).toBe("The Landlord may terminate this Lease");
+    expect(SOURCE.slice(v.start_char, v.end_char)).toBe(v.source_excerpt);
+  });
+
+  it("punctuation drift → repaired with corrected excerpt and offsets", () => {
+    // Model inserted a stray comma the source does not contain.
+    const drifted = "pay rent, on the first day";
+    const v = verifyQuoteAgainstSource(SOURCE, drifted);
+    expect(v.status).toBe("repaired");
+    expect(v.source_excerpt).toBe("pay rent on the first day");
+    expect(SOURCE.slice(v.start_char, v.end_char)).toBe(v.source_excerpt);
+  });
+
+  it("fabricated quote → unverified with no offsets", () => {
+    const v = verifyQuoteAgainstSource(SOURCE, "The Tenant waives all rights.");
+    expect(v.status).toBe("unverified");
+    expect(v.start_char).toBeUndefined();
+    expect(v.end_char).toBeUndefined();
+    expect(v.source_excerpt).toBeUndefined();
+  });
+
+  it("empty / unreadable source → unverified", () => {
+    expect(verifyQuoteAgainstSource("", "anything").status).toBe("unverified");
+    expect(
+      verifyQuoteAgainstSource("Document could not be read.", "anything").status,
+    ).toBe("unverified");
+  });
+
+  it("cross-page [[PAGE_BREAK]] quote → each segment verified independently", () => {
+    const src = "the first day of each month. The Landlord may terminate";
+    const quote = "the first day of each month[[PAGE_BREAK]]The Landlord may terminate";
+    const v = verifyQuoteAgainstSource(src, quote);
+    expect(v.status).toBe("verified");
+    expect(v.source_excerpt).toContain("[[PAGE_BREAK]]");
+  });
+
+  it("cross-page quote with a missing segment → unverified", () => {
+    const quote = "the first day of each month[[PAGE_BREAK]]never appears here";
+    const v = verifyQuoteAgainstSource(SOURCE, quote);
+    expect(v.status).toBe("unverified");
+  });
+});
+
+describe("verifyDocumentCitationAnnotation", () => {
+  const fetcher = fetcherFor({ "doc-1": SOURCE });
+
+  it("marks a verified quote and attaches per-quote offsets + aggregate status", async () => {
+    const ann = (await verifyDocumentCitationAnnotation(
+      docAnnotation([{ page: 1, quote: "The Tenant shall pay rent" }]),
+      fetcher,
+    )) as Record<string, unknown>;
+    expect(ann.verification_status).toBe("verified");
+    const quotes = ann.quotes as { verification: { status: string } }[];
+    expect(quotes[0].verification.status).toBe("verified");
+  });
+
+  it("repairs a drifted quote by swapping in the exact source excerpt", async () => {
+    const ann = (await verifyDocumentCitationAnnotation(
+      docAnnotation([{ page: 1, quote: "the  TENANT shall pay rent" }]),
+      fetcher,
+    )) as Record<string, unknown>;
+    expect(ann.verification_status).toBe("repaired");
+    const quotes = ann.quotes as {
+      quote: string;
+      verification: { status: string; source_excerpt: string };
+    }[];
+    expect(quotes[0].verification.status).toBe("repaired");
+    // The displayed quote is swapped to the true source text.
+    expect(quotes[0].quote).toBe("The Tenant shall pay rent");
+    // Legacy top-level quote mirror is updated too.
+    expect(ann.quote).toBe("The Tenant shall pay rent");
+  });
+
+  it("marks a fabricated quote unverified and preserves the model text", async () => {
+    const ann = (await verifyDocumentCitationAnnotation(
+      docAnnotation([{ page: 1, quote: "The Tenant may sublet freely." }]),
+      fetcher,
+    )) as Record<string, unknown>;
+    expect(ann.verification_status).toBe("unverified");
+    const quotes = ann.quotes as { quote: string }[];
+    expect(quotes[0].quote).toBe("The Tenant may sublet freely.");
+  });
+
+  it("aggregates to unverified when any quote is unverified", async () => {
+    const ann = (await verifyDocumentCitationAnnotation(
+      docAnnotation([
+        { page: 1, quote: "The Tenant shall pay rent" },
+        { page: 1, quote: "Nonexistent clause here." },
+      ]),
+      fetcher,
+    )) as Record<string, unknown>;
+    expect(ann.verification_status).toBe("unverified");
+  });
+
+  it("unreadable source → all quotes unverified", async () => {
+    const ann = (await verifyDocumentCitationAnnotation(
+      docAnnotation([{ page: 1, quote: "The Tenant shall pay rent" }]),
+      fetcherFor({ "doc-1": "Document could not be read." }),
+    )) as Record<string, unknown>;
+    expect(ann.verification_status).toBe("unverified");
+  });
+
+  it("leaves case-law annotations untouched (no CourtListener regression)", async () => {
+    const caseAnn = {
+      type: "citation_data",
+      kind: "case",
+      ref: 2,
+      cluster_id: 42,
+      case_name: "Roe v. Doe",
+      quotes: [{ opinionId: null, type: null, author: null, quote: "held that…" }],
+    };
+    const out = await verifyDocumentCitationAnnotation(caseAnn, fetcher);
+    expect(out).toBe(caseAnn);
+    expect(out as Record<string, unknown>).not.toHaveProperty(
+      "verification_status",
+    );
+  });
+});
+
+describe("verifyDocumentCitations (batch)", () => {
+  it("verifies documents and passes case citations through unchanged", async () => {
+    const caseAnn = { type: "citation_data", kind: "case", ref: 2, cluster_id: 7 };
+    const out = await verifyDocumentCitations(
+      [docAnnotation([{ page: 1, quote: "The Tenant shall pay rent" }]), caseAnn],
+      fetcherFor({ "doc-1": SOURCE }),
+    );
+    expect((out[0] as Record<string, unknown>).verification_status).toBe(
+      "verified",
+    );
+    expect(out[1]).toBe(caseAnn);
+  });
+});

--- a/backend/src/lib/chat/verifyCitations.ts
+++ b/backend/src/lib/chat/verifyCitations.ts
@@ -1,0 +1,185 @@
+import type {
+  CitationVerificationStatus,
+  QuoteVerification,
+} from "./types";
+import { normalizeWithMap } from "./tools/documentOps";
+
+// Mirrors the frontend: cross-page quotes join two page segments with this
+// sentinel (see expandDocumentQuoteEntry in
+// frontend/src/app/components/shared/types.ts).
+const PAGE_BREAK_SENTINEL = "[[PAGE_BREAK]]";
+
+// Source-text sentinels returned by readDocumentContent when a document can't
+// be read. Treat these as "no source" so every quote falls back to unverified
+// rather than false-negative matching against the literal error string.
+const UNREADABLE_SOURCES = new Set([
+  "Document could not be read.",
+  "Document not found.",
+]);
+
+type QuoteLocation = { start: number; end: number; excerpt: string };
+
+/**
+ * Locate `quote` inside `source`, returning the exact original substring
+ * (`excerpt`) plus its char offsets into `source`. Tries progressively more
+ * tolerant matchers and returns the first hit:
+ *   1. exact substring
+ *   2. whitespace + case normalized
+ *   3. whitespace + case + punctuation normalized (tolerant/fuzzy)
+ * Offsets index into the EXTRACTED source text, not the raw file bytes.
+ */
+export function locateQuote(source: string, quote: string): QuoteLocation | null {
+  if (!source || !quote) return null;
+
+  // Tier 1: exact.
+  const exactIdx = source.indexOf(quote);
+  if (exactIdx >= 0) {
+    return { start: exactIdx, end: exactIdx + quote.length, excerpt: quote };
+  }
+
+  // Tier 2: whitespace + case. Tier 3: also punctuation-tolerant.
+  return (
+    locateNormalized(source, quote, {}) ??
+    locateNormalized(source, quote, { stripPunctuation: true })
+  );
+}
+
+function locateNormalized(
+  source: string,
+  quote: string,
+  opts: { stripPunctuation?: boolean },
+): QuoteLocation | null {
+  const { norm, origIdx } = normalizeWithMap(source, opts);
+  const needle = normalizeWithMap(quote, opts).norm.trim();
+  if (!needle) return null;
+  const pos = norm.indexOf(needle);
+  if (pos < 0) return null;
+  const endNormPos = pos + needle.length;
+  const start = origIdx[pos] ?? 0;
+  const end =
+    endNormPos - 1 < origIdx.length
+      ? origIdx[endNormPos - 1] + 1
+      : source.length;
+  return { start, end, excerpt: source.slice(start, end) };
+}
+
+/**
+ * Verify a single model quote against the source text, returning the
+ * per-quote verification record. Cross-page quotes (containing the
+ * `[[PAGE_BREAK]]` sentinel) are split and each segment verified independently;
+ * char offsets are only attached for single-segment quotes.
+ */
+export function verifyQuoteAgainstSource(
+  source: string,
+  quote: string,
+): QuoteVerification {
+  if (!source || UNREADABLE_SOURCES.has(source)) {
+    return { status: "unverified" };
+  }
+
+  if (quote.includes(PAGE_BREAK_SENTINEL)) {
+    const segments = quote
+      .split(PAGE_BREAK_SENTINEL)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (!segments.length) return { status: "unverified" };
+    const located = segments.map((seg) => ({ seg, loc: locateQuote(source, seg) }));
+    if (located.some((l) => !l.loc)) return { status: "unverified" };
+    const anyRepaired = located.some((l) => l.loc!.excerpt !== l.seg);
+    return {
+      status: anyRepaired ? "repaired" : "verified",
+      source_excerpt: located
+        .map((l) => l.loc!.excerpt)
+        .join(` ${PAGE_BREAK_SENTINEL} `),
+    };
+  }
+
+  const loc = locateQuote(source, quote);
+  if (!loc) return { status: "unverified" };
+  return {
+    status: loc.excerpt === quote ? "verified" : "repaired",
+    start_char: loc.start,
+    end_char: loc.end,
+    source_excerpt: loc.excerpt,
+  };
+}
+
+/** Aggregate a list of per-quote statuses: unverified beats repaired beats verified. */
+function aggregateStatus(
+  statuses: CitationVerificationStatus[],
+): CitationVerificationStatus {
+  if (statuses.some((s) => s === "unverified")) return "unverified";
+  if (statuses.some((s) => s === "repaired")) return "repaired";
+  return "verified";
+}
+
+type DocQuoteEntry = { page: number | string; quote: string };
+
+/**
+ * Attach server-side verification to one document citation annotation.
+ * Case-law annotations (kind === "case") are returned untouched — their
+ * existence is verified upstream via CourtListener and must never be
+ * re-marked. For document annotations, source text is fetched once via
+ * `getSourceText(doc_id)` and each quote is located in it; repaired quotes
+ * have the exact source excerpt swapped in so the UI never shows drifted text.
+ */
+export async function verifyDocumentCitationAnnotation(
+  annotation: unknown,
+  getSourceText: (docId: string) => Promise<string>,
+): Promise<unknown> {
+  if (!annotation || typeof annotation !== "object") return annotation;
+  const a = annotation as Record<string, unknown>;
+  if (a.kind === "case") return annotation;
+  const docId = typeof a.doc_id === "string" ? a.doc_id : null;
+  if (!docId) return annotation;
+
+  const entries: DocQuoteEntry[] = Array.isArray(a.quotes)
+    ? (a.quotes as DocQuoteEntry[])
+    : typeof a.quote === "string"
+      ? [{ page: (a.page as number | string) ?? 1, quote: a.quote }]
+      : [];
+  if (!entries.length) return annotation;
+
+  let source: string;
+  try {
+    source = await getSourceText(docId);
+  } catch {
+    source = "";
+  }
+
+  const verifiedQuotes = entries.map((entry) => {
+    const verification = verifyQuoteAgainstSource(source, entry.quote);
+    // Swap the exact source text into the displayed quote when we repaired it,
+    // so a drifted quote is never surfaced as the source's words.
+    const quote =
+      verification.status === "repaired" && verification.source_excerpt
+        ? verification.source_excerpt
+        : entry.quote;
+    return { ...entry, quote, verification };
+  });
+
+  const verificationStatus = aggregateStatus(
+    verifiedQuotes.map((q) => q.verification.status),
+  );
+
+  return {
+    ...a,
+    quote: verifiedQuotes[0]?.quote ?? a.quote,
+    quotes: verifiedQuotes,
+    verification_status: verificationStatus,
+  };
+}
+
+/**
+ * Verify a batch of citation annotations. Document annotations are verified
+ * against source text supplied by `getSourceText`; case annotations pass
+ * through unchanged.
+ */
+export async function verifyDocumentCitations(
+  annotations: unknown[],
+  getSourceText: (docId: string) => Promise<string>,
+): Promise<unknown[]> {
+  return Promise.all(
+    annotations.map((a) => verifyDocumentCitationAnnotation(a, getSourceText)),
+  );
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -16,5 +16,5 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/__tests__/**"]
 }


### PR DESCRIPTION
## Summary

Hallucinated citations are the failure mode that gets a small firm sanctioned. This PR adds server-side verification of assistant citations: after the model's `<CITATIONS>` block is parsed, every document quote is checked against the actual extracted text of the cited document before the citation is streamed to the client or persisted.

Each quote is located in the source with progressively more tolerant matching — exact substring, then whitespace/case-normalized, then punctuation-tolerant — and gets a per-quote `verification` record plus char offsets into the extracted text. Each citation gets an aggregate `verification_status`:

- `verified` — quote is character-identical to the source
- `repaired` — quote was found under tolerant matching but drifted; the exact source excerpt is swapped into the displayed quote so drifted text is never presented as the source's words
- `unverified` — no match; the model's text is preserved but must be treated as untrusted

Cross-page quotes (`[[PAGE_BREAK]]` sentinel) are split and each segment verified independently. Case-law citations pass through untouched — their existence is already verified via CourtListener and is never re-marked here.

## Changes

- `backend/src/lib/chat/verifyCitations.ts` (new) — quote location + verification + annotation/batch verification logic
- `backend/src/lib/chat/verifyCitations.test.ts` (new) — 16 focused unit tests (exact/drifted/fabricated quotes, unreadable sources, cross-page quotes, case-citation passthrough, aggregation)
- `backend/src/lib/chat/streaming.ts` — verify final citations before the `citations` SSE frame; source text is fetched at most once per document per turn (memoized), via `readDocumentContent(..., { emitEvents: false })` so no extra events fire
- `backend/src/lib/chat/tools/documentOps.ts` — `normalizeWithMap` gains an optional `stripPunctuation` mode and is exported (used by tier-3 tolerant matching)
- `backend/src/lib/chat/types.ts` — `CitationVerificationStatus` / `QuoteVerification` types
- `backend/tsconfig.json` — exclude `*.test.ts` / `__tests__` from the `tsc` build so tests don't require test deps at build time

No new runtime dependencies. No frontend changes: the new fields ride along on the existing citation annotations; a missing `verification_status` is documented as "treat as untrusted", so existing clients are unaffected.

## Why

Citation trust is mission-core: the assistant's answer is only usable in legal work if every quote it attributes to a document is actually in that document. This closes the gap server-side, where the source of truth (document bytes in storage) lives — the client never has to be trusted to check.

No new vendors. Negligible compute cost: verification is pure string matching over document text the server already extracts, with source text memoized per document per turn — no extra LLM calls and no network egress (the tests explicitly prove verification only reads bytes handed to it).

## Testing

- `npm install && npm run build` in `backend/` — green on this branch as committed
- `npx vitest run src/lib/chat/verifyCitations.test.ts` — 16/16 passed (vitest installed locally with `--no-save` and not committed; upstream has no test harness yet, so tests run atop the test-harness PR)
- `frontend/` untouched

## Provenance

All changes are mechanical ports of code in amal66/mike@origin/main (commit b3166dd); exceptions: none. Sources: `apps/api/src/lib/tools/verifyCitations.ts` + `.test.ts` (logic and tests, verbatim modulo import paths and mock/comment path rewrites), `apps/api/src/lib/tools/stream.ts` (streaming hook, verbatim modulo `createCitationAnnotation` → upstream's `createCitation`), `apps/api/src/lib/tools/docRead.ts` (`normalizeWithMap` extension, verbatim), `packages/core/src/types.ts` (the two verification types, inlined verbatim), `apps/api/tsconfig.json` (test-file build exclusion).

## Credits & prior art
- **@Gadoes** ([Gadoes/dispumike](https://github.com/Gadoes/dispumike)) — independently parallels this work: their fork built citation verification for case-law sources (via legal-database integrations such as CourtListener/EUR-Lex). This PR verifies document quotes against source text server-side — same goal (no hallucinated citations reach a lawyer), different mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEguyEgXa9JjCciXCcVemC


