### PR TITLE
security: reject download tokens without an expiry

### DIFF
--- a/backend/src/core/downloadTokens.ts
+++ b/backend/src/core/downloadTokens.ts
@@ -1,0 +1,97 @@
+import crypto from "crypto";
+
+export type DownloadTokenPayload = {
+  path: string;
+  filename: string;
+  /** Unix timestamp (seconds) after which the token is invalid. */
+  exp?: number;
+};
+
+function b64urlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function b64urlDecode(s: string): Buffer {
+  let t = s.replace(/-/g, "+").replace(/_/g, "/");
+  while (t.length % 4) t += "=";
+  return Buffer.from(t, "base64");
+}
+
+function timingSafeEqStr(a: string, b: string): boolean {
+  const maxLen = Math.max(a.length, b.length, 1);
+  const aBuf = Buffer.alloc(maxLen, 0);
+  const bBuf = Buffer.alloc(maxLen, 0);
+  Buffer.from(a).copy(aBuf);
+  Buffer.from(b).copy(bBuf);
+  return crypto.timingSafeEqual(aBuf, bBuf) && a.length === b.length;
+}
+
+const DEFAULT_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+export function signDownloadPayload(
+  payload: DownloadTokenPayload,
+  secret: string,
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+): string {
+  const exp = payload.exp ?? Math.floor(Date.now() / 1000) + ttlSeconds;
+  const encodedPayload = b64urlEncode(
+    Buffer.from(
+      JSON.stringify({ p: payload.path, f: payload.filename, e: exp }),
+      "utf8",
+    ),
+  );
+  const signature = crypto
+    .createHmac("sha256", secret)
+    .update(encodedPayload)
+    .digest();
+  return `${encodedPayload}.${b64urlEncode(signature)}`;
+}
+
+export function verifyDownloadPayload(
+  token: string,
+  secret: string,
+): DownloadTokenPayload | null {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+
+  const [encodedPayload, encodedSignature] = parts;
+  const expectedSignature = crypto
+    .createHmac("sha256", secret)
+    .update(encodedPayload)
+    .digest();
+
+  if (!timingSafeEqStr(encodedSignature, b64urlEncode(expectedSignature))) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(
+      b64urlDecode(encodedPayload).toString("utf8"),
+    ) as {
+      p: unknown;
+      f: unknown;
+      e?: unknown;
+    };
+    if (typeof parsed.p !== "string" || typeof parsed.f !== "string") {
+      return null;
+    }
+    if (!parsed.p || !parsed.f) return null;
+    // Every token must carry an expiry. A token without `e` is legacy (issued
+    // before expiry existed) and would otherwise be valid forever, so reject it
+    // — any such link is long stale (all issuers have set `e` since), and a
+    // fresh, expiring token is re-issued on next access.
+    if (
+      typeof parsed.e !== "number" ||
+      parsed.e < Math.floor(Date.now() / 1000)
+    ) {
+      return null;
+    }
+    return { path: parsed.p, filename: parsed.f };
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/lib/__tests__/downloadTokens.expiry.test.ts
+++ b/backend/src/lib/__tests__/downloadTokens.expiry.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { signDownloadPayload, verifyDownloadPayload } from "../../core/downloadTokens";
+
+describe("token expiry", () => {
+    const SECRET = "expiry-test-secret-value-32bytes!";
+
+    it("accepts a token whose exp is in the future", () => {
+        const futureExp = Math.floor(Date.now() / 1000) + 3600;
+        const token = signDownloadPayload(
+            { path: "p", filename: "f.pdf", exp: futureExp },
+            SECRET,
+        );
+        expect(verifyDownloadPayload(token, SECRET)).not.toBeNull();
+    });
+
+    it("rejects a token whose exp is in the past", () => {
+        const pastExp = Math.floor(Date.now() / 1000) - 1;
+        const token = signDownloadPayload(
+            { path: "p", filename: "f.pdf", exp: pastExp },
+            SECRET,
+        );
+        expect(verifyDownloadPayload(token, SECRET)).toBeNull();
+    });
+
+    it("rejects a legacy token with no exp field (would otherwise never expire)", () => {
+        // Manually build a well-signed token without the 'e' field to simulate
+        // old tokens. Such a token was previously accepted forever; it must now
+        // be rejected so every valid token carries an expiry.
+        const b64u = (buf: Buffer) =>
+            buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+        const crypto = require("crypto") as typeof import("crypto");
+        const payload = b64u(Buffer.from(JSON.stringify({ p: "path", f: "file.pdf" })));
+        const sig = b64u(crypto.createHmac("sha256", SECRET).update(payload).digest());
+        const token = `${payload}.${sig}`;
+        expect(verifyDownloadPayload(token, SECRET)).toBeNull();
+    });
+});

--- a/backend/src/lib/downloadTokens.ts
+++ b/backend/src/lib/downloadTokens.ts
@@ -1,4 +1,7 @@
-import crypto from "crypto";
+import {
+  signDownloadPayload,
+  verifyDownloadPayload,
+} from "../core/downloadTokens";
 
 /**
  * HMAC-signed, non-expiring download tokens.
@@ -10,66 +13,24 @@ import crypto from "crypto";
  */
 
 function getSecret(): string {
-    const secret = process.env.DOWNLOAD_SIGNING_SECRET;
-    if (!secret) {
-        throw new Error(
-            "DOWNLOAD_SIGNING_SECRET must be set. " +
-                "Generate a strong random value (e.g. `openssl rand -hex 32`) and set it in the environment.",
-        );
-    }
-    return secret;
-}
-
-function b64urlEncode(buf: Buffer): string {
-    return buf
-        .toString("base64")
-        .replace(/\+/g, "-")
-        .replace(/\//g, "_")
-        .replace(/=+$/g, "");
-}
-
-function b64urlDecode(s: string): Buffer {
-    let t = s.replace(/-/g, "+").replace(/_/g, "/");
-    while (t.length % 4) t += "=";
-    return Buffer.from(t, "base64");
-}
-
-function timingSafeEqStr(a: string, b: string): boolean {
-    if (a.length !== b.length) return false;
-    return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  const secret = process.env.DOWNLOAD_SIGNING_SECRET;
+  if (!secret) {
+    throw new Error(
+      "DOWNLOAD_SIGNING_SECRET must be set. " +
+        "Generate a strong random value (e.g. `openssl rand -hex 32`) and set it in the environment.",
+    );
+  }
+  return secret;
 }
 
 export function signDownload(path: string, filename: string): string {
-    const payload = JSON.stringify({ p: path, f: filename });
-    const enc = b64urlEncode(Buffer.from(payload, "utf8"));
-    const sig = crypto
-        .createHmac("sha256", getSecret())
-        .update(enc)
-        .digest();
-    return `${enc}.${b64urlEncode(sig)}`;
+  return signDownloadPayload({ path, filename }, getSecret());
 }
 
 export function verifyDownload(
-    token: string,
+  token: string,
 ): { path: string; filename: string } | null {
-    const parts = token.split(".");
-    if (parts.length !== 2) return null;
-    const [enc, sigEnc] = parts;
-    const expected = crypto
-        .createHmac("sha256", getSecret())
-        .update(enc)
-        .digest();
-    if (!timingSafeEqStr(sigEnc, b64urlEncode(expected))) return null;
-    try {
-        const parsed = JSON.parse(b64urlDecode(enc).toString("utf8")) as {
-            p: string;
-            f: string;
-        };
-        if (!parsed?.p || !parsed?.f) return null;
-        return { path: parsed.p, filename: parsed.f };
-    } catch {
-        return null;
-    }
+  return verifyDownloadPayload(token, getSecret());
 }
 
 /**
@@ -77,5 +38,5 @@ export function verifyDownload(
  * prefixes it with NEXT_PUBLIC_API_BASE_URL when rendering `<a href=…>`.
  */
 export function buildDownloadUrl(path: string, filename: string): string {
-    return `/download/${signDownload(path, filename)}`;
+  return `/download/${signDownload(path, filename)}`;
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -16,5 +16,5 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/__tests__/**"]
 }


### PR DESCRIPTION
## Summary

Download links are HMAC-signed tokens, but a token never expired: anyone who ever obtained a link (old chat exports, forwarded messages, logs) could fetch the file forever, and there was no way to invalidate it short of rotating the signing secret. This PR ports the fork's hardening: every token now carries an expiry (30-day default TTL), verification rejects expired tokens, and — fail-closed — a well-signed token *without* an expiry field is rejected rather than treated as eternal.

## Changes

- `backend/src/core/downloadTokens.ts` (new): pure sign/verify functions. Payload gains an `e` (expiry, unix seconds) field, default TTL 30 days; `verifyDownloadPayload` returns `null` when `e` is missing, non-numeric, or in the past. Also hardens the timing-safe compare against length differences.
- `backend/src/lib/downloadTokens.ts`: becomes a thin env-secret wrapper (`signDownload` / `verifyDownload` / `buildDownloadUrl`) delegating to the core module. Public API unchanged — no caller changes needed.
- `backend/src/lib/__tests__/downloadTokens.expiry.test.ts` (new): the fork's "token expiry" suite — future-exp accepted, past-exp rejected, well-signed legacy token without an exp field rejected.
- `backend/tsconfig.json`: excludes test files from `tsc` output (byte-identical to the exclusion in the test-harness PR, so both merge cleanly), keeping `npm run build` green before vitest lands.

Note on rollout: previously issued (non-expiring) tokens become invalid — deliberate, that is the vulnerability being closed. Fresh tokens are re-issued wherever download URLs are built.

## Why

Fail-open token validation is the wrong default for a legal product: a leaked link is a permanent, unauthenticated-looking capability to the underlying document path. Expiring tokens bound that exposure, and rejecting exp-less tokens closes the legacy loophole instead of grandfathering it in.

## Testing

- `cd backend && npm install && npm run build` — tsc green as committed (no vitest required).
- With the test-harness PR merged locally (`git merge upstream-pr/test-harness`, clean, no conflicts): `cd backend && npm test` — 2 files, 15/15 passed (12 from the harness's `downloadTokens.test.ts` + 3 expiry tests from this PR).
- Local merge of this branch + the harness branch + the production-cors branch: clean, 24/24 backend tests pass.

## Provenance

All changes are mechanical ports of code in amal66/mike@origin/main (commit b3166dd); exceptions:
- The fork keeps its expiry tests inside `apps/api/src/lib/__tests__/downloadTokens.test.ts`; the harness PR already ships the non-expiry subset of that file at the same backend path, and git's add/add merge conflicts even on pure one-sided insertions (verified empirically), so the remaining suite lands as a sibling file `downloadTokens.expiry.test.ts`. Its contents are line-for-line from the fork's test file (only the unused `beforeAll`/`afterAll` imports trimmed).

## Credits & prior art
- **@bmersereau** ([upstream #77](https://github.com/Open-Legal-Products/mike/pull/77)) — adapted from #77, which first added an expiry (`exp` field, 30-day default TTL) to the HMAC-signed download tokens. The fork's original expiry commit records #77 as its precedent, and this PR carries the same payload shape and TTL. The one deliberate difference: #77 accepted legacy tokens without an expiry for backward compatibility; this PR rejects them (fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEguyEgXa9JjCciXCcVemC


