### PR TITLE
[Docs 02] docs: testing policy in CONTRIBUTING + PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- What does this PR do, in one or two sentences? -->
+
+## Why / Motivation
+
+<!-- What problem does this solve? Why now, and why this approach?
+     Link the issue or context that prompted it. -->
+
+## Changes
+
+<!-- The notable changes, at a high level. Describe the outcome, not the diff. -->
+
+## Tradeoffs & risks
+
+<!-- What did you weigh? What could break, what's out of scope, and what
+     follow-ups (if any) does this leave behind? Note any security or
+     migration implications. -->
+
+## How verified
+
+<!-- How do you know this works? Tests added/run, manual steps, commands,
+     screenshots. Include the exact commands where relevant. -->
+
+## Checklist
+
+- [ ] Ran the relevant build/test command for the area changed.
+- [ ] Reviewed `git diff` and removed unrelated changes.
+- [ ] Updated docs / env examples if setup, config, or behavior changed.
+- [ ] No secrets, API keys, real documents, or `.env` files committed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,3 +54,22 @@ Frontend:
 ```bash
 npm run build --prefix frontend
 ```
+
+## Testing
+
+```bash
+npm test --prefix backend            # backend unit + route integration tests (vitest)
+npm test --prefix frontend           # frontend component/hook tests (vitest + jsdom)
+npm run test:e2e                     # Playwright end-to-end suite — see docs/e2e-ci.md
+node evals/run.mjs --threshold 1.0   # offline eval harness (no network, no API keys)
+npm run test:stack --prefix backend  # gated: real-Supabase auth/access tests (run `supabase start` first)
+```
+
+- New features and bug fixes should come with a test at the lowest layer that
+  can catch the regression: unit first, then route-level integration, then
+  end-to-end only for flows a browser is genuinely needed to prove.
+- CI runs the build, unit/integration tests, and the eval harness on every PR
+  (`.github/workflows/ci.yml`), and the Playwright suite in a full local stack
+  (`.github/workflows/e2e.yml`).
+- Tests that need a live Supabase or an LLM key are env-gated and skip cleanly
+  when the environment is absent — a plain `npm test` should always be green.


### PR DESCRIPTION
## Summary

Contributor-facing testing policy: a Testing section in `CONTRIBUTING.md` and a PR template whose checklist asks how the change was verified. The capstone of the testing series — it documents the commands the sibling PRs introduce.

## Changes

- `CONTRIBUTING.md` — new Testing section: how to run each suite (`npm test` in `backend/`/`frontend/`, `npm run test:e2e`, `node evals/run.mjs`, the gated `test:stack` real-Supabase suite), the expectation that features/fixes carry a test at the lowest layer that can catch the regression, and the rule that env-gated tests must skip cleanly so plain `npm test` is always green.
- `.github/PULL_REQUEST_TEMPLATE.md` — summary / why / changes / tradeoffs / **how verified** structure with a short checklist, matching the PR-description format CONTRIBUTING already asks for.

## Why

The repo's testing story only sticks if contributors know it exists and are asked to participate in it. Today CONTRIBUTING says "run the relevant build or test command" but there is nothing to run; once the series lands, this makes the expectation concrete.

## Merge order

Best merged **last** in the series, after the suites it references exist: #228 (harness), #229 (backend unit), #230 (frontend unit), #231 (evals), #232 (CI), #220 (e2e), and #233 (route integration). Merging it earlier is harmless — the documented commands simply arrive as their PRs land.

## Testing

Docs-only; rendered and proofread. Commands verified against the sibling branches they document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
