### PR TITLE
[Lint 04] fix: burn down frontend eslint errors; make CI lint blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@
 # on a tree without those pieces the test steps no-op and the build still
 # gates the merge. Beyond the fork version this also builds the frontend
 # (placeholder NEXT_PUBLIC_* env — verified sufficient for `next build`) and
-# runs eslint as an advisory step (see the comment on that step).
+# runs eslint as a blocking gate (the error backlog is at zero).
 name: CI
 
 on:
@@ -61,11 +61,9 @@ jobs:
       # harness PR merges); runs the suite once it exists.
       - run: npm test --if-present
 
-      # Advisory only for now: main currently carries 23 eslint errors, so a
-      # blocking gate would turn every PR red on inherited debt. Flip this to
-      # blocking (remove continue-on-error) once the backlog is burned down.
+      # Blocking gate: the eslint error backlog was burned down in this PR
+      # (0 errors; warnings do not fail the step), so any new error fails CI.
       - run: npm run lint
-        continue-on-error: true
 
       # Production build. NEXT_PUBLIC_* values are inlined at build time and
       # only need to be well-formed here — nothing is contacted during build.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,102 @@
+# CI: build and test.
+#
+# Adapted from the amal66/mike fork's .github/workflows/ci.yml (monorepo
+# layout) to this repository's backend/ + frontend/ layout. Test steps use
+# `npm test --if-present`, and the eval job checks for evals/run.mjs, so this
+# workflow is safe to merge before or after the test-harness and evals PRs:
+# on a tree without those pieces the test steps no-op and the build still
+# gates the merge. Beyond the fork version this also builds the frontend
+# (placeholder NEXT_PUBLIC_* env — verified sufficient for `next build`) and
+# runs eslint as an advisory step (see the comment on that step).
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    name: Backend build and tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - run: npm ci
+
+      # No-ops on a tree without a "test" script (e.g. before the vitest
+      # harness PR merges); runs the suite once it exists.
+      - run: npm test --if-present
+
+      - run: npm run build
+
+  frontend:
+    name: Frontend build and tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+
+      # No-ops on a tree without a "test" script (e.g. before the vitest
+      # harness PR merges); runs the suite once it exists.
+      - run: npm test --if-present
+
+      # Advisory only for now: main currently carries 23 eslint errors, so a
+      # blocking gate would turn every PR red on inherited debt. Flip this to
+      # blocking (remove continue-on-error) once the backlog is burned down.
+      - run: npm run lint
+        continue-on-error: true
+
+      # Production build. NEXT_PUBLIC_* values are inlined at build time and
+      # only need to be well-formed here — nothing is contacted during build.
+      # This catches type errors (next build runs tsc) and broken routes/imports.
+      - run: npm run build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY: sb_publishable_placeholder
+          NEXT_PUBLIC_API_BASE_URL: http://localhost:3001
+
+  # -----------------------------------------------------------------------
+  # Offline eval harness: deterministic scorecard for citation accuracy,
+  # prompt-injection resistance, and privilege/PII leakage. Runs against
+  # committed fixtures (no network, no LLM calls, no secrets), so it is cheap
+  # enough to gate every PR. --threshold 1.0 = every case must pass.
+  # Skips gracefully until the evals PR merges.
+  # -----------------------------------------------------------------------
+  evals:
+    name: Eval harness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run eval harness (skips if evals/ not present)
+        run: |
+          if [ -f evals/run.mjs ]; then
+            node evals/run.mjs --threshold 1.0
+          else
+            echo "evals/run.mjs not present on this tree; skipping"
+          fi

--- a/frontend/src/app/components/assistant/AskInputPopup.tsx
+++ b/frontend/src/app/components/assistant/AskInputPopup.tsx
@@ -242,6 +242,7 @@ export function AskInputPopup({
     };
 
     useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- auto-submit when every question is answered; submit() sets state as part of the side effect
         if (canSubmit) submit();
     });
 

--- a/frontend/src/app/components/assistant/CaseLawPanel.tsx
+++ b/frontend/src/app/components/assistant/CaseLawPanel.tsx
@@ -216,6 +216,7 @@ export function CaseLawPanel({
 
     useEffect(() => {
         if (tab.opinions?.length) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- sync path of an async fetch effect: serve prop/cache data without a loading flash
             setOpinions(tab.opinions);
             setLoading(false);
             setError(null);
@@ -269,10 +270,12 @@ export function CaseLawPanel({
             orderOpinions(opinions).find(
                 ({ opinion }) => typeof opinion.opinionId === "number",
             )?.opinion.opinionId ?? null;
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- reset active opinion after opinions load
         setActiveOpinionId(firstOpinionId);
     }, [opinions]);
 
     useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- sync quote list when the tab prop changes
         setRelevantQuotes(tab.quotes ?? []);
     }, [tab.quotes]);
 
@@ -321,6 +324,7 @@ export function CaseLawPanel({
     );
 
     useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- reset quote selection when the quote set changes
         setQuoteIndexState({ cacheKey: quoteCacheKey, index: 0 });
         const firstQuote = relevantQuotes[0];
         setActiveQuoteKey(firstQuote ? relevantQuoteKey(firstQuote, 0) : null);

--- a/frontend/src/app/components/assistant/ChatView.tsx
+++ b/frontend/src/app/components/assistant/ChatView.tsx
@@ -83,6 +83,7 @@ export function ChatView({
     const panelCloseTimerRef = useRef<number | null>(null);
 
     useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- reset per-chat UI state when switching chats
         setHiddenAskInputKeys(new Set());
     }, [chatId]);
 
@@ -519,6 +520,7 @@ export function ChatView({
         const c = messagesContainerRef.current;
         if (!c) return;
         c.addEventListener("scroll", updateScrollButton);
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- initial scroll-button state must be measured from the live DOM
         updateScrollButton();
         return () => c.removeEventListener("scroll", updateScrollButton);
     }, [messages, updateScrollButton]);
@@ -553,6 +555,7 @@ export function ChatView({
     useEffect(() => {
         if (messages.length === 0) {
             hasScrolledRef.current = false;
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- hide messages until scroll position is restored to avoid a visible jump
             setMessagesVisible(false);
         } else if (!hasScrolledRef.current) {
             const userMsgCount = messages.filter(
@@ -682,8 +685,8 @@ export function ChatView({
                                         {msg.role === "user" ? (
                                             <UserMessage
                                                 content={msg.content ?? ""}
-                                                files={(msg as any).files}
-                                                workflow={(msg as any).workflow}
+                                                files={msg.files}
+                                                workflow={msg.workflow}
                                             />
                                         ) : (
                                             <AssistantMessage
@@ -692,11 +695,11 @@ export function ChatView({
                                                     i === messages.length - 1 &&
                                                     isResponseLoading
                                                 }
-                                                isError={!!(msg as any).error}
+                                                isError={!!msg.error}
                                                 errorMessage={
-                                                    typeof (msg as any)
-                                                        .error === "string"
-                                                        ? (msg as any).error
+                                                    typeof msg.error ===
+                                                    "string"
+                                                        ? msg.error
                                                         : undefined
                                                 }
                                                 citations={msg.citations}

--- a/frontend/src/app/components/assistant/CitationQuotesHeader.tsx
+++ b/frontend/src/app/components/assistant/CitationQuotesHeader.tsx
@@ -47,6 +47,7 @@ export function CitationQuotesHeader({
 
     useEffect(() => {
         if (!hasMultipleQuotes && viewMode === "list") {
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- collapse list view when quotes drop to a single item
             setViewMode("single");
         }
     }, [hasMultipleQuotes, viewMode]);

--- a/frontend/src/app/components/assistant/PreResponseWrapper.tsx
+++ b/frontend/src/app/components/assistant/PreResponseWrapper.tsx
@@ -29,6 +29,7 @@ export function PreResponseWrapper({
 
     useEffect(() => {
         if (forceOpen) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- streaming open/minimize latch (see comment above)
             setIsOpen(true);
             return;
         }

--- a/frontend/src/app/components/modals/Modal.tsx
+++ b/frontend/src/app/components/modals/Modal.tsx
@@ -61,6 +61,7 @@ export function Modal({
     // Portals can't render during SSR, so a keep-mounted modal only renders
     // (hidden) after the first client mount.
     const [hasMounted, setHasMounted] = useState(false);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- SSR portal gate: must flip after first client mount
     useEffect(() => setHasMounted(true), []);
     const hasHeader = breadcrumbs?.length;
     const hasFooter =

--- a/frontend/src/app/components/shared/MfaLoginGate.tsx
+++ b/frontend/src/app/components/shared/MfaLoginGate.tsx
@@ -21,6 +21,7 @@ export function MfaLoginGate({ children }: { children: ReactNode }) {
 
     useEffect(() => {
         if (!user) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- sync fast paths of the async MFA check effect
             setGateState("idle");
             return;
         }
@@ -64,6 +65,7 @@ export function MfaLoginGate({ children }: { children: ReactNode }) {
 
         if (gateState === "required" && !isVerifyPage) {
             if (hasRecentMfaVerification()) {
+                // eslint-disable-next-line react-hooks/set-state-in-effect -- clear gate when a recent MFA verification exists instead of redirecting
                 setGateState("verified");
                 return;
             }

--- a/frontend/src/app/components/tabular/TRChatPanel.tsx
+++ b/frontend/src/app/components/tabular/TRChatPanel.tsx
@@ -164,6 +164,7 @@ function TRResponseStatus({ isActive }: { isActive: boolean }) {
 
     useEffect(() => {
         if (wasActiveRef.current && !isActive) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- timed 'Done' flash on the active->idle transition
             setShowDone(true);
             setDoneVisible(true);
             const t = setTimeout(() => setDoneVisible(false), 1500);

--- a/frontend/src/app/contexts/ChatHistoryContext.tsx
+++ b/frontend/src/app/contexts/ChatHistoryContext.tsx
@@ -73,6 +73,7 @@ export function ChatHistoryProvider({ children }: { children: ReactNode }) {
 
     useEffect(() => {
         if (!user) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- clear chat state on logout inside the effect that loads chats
             setChats([]);
             setChatLimit(INITIAL_CHAT_LIMIT);
             setHasMoreChats(false);

--- a/frontend/src/app/hooks/useFetchDocxBytes.ts
+++ b/frontend/src/app/hooks/useFetchDocxBytes.ts
@@ -49,6 +49,7 @@ export function useFetchDocxBytes(
 
     useEffect(() => {
         if (!documentId) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- clear stale bytes when documentId is removed, within the fetch effect
             setBytes(null);
             setDownloadUrl(null);
             return;

--- a/frontend/src/app/hooks/useSelectedModel.ts
+++ b/frontend/src/app/hooks/useSelectedModel.ts
@@ -16,6 +16,7 @@ export function useSelectedModel(): [string, (id: string) => void] {
     const [model, setModelState] = useState<string>(DEFAULT_MODEL_ID);
 
     useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration-safe localStorage read; SSR must render the default model
         setModelState(readStored());
     }, []);
 

--- a/frontend/src/app/support/page.tsx
+++ b/frontend/src/app/support/page.tsx
@@ -228,7 +228,7 @@ export default function SupportPage() {
                             {/* Email Display (if logged in) */}
                             {user?.email && (
                                 <div className="text-sm text-gray-500">
-                                    We'll respond to:{" "}
+                                    We&apos;ll respond to:{" "}
                                     <span className="font-medium">
                                         {user.email}
                                     </span>


### PR DESCRIPTION
## Summary

Follow-up to #232: burns the frontend eslint error backlog down from **23 errors / 40 warnings** to **0 errors / 40 warnings**, then flips the CI lint step from advisory (`continue-on-error: true`) to a blocking gate. All edits are minimal and behavior-preserving — no rule is disabled repo-wide.

> **Stacking note:** this branch stacks on #232 and includes its `ci.yml` commit — please review the top commit only (`fix: burn down frontend eslint errors; make CI lint blocking`). Will be Graphite-stacked properly once write access allows.

## Changes

| Rule | Count | How it was resolved |
| --- | --- | --- |
| `@typescript-eslint/no-explicit-any` | 5 | Fixed. `ChatView.tsx` used `(msg as any).files` / `.workflow` / `.error`, but the `Message` interface (`shared/types.ts`) already declares all three fields with exactly the shapes the `UserMessage` / `AssistantMessage` props expect. Casts removed; plain property access type-checks cleanly (verified by `next build`, which runs tsc). |
| `react/no-unescaped-entities` | 1 | Fixed. `support/page.tsx`: `We'll` → `We&apos;ll`. |
| `react-hooks/set-state-in-effect` | 17 | Targeted `// eslint-disable-next-line` with a one-line reason at each site (details below). Every occurrence is an intentional effect-driven state pattern; any "real" fix (derive-during-render, key-based remount, `useSyncExternalStore`) would change runtime behavior, so per-site disables were the safe call. |

### The 17 `set-state-in-effect` disables and their reasons

| Site | Reason |
| --- | --- |
| `modals/Modal.tsx:64` | SSR portal gate — `hasMounted` must flip after first client mount |
| `hooks/useSelectedModel.ts:19` | Hydration-safe localStorage read; SSR must render the default model |
| `hooks/useFetchDocxBytes.ts:52` | Clear stale bytes when `documentId` is removed, inside the fetch effect |
| `contexts/ChatHistoryContext.tsx:76` | Clear chat state on logout inside the effect that loads chats |
| `assistant/CaseLawPanel.tsx:219` | Sync path of an async fetch effect: serve prop/cache data without a loading flash |
| `assistant/CaseLawPanel.tsx:272` | Reset active opinion after opinions load |
| `assistant/CaseLawPanel.tsx:276` | Sync quote list when the tab prop changes |
| `assistant/CaseLawPanel.tsx:324` | Reset quote selection when the quote set changes |
| `assistant/ChatView.tsx:86` | Reset per-chat UI state when switching chats |
| `assistant/ChatView.tsx:522` | Initial scroll-button state must be measured from the live DOM |
| `assistant/ChatView.tsx:556` | Hide messages until scroll position is restored to avoid a visible jump |
| `assistant/CitationQuotesHeader.tsx:50` | Collapse list view when quotes drop to a single item |
| `assistant/PreResponseWrapper.tsx:32` | Streaming open/minimize latch (existing comment documents why) |
| `assistant/AskInputPopup.tsx:245` | Auto-submit when every question is answered; `submit()` sets state as part of the side effect |
| `shared/MfaLoginGate.tsx:24` | Sync fast paths of the async MFA check effect |
| `shared/MfaLoginGate.tsx:67` | Clear gate when a recent MFA verification exists instead of redirecting |
| `tabular/TRChatPanel.tsx:167` | Timed "Done" flash on the active→idle transition |

### CI

`.github/workflows/ci.yml`: removed `continue-on-error: true` from the frontend lint step and rewrote the step comment (and the header note) — lint is now a blocking gate since the error backlog is at zero. Warnings do not fail the step.

## Why

#232 landed the lint step as advisory-only because main carried 23 inherited eslint errors and a blocking gate would have turned every PR red on debt it didn't create. With the backlog at zero, the gate can hold the line: any new eslint error fails CI at the PR, instead of accreting silently.

## Testing

- `cd frontend && npm run lint` — exits 0: **0 errors, 40 warnings** (was 23 errors / 40 warnings; warnings are pre-existing, mostly `no-unused-vars` on `node` ref params and `no-explicit-any` warnings in test-adjacent code).
- `npm test` — no `test` script exists on this branch (predates the vitest harness PR); CI's `npm test --if-present` no-ops, as designed in #232.
- `NEXT_PUBLIC_SUPABASE_URL=https://placeholder.supabase.co NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=sb_publishable_placeholder NEXT_PUBLIC_API_BASE_URL=http://localhost:3001 npm run build` — passes (compiles + type-checks all routes), confirming the `ChatView.tsx` cast removals are type-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
