### PR TITLE
[Testing 09] test: unit-cover the highest-risk backend libs + raise the coverage ratchet

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -37,6 +37,7 @@
         "@types/express": "^4.17.21",
         "@types/multer": "^1.4.12",
         "@types/node": "^22.14.1",
+        "@vitest/coverage-v8": "^4.1.9",
         "prettier": "^3.8.1",
         "tsx": "^4.19.3",
         "typescript": "^5.8.3",
@@ -968,6 +969,42 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -975,6 +1012,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1488,12 +1549,33 @@
         "hono": "^4"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -3502,6 +3584,37 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -3714,6 +3827,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/async": {
@@ -4671,6 +4796,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -4722,6 +4857,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-to-text": {
       "version": "9.0.5",
@@ -4883,6 +5025,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
@@ -4891,6 +5072,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
@@ -5276,6 +5464,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mammoth": {
@@ -6062,6 +6278,19 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
@@ -6292,6 +6521,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "mike-backend",
       "version": "1.0.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
         "@aws-sdk/client-s3": "^3.787.0",
@@ -38,7 +39,8 @@
         "@types/node": "^22.14.1",
         "prettier": "^3.8.1",
         "tsx": "^4.19.3",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -975,6 +977,40 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
@@ -1451,6 +1487,13 @@
       "peerDependencies": {
         "hono": "^4"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -2059,6 +2102,25 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -2070,6 +2132,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -2152,6 +2224,270 @@
         "react": "^18.0 || ^19.0 || ^19.0.0-rc",
         "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
@@ -2885,6 +3221,13 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.102.1",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.102.1.tgz",
@@ -2971,6 +3314,17 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -2980,6 +3334,17 @@
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/connect": {
@@ -3001,6 +3366,20 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.25",
@@ -3123,6 +3502,119 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.12",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
@@ -3213,6 +3705,16 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -3346,6 +3848,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -3381,6 +3893,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -3478,6 +3997,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dingbat-to-unicode": {
@@ -3662,6 +4191,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3722,6 +4258,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -3750,6 +4296,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -3884,6 +4440,24 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/fetch-blob": {
@@ -4416,6 +4990,267 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -4431,6 +5266,16 @@
         "duck": "^0.1.12",
         "option": "~0.2.1",
         "underscore": "^1.13.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/mammoth": {
@@ -4664,6 +5509,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -4771,6 +5630,13 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pdfjs-dist": {
       "version": "4.10.38",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
@@ -4792,6 +5658,26 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -4799,6 +5685,54 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prettier": {
@@ -4989,6 +5923,40 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/router": {
@@ -5244,11 +6212,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -5258,6 +6250,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -5293,6 +6292,50 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tmp": {
       "version": "0.2.5",
@@ -5422,6 +6465,174 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -5444,6 +6655,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
@@ -37,6 +38,7 @@
     "@types/express": "^4.17.21",
     "@types/multer": "^1.4.12",
     "@types/node": "^22.14.1",
+    "@vitest/coverage-v8": "^4.1.9",
     "prettier": "^3.8.1",
     "tsx": "^4.19.3",
     "typescript": "^5.8.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
@@ -38,7 +39,8 @@
     "@types/node": "^22.14.1",
     "prettier": "^3.8.1",
     "tsx": "^4.19.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.9"
   },
   "license": "AGPL-3.0-only"
 }

--- a/backend/src/lib/__tests__/access.test.ts
+++ b/backend/src/lib/__tests__/access.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+    checkProjectAccess,
+    ensureDocAccess,
+    ensureReviewAccess,
+    filterAccessibleDocumentIds,
+    listAccessibleProjectIds,
+} from "../access";
+
+type Row = Record<string, unknown>;
+
+function makeDb(tables: Record<string, Row[]>) {
+    return {
+        from(table: string) {
+            let rows = [...(tables[table] ?? [])];
+            const query = {
+                select: () => query,
+                eq: (column: string, value: unknown) => {
+                    rows = rows.filter((row) => row[column] === value);
+                    return query;
+                },
+                neq: (column: string, value: unknown) => {
+                    rows = rows.filter((row) => row[column] !== value);
+                    return query;
+                },
+                in: (column: string, values: unknown[]) => {
+                    rows = rows.filter((row) => values.includes(row[column]));
+                    return query;
+                },
+                filter: (column: string, operator: string, value: string) => {
+                    if (operator !== "cs") return query;
+                    const expected = (JSON.parse(value) as string[]).map((item) =>
+                        item.toLowerCase(),
+                    );
+                    rows = rows.filter((row) => {
+                        const actual = row[column];
+                        const normalizedActual = Array.isArray(actual)
+                            ? actual.map((item) => String(item).toLowerCase())
+                            : [];
+                        return (
+                            Array.isArray(actual) &&
+                            expected.every((item) => normalizedActual.includes(item))
+                        );
+                    });
+                    return query;
+                },
+                single: async () => ({ data: rows[0] ?? null, error: null }),
+                then: (
+                    resolve: (value: { data: Row[]; error: null }) => unknown,
+                    reject?: (reason: unknown) => unknown,
+                ) => Promise.resolve({ data: rows, error: null }).then(resolve, reject),
+            };
+            return query;
+        },
+    } as any;
+}
+
+describe("access helpers", () => {
+    const db = makeDb({
+        projects: [
+            { id: "own-project", user_id: "owner", shared_with: [] },
+            {
+                id: "shared-project",
+                user_id: "other-owner",
+                shared_with: ["Reviewer@Example.com"],
+            },
+            { id: "private-project", user_id: "other-owner", shared_with: [] },
+        ],
+        documents: [
+            { id: "own-doc", user_id: "owner", project_id: null },
+            {
+                id: "shared-doc",
+                user_id: "other-owner",
+                project_id: "shared-project",
+            },
+            {
+                id: "private-doc",
+                user_id: "other-owner",
+                project_id: "private-project",
+            },
+        ],
+    });
+
+    it("allows project owners", async () => {
+        await expect(
+            checkProjectAccess("own-project", "owner", "owner@example.com", db),
+        ).resolves.toMatchObject({ ok: true, isOwner: true });
+    });
+
+    it("allows shared project access case-insensitively", async () => {
+        await expect(
+            checkProjectAccess(
+                "shared-project",
+                "reviewer",
+                "reviewer@example.com",
+                db,
+            ),
+        ).resolves.toMatchObject({ ok: true, isOwner: false });
+    });
+
+    it("denies private project access", async () => {
+        await expect(
+            checkProjectAccess(
+                "private-project",
+                "reviewer",
+                "reviewer@example.com",
+                db,
+            ),
+        ).resolves.toEqual({ ok: false });
+    });
+
+    it("allows document owners and shared-project readers", async () => {
+        await expect(
+            ensureDocAccess(
+                { user_id: "owner", project_id: null },
+                "owner",
+                "owner@example.com",
+                db,
+            ),
+        ).resolves.toMatchObject({ ok: true, isOwner: true });
+
+        await expect(
+            ensureDocAccess(
+                { user_id: "other-owner", project_id: "shared-project" },
+                "reviewer",
+                "reviewer@example.com",
+                db,
+            ),
+        ).resolves.toMatchObject({ ok: true, isOwner: false });
+    });
+
+    it("filters user-supplied document IDs to accessible documents only", async () => {
+        await expect(
+            filterAccessibleDocumentIds(
+                ["own-doc", "shared-doc", "private-doc", "missing-doc"],
+                "reviewer",
+                "reviewer@example.com",
+                db,
+            ),
+        ).resolves.toEqual(["shared-doc"]);
+    });
+
+    it("lists own and directly shared projects", async () => {
+        await expect(
+            listAccessibleProjectIds("owner", "reviewer@example.com", db),
+        ).resolves.toEqual(expect.arrayContaining(["own-project", "shared-project"]));
+    });
+
+    it("allows direct review sharing without project access", async () => {
+        await expect(
+            ensureReviewAccess(
+                {
+                    user_id: "other-owner",
+                    project_id: null,
+                    shared_with: ["Reviewer@Example.com"],
+                },
+                "reviewer",
+                "reviewer@example.com",
+                db,
+            ),
+        ).resolves.toMatchObject({ ok: true, isOwner: false });
+    });
+});

--- a/backend/src/lib/__tests__/chatTypes.test.ts
+++ b/backend/src/lib/__tests__/chatTypes.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import {
+    resolveDoc,
+    resolveDocLabel,
+    type DocIndex,
+    type DocStore,
+} from "../chat/types";
+
+// ---------------------------------------------------------------------------
+// resolveDoc
+// ---------------------------------------------------------------------------
+
+describe("resolveDoc", () => {
+    const index: DocIndex = {
+        "doc-1": { document_id: "uuid-aaa", filename: "contract.pdf" },
+        "doc-2": { document_id: "uuid-bbb", filename: "nda.pdf" },
+    };
+
+    it("returns the doc entry for a known label", () => {
+        expect(resolveDoc("doc-1", index)).toEqual({
+            document_id: "uuid-aaa",
+            filename: "contract.pdf",
+        });
+    });
+
+    it("returns undefined for an unknown label", () => {
+        expect(resolveDoc("doc-99", index)).toBeUndefined();
+    });
+
+    it("returns undefined for an empty string", () => {
+        expect(resolveDoc("", index)).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// resolveDocLabel
+// ---------------------------------------------------------------------------
+
+describe("resolveDocLabel", () => {
+    const store: DocStore = new Map([
+        ["doc-1", { storage_path: "path/a", file_type: "pdf", filename: "contract.pdf" }],
+        ["doc-2", { storage_path: "path/b", file_type: "pdf", filename: "nda.pdf" }],
+    ]);
+
+    const index: DocIndex = {
+        "doc-1": { document_id: "uuid-aaa", filename: "contract.pdf" },
+        "doc-2": { document_id: "uuid-bbb", filename: "nda.pdf" },
+    };
+
+    it("resolves by label when the label is in the store", () => {
+        expect(resolveDocLabel("doc-1", store, index)).toBe("doc-1");
+    });
+
+    it("resolves by filename when the filename matches a store entry", () => {
+        expect(resolveDocLabel("contract.pdf", store, index)).toBe("doc-1");
+    });
+
+    it("resolves by document UUID via the docIndex", () => {
+        expect(resolveDocLabel("uuid-bbb", store, index)).toBe("doc-2");
+    });
+
+    it("returns null when nothing matches", () => {
+        expect(resolveDocLabel("unknown-id", store, index)).toBeNull();
+    });
+
+    it("returns null when docIndex is omitted and only UUID matches", () => {
+        // Without the index there is no fallback for raw UUIDs.
+        expect(resolveDocLabel("uuid-aaa", store)).toBeNull();
+    });
+
+    it("prioritises exact label match over filename match", () => {
+        // If a label happens to equal a filename of a different doc,
+        // the label match wins.
+        const storeWithCrossMatch: DocStore = new Map([
+            ["nda.pdf", { storage_path: "path/c", file_type: "pdf", filename: "contract.pdf" }],
+        ]);
+        // "nda.pdf" is a label here, and it IS in the store, so it should
+        // be returned directly without the filename-fallback loop.
+        expect(resolveDocLabel("nda.pdf", storeWithCrossMatch)).toBe("nda.pdf");
+    });
+});

--- a/backend/src/lib/__tests__/citations.test.ts
+++ b/backend/src/lib/__tests__/citations.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect } from "vitest";
+import {
+    parseCitations,
+    parseCitationsWithDiagnostics,
+    parsePartialCitationObjects,
+    createCitation,
+    CITATIONS_OPEN_TAG,
+    CITATIONS_CLOSE_TAG,
+} from "../chat/citations";
+import type { DocIndex } from "../chat/types";
+
+function citationsBlock(json: string) {
+    return `Answer text.\n${CITATIONS_OPEN_TAG}\n${json}\n${CITATIONS_CLOSE_TAG}`;
+}
+
+// ---------------------------------------------------------------------------
+// parseCitationsWithDiagnostics
+// ---------------------------------------------------------------------------
+
+describe("parseCitationsWithDiagnostics", () => {
+    it("reports no block when the tags are absent", () => {
+        const { citations, diagnostics } =
+            parseCitationsWithDiagnostics("plain answer");
+        expect(citations).toEqual([]);
+        expect(diagnostics).toEqual({ hasBlock: false, rawLength: 0, error: null });
+    });
+
+    it("reports a JSON parse error for malformed block content", () => {
+        const { citations, diagnostics } = parseCitationsWithDiagnostics(
+            citationsBlock("[{not json"),
+        );
+        expect(citations).toEqual([]);
+        expect(diagnostics.hasBlock).toBe(true);
+        expect(diagnostics.rawLength).toBeGreaterThan(0);
+        expect(diagnostics.error).toBeTruthy();
+    });
+
+    it("reports an error when the block JSON is not an array", () => {
+        const { citations, diagnostics } = parseCitationsWithDiagnostics(
+            citationsBlock('{"ref": 1}'),
+        );
+        expect(citations).toEqual([]);
+        expect(diagnostics.error).toBe("CITATIONS block JSON was not an array.");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// parseCitations — document citations
+// ---------------------------------------------------------------------------
+
+describe("parseCitations (document citations)", () => {
+    it("parses a minimal document citation", () => {
+        const [citation] = parseCitations(
+            citationsBlock(
+                '[{"ref": 1, "doc_id": "doc-1", "page": 3, "quote": "the term"}]',
+            ),
+        );
+        expect(citation).toMatchObject({
+            kind: "document",
+            ref: 1,
+            doc_id: "doc-1",
+            page: 3,
+            quote: "the term",
+        });
+        expect(citation.quotes).toHaveLength(1);
+    });
+
+    it("derives ref from a [N] marker when ref is missing", () => {
+        const [citation] = parseCitations(
+            citationsBlock(
+                '[{"marker": "[7]", "doc_id": "doc-1", "page": 1, "quote": "q"}]',
+            ),
+        );
+        expect(citation.ref).toBe(7);
+    });
+
+    it("drops entries without a usable ref or marker", () => {
+        expect(
+            parseCitations(
+                citationsBlock('[{"doc_id": "doc-1", "quote": "q", "marker": "nope"}]'),
+            ),
+        ).toEqual([]);
+    });
+
+    it("drops document entries without doc_id or quote", () => {
+        expect(
+            parseCitations(citationsBlock('[{"ref": 1, "doc_id": "doc-1"}]')),
+        ).toEqual([]);
+        expect(
+            parseCitations(citationsBlock('[{"ref": 1, "quote": "q"}]')),
+        ).toEqual([]);
+    });
+
+    it("drops non-object entries but keeps valid ones", () => {
+        const citations = parseCitations(
+            citationsBlock(
+                '[null, "junk", {"ref": 2, "doc_id": "doc-2", "page": 4, "quote": "kept"}]',
+            ),
+        );
+        expect(citations).toHaveLength(1);
+        expect(citations[0]).toMatchObject({ ref: 2, doc_id: "doc-2" });
+    });
+
+    it("accepts a text field as a quote alias", () => {
+        const [citation] = parseCitations(
+            citationsBlock('[{"ref": 1, "doc_id": "doc-1", "page": 2, "text": "aliased"}]'),
+        );
+        expect(citation.kind).toBe("document");
+        expect((citation as { quote: string }).quote).toBe("aliased");
+    });
+
+    it("normalizes pages: numbers kept, ranges kept, junk becomes 1", () => {
+        const citations = parseCitations(
+            citationsBlock(
+                '[{"ref": 1, "doc_id": "d", "page": 5, "quote": "a"},' +
+                    '{"ref": 2, "doc_id": "d", "page": "3-5", "quote": "b"},' +
+                    '{"ref": 3, "doc_id": "d", "page": "12", "quote": "c"},' +
+                    '{"ref": 4, "doc_id": "d", "page": "unknown", "quote": "d"}]',
+            ),
+        );
+        expect(citations.map((c) => (c as { page: number | string }).page)).toEqual([
+            5,
+            "3-5",
+            12,
+            1,
+        ]);
+    });
+
+    it("keeps at most 3 quotes and inherits top-level page/sheet/cell", () => {
+        const [citation] = parseCitations(
+            citationsBlock(
+                JSON.stringify([
+                    {
+                        ref: 1,
+                        doc_id: "doc-1",
+                        page: 9,
+                        sheet: "Summary",
+                        cell: "B7",
+                        quotes: [
+                            { quote: "one" },
+                            { quote: "two", page: 2 },
+                            { quote: "three", sheet: "Detail", cell: "C1" },
+                            { quote: "four" },
+                        ],
+                    },
+                ]),
+            ),
+        );
+        expect(citation.kind).toBe("document");
+        const doc = citation as {
+            page: number | string;
+            quotes: { page: number | string; quote: string; sheet?: string; cell?: string }[];
+        };
+        expect(doc.quotes).toHaveLength(3);
+        expect(doc.quotes[0]).toEqual({
+            page: 9,
+            quote: "one",
+            sheet: "Summary",
+            cell: "B7",
+        });
+        expect(doc.quotes[1].page).toBe(2);
+        expect(doc.quotes[2]).toMatchObject({ sheet: "Detail", cell: "C1" });
+        // Top-level fields mirror the first quote.
+        expect(doc.page).toBe(9);
+    });
+
+    it("skips quote rows without text", () => {
+        const [citation] = parseCitations(
+            citationsBlock(
+                '[{"ref": 1, "doc_id": "doc-1", "page": 1,' +
+                    ' "quotes": [{"page": 2}, {"quote": "  "}, {"quote": "real"}]}]',
+            ),
+        );
+        expect((citation as { quotes: unknown[] }).quotes).toHaveLength(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// parseCitations — case citations
+// ---------------------------------------------------------------------------
+
+describe("parseCitations (case citations)", () => {
+    it("parses a case citation from a numeric cluster_id", () => {
+        const [citation] = parseCitations(
+            citationsBlock('[{"ref": 1, "cluster_id": 12345, "quote": "held that"}]'),
+        );
+        expect(citation).toMatchObject({ kind: "case", ref: 1, cluster_id: 12345 });
+        expect((citation as { quotes: unknown[] }).quotes).toEqual([
+            { opinionId: null, type: null, author: null, quote: "held that" },
+        ]);
+    });
+
+    it("accepts clusterId camelCase and string cluster ids", () => {
+        const citations = parseCitations(
+            citationsBlock(
+                '[{"ref": 1, "clusterId": 7, "quote": "a"},' +
+                    '{"ref": 2, "cluster_id": "42", "quote": "b"}]',
+            ),
+        );
+        expect(citations.map((c) => (c as { cluster_id: number }).cluster_id)).toEqual([
+            7, 42,
+        ]);
+    });
+
+    it("floors fractional cluster ids", () => {
+        const [citation] = parseCitations(
+            citationsBlock('[{"ref": 1, "cluster_id": 12.9, "quote": "q"}]'),
+        );
+        expect((citation as { cluster_id: number }).cluster_id).toBe(12);
+    });
+
+    it("treats non-positive cluster ids as document citations", () => {
+        // cluster_id 0 fails the > 0 check, so the entry needs a doc_id.
+        expect(
+            parseCitations(citationsBlock('[{"ref": 1, "cluster_id": 0, "quote": "q"}]')),
+        ).toEqual([]);
+    });
+
+    it("normalizes structured case quotes with opinion metadata", () => {
+        const [citation] = parseCitations(
+            citationsBlock(
+                JSON.stringify([
+                    {
+                        ref: 3,
+                        cluster_id: 99,
+                        quotes: [
+                            {
+                                quote: "majority text",
+                                opinion_id: 11.7,
+                                type: "majority",
+                                author: "Judge A",
+                            },
+                            { text: "concurrence text", opinionId: 12 },
+                            { type: "no quote text, dropped" },
+                        ],
+                    },
+                ]),
+            ),
+        );
+        expect((citation as { quotes: unknown[] }).quotes).toEqual([
+            {
+                opinionId: 11,
+                type: "majority",
+                author: "Judge A",
+                quote: "majority text",
+            },
+            { opinionId: 12, type: null, author: null, quote: "concurrence text" },
+        ]);
+    });
+
+    it("drops case citations with no quotes at all", () => {
+        expect(
+            parseCitations(citationsBlock('[{"ref": 1, "cluster_id": 5}]')),
+        ).toEqual([]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// parsePartialCitationObjects
+// ---------------------------------------------------------------------------
+
+describe("parsePartialCitationObjects", () => {
+    it("returns [] when no array has started", () => {
+        expect(parsePartialCitationObjects("streaming <CITATIONS>")).toEqual([]);
+    });
+
+    it("extracts complete objects and ignores a trailing incomplete one", () => {
+        const partial =
+            '<CITATIONS>[{"ref": 1, "doc_id": "doc-1", "page": 2, "quote": "done"},' +
+            ' {"ref": 2, "doc_id": "doc-2", "page": 3, "quote": "still stream';
+        const citations = parsePartialCitationObjects(partial);
+        expect(citations).toHaveLength(1);
+        expect(citations[0]).toMatchObject({ ref: 1, doc_id: "doc-1" });
+    });
+
+    it("handles braces and escaped quotes inside string values", () => {
+        const partial =
+            '<CITATIONS>[{"ref": 1, "doc_id": "doc-1", "page": 1,' +
+            ' "quote": "clause {a} says \\"stop\\""}';
+        const citations = parsePartialCitationObjects(partial);
+        expect(citations).toHaveLength(1);
+        expect((citations[0] as { quote: string }).quote).toBe(
+            'clause {a} says "stop"',
+        );
+    });
+
+    it("ignores content after the closing tag", () => {
+        const text =
+            '<CITATIONS>[{"ref": 1, "doc_id": "a", "page": 1, "quote": "q"}]</CITATIONS>' +
+            '[{"ref": 9, "doc_id": "b", "page": 1, "quote": "after"}]';
+        const citations = parsePartialCitationObjects(text);
+        expect(citations).toHaveLength(1);
+        expect(citations[0]).toMatchObject({ ref: 1 });
+    });
+
+    it("stops at the array close bracket", () => {
+        const text =
+            '[{"ref": 1, "doc_id": "a", "page": 1, "quote": "q"}] {"ref": 2, "doc_id": "b", "page": 1, "quote": "outside"}';
+        const citations = parsePartialCitationObjects(text);
+        expect(citations).toHaveLength(1);
+    });
+
+    it("skips malformed objects but keeps later valid ones", () => {
+        const text =
+            '[{"ref": bad}, {"ref": 2, "doc_id": "doc-2", "page": 1, "quote": "ok"}';
+        const citations = parsePartialCitationObjects(text);
+        expect(citations).toHaveLength(1);
+        expect(citations[0]).toMatchObject({ ref: 2 });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// createCitation
+// ---------------------------------------------------------------------------
+
+describe("createCitation", () => {
+    const docIndex: DocIndex = {
+        "doc-1": {
+            document_id: "uuid-aaa",
+            filename: "contract.pdf",
+            version_id: "ver-1",
+            version_number: 2,
+        },
+    };
+
+    it("builds a document citation payload from the doc index", () => {
+        const [parsed] = parseCitations(
+            citationsBlock('[{"ref": 1, "doc_id": "doc-1", "page": 4, "quote": "q"}]'),
+        );
+        expect(createCitation(parsed, docIndex)).toMatchObject({
+            type: "citation_data",
+            kind: "document",
+            ref: 1,
+            doc_id: "doc-1",
+            document_id: "uuid-aaa",
+            version_id: "ver-1",
+            version_number: 2,
+            filename: "contract.pdf",
+            page: 4,
+            quote: "q",
+        });
+    });
+
+    it("falls back to the raw doc_id as filename when unresolvable", () => {
+        const [parsed] = parseCitations(
+            citationsBlock('[{"ref": 1, "doc_id": "doc-9", "page": 1, "quote": "q"}]'),
+        );
+        const citation = createCitation(parsed, docIndex);
+        expect(citation).toMatchObject({
+            filename: "doc-9",
+            document_id: undefined,
+            version_id: null,
+        });
+    });
+
+    it("enriches a case citation from the cluster map", () => {
+        const [parsed] = parseCitations(
+            citationsBlock('[{"ref": 2, "cluster_id": 55, "quote": "held"}]'),
+        );
+        const cases = new Map([
+            [
+                55,
+                {
+                    caseName: "Smith v. Jones",
+                    citations: ["123 U.S. 456", "alt cite"],
+                    url: "https://example.test/case",
+                    pdfUrl: null,
+                    dateFiled: "1990-01-02",
+                },
+            ],
+        ]);
+        expect(createCitation(parsed, docIndex, cases)).toMatchObject({
+            type: "citation_data",
+            kind: "case",
+            ref: 2,
+            cluster_id: 55,
+            case_name: "Smith v. Jones",
+            citation: "123 U.S. 456",
+            url: "https://example.test/case",
+            pdfUrl: null,
+            dateFiled: "1990-01-02",
+        });
+    });
+
+    it("nulls case metadata when the cluster map has no entry", () => {
+        const [parsed] = parseCitations(
+            citationsBlock('[{"ref": 2, "cluster_id": 55, "quote": "held"}]'),
+        );
+        expect(createCitation(parsed, docIndex)).toMatchObject({
+            case_name: null,
+            citation: null,
+            url: null,
+            pdfUrl: null,
+            dateFiled: null,
+        });
+    });
+});

--- a/backend/src/lib/__tests__/documentVersions.test.ts
+++ b/backend/src/lib/__tests__/documentVersions.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect } from "vitest";
+import {
+    loadActiveVersion,
+    attachActiveVersionPaths,
+    attachLatestVersionNumbers,
+} from "../documentVersions";
+
+type Row = Record<string, unknown>;
+
+/**
+ * Read-only Supabase mock covering the query chains documentVersions uses:
+ * select/eq/in/is/not filters plus single() and awaiting the builder.
+ */
+function makeDb(tables: Record<string, Row[]>) {
+    return {
+        from(table: string) {
+            let rows = [...(tables[table] ?? [])];
+            const query: any = {
+                select: () => query,
+                eq: (column: string, value: unknown) => {
+                    rows = rows.filter((row) => row[column] === value);
+                    return query;
+                },
+                in: (column: string, values: unknown[]) => {
+                    rows = rows.filter((row) => values.includes(row[column]));
+                    return query;
+                },
+                is: (column: string, value: unknown) => {
+                    rows = rows.filter((row) => (row[column] ?? null) === value);
+                    return query;
+                },
+                not: (column: string, operator: string, value: unknown) => {
+                    if (operator === "is" && value === null) {
+                        rows = rows.filter((row) => row[column] != null);
+                    }
+                    return query;
+                },
+                single: async () => ({ data: rows[0] ?? null, error: null }),
+                then: (
+                    resolve: (value: { data: Row[]; error: null }) => unknown,
+                    reject?: (reason: unknown) => unknown,
+                ) => Promise.resolve({ data: rows, error: null }).then(resolve, reject),
+            };
+            return query;
+        },
+    } as any;
+}
+
+/** Shape of the mutable doc rows the attach* helpers annotate in place. */
+type TestDoc = {
+    id: string;
+    current_version_id?: string | null;
+    latest_version_number?: number | null;
+    [k: string]: unknown;
+};
+
+const FULL_VERSION = {
+    id: "ver-1",
+    document_id: "doc-1",
+    storage_path: "documents/u/doc-1/source.pdf",
+    pdf_storage_path: "documents/u/doc-1/converted.pdf",
+    version_number: 3,
+    filename: "contract.pdf",
+    source: "upload",
+    file_type: "application/pdf",
+    size_bytes: 1024,
+    page_count: 12,
+    deleted_at: null,
+};
+
+// ---------------------------------------------------------------------------
+// loadActiveVersion
+// ---------------------------------------------------------------------------
+
+describe("loadActiveVersion", () => {
+    it("resolves the document's current version by default", async () => {
+        const db = makeDb({
+            documents: [{ id: "doc-1", current_version_id: "ver-1" }],
+            document_versions: [FULL_VERSION],
+        });
+        await expect(loadActiveVersion("doc-1", db)).resolves.toEqual({
+            id: "ver-1",
+            storage_path: "documents/u/doc-1/source.pdf",
+            pdf_storage_path: "documents/u/doc-1/converted.pdf",
+            version_number: 3,
+            filename: "contract.pdf",
+            source: "upload",
+            file_type: "application/pdf",
+            size_bytes: 1024,
+            page_count: 12,
+        });
+    });
+
+    it("prefers an explicit versionId over current_version_id", async () => {
+        const db = makeDb({
+            documents: [{ id: "doc-1", current_version_id: "ver-1" }],
+            document_versions: [
+                FULL_VERSION,
+                { ...FULL_VERSION, id: "ver-2", version_number: 2 },
+            ],
+        });
+        const version = await loadActiveVersion("doc-1", db, "ver-2");
+        expect(version?.id).toBe("ver-2");
+        expect(version?.version_number).toBe(2);
+    });
+
+    it("returns null when neither versionId nor current_version_id exist", async () => {
+        const db = makeDb({
+            documents: [{ id: "doc-1", current_version_id: null }],
+            document_versions: [FULL_VERSION],
+        });
+        await expect(loadActiveVersion("doc-1", db)).resolves.toBeNull();
+    });
+
+    it("returns null when the version belongs to a different document", async () => {
+        const db = makeDb({
+            documents: [{ id: "doc-1", current_version_id: "ver-other" }],
+            document_versions: [
+                { ...FULL_VERSION, id: "ver-other", document_id: "doc-2" },
+            ],
+        });
+        await expect(loadActiveVersion("doc-1", db)).resolves.toBeNull();
+        // Also guards against a spoofed explicit versionId.
+        await expect(
+            loadActiveVersion("doc-1", db, "ver-other"),
+        ).resolves.toBeNull();
+    });
+
+    it("returns null for soft-deleted versions", async () => {
+        const db = makeDb({
+            documents: [{ id: "doc-1", current_version_id: "ver-1" }],
+            document_versions: [
+                { ...FULL_VERSION, deleted_at: "2026-01-01T00:00:00Z" },
+            ],
+        });
+        await expect(loadActiveVersion("doc-1", db)).resolves.toBeNull();
+    });
+
+    it("returns null when the version has no storage_path", async () => {
+        const db = makeDb({
+            documents: [{ id: "doc-1", current_version_id: "ver-1" }],
+            document_versions: [{ ...FULL_VERSION, storage_path: null }],
+        });
+        await expect(loadActiveVersion("doc-1", db)).resolves.toBeNull();
+    });
+
+    it("defaults optional metadata fields to null", async () => {
+        const db = makeDb({
+            documents: [{ id: "doc-1", current_version_id: "ver-1" }],
+            document_versions: [
+                {
+                    id: "ver-1",
+                    document_id: "doc-1",
+                    storage_path: "documents/u/doc-1/source.docx",
+                    deleted_at: null,
+                },
+            ],
+        });
+        await expect(loadActiveVersion("doc-1", db)).resolves.toEqual({
+            id: "ver-1",
+            storage_path: "documents/u/doc-1/source.docx",
+            pdf_storage_path: null,
+            version_number: null,
+            filename: null,
+            source: null,
+            file_type: null,
+            size_bytes: null,
+            page_count: null,
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// attachActiveVersionPaths
+// ---------------------------------------------------------------------------
+
+describe("attachActiveVersionPaths", () => {
+    it("returns the same empty array untouched", async () => {
+        const db = makeDb({ document_versions: [] });
+        const docs: TestDoc[] = [];
+        await expect(attachActiveVersionPaths(db, docs)).resolves.toBe(docs);
+    });
+
+    it("nulls all fields when no document has a current version", async () => {
+        const db = makeDb({ document_versions: [FULL_VERSION] });
+        const [doc] = await attachActiveVersionPaths<TestDoc>(db, [
+            { id: "doc-1", current_version_id: null },
+        ]);
+        expect(doc).toMatchObject({
+            filename: "Untitled document",
+            storage_path: null,
+            pdf_storage_path: null,
+            file_type: null,
+            size_bytes: null,
+            page_count: null,
+        });
+    });
+
+    it("merges active-version metadata onto each row", async () => {
+        const db = makeDb({
+            document_versions: [
+                FULL_VERSION,
+                {
+                    ...FULL_VERSION,
+                    id: "ver-2",
+                    storage_path: "documents/u/doc-2/source.docx",
+                    pdf_storage_path: null,
+                    filename: "nda.docx",
+                    version_number: 1,
+                },
+            ],
+        });
+        const docs = await attachActiveVersionPaths<TestDoc>(db, [
+            { id: "doc-1", current_version_id: "ver-1" },
+            { id: "doc-2", current_version_id: "ver-2" },
+            { id: "doc-3", current_version_id: null },
+        ]);
+        expect(docs[0]).toMatchObject({
+            storage_path: "documents/u/doc-1/source.pdf",
+            pdf_storage_path: "documents/u/doc-1/converted.pdf",
+            active_version_number: 3,
+            filename: "contract.pdf",
+            file_type: "application/pdf",
+            size_bytes: 1024,
+            page_count: 12,
+        });
+        expect(docs[1]).toMatchObject({
+            storage_path: "documents/u/doc-2/source.docx",
+            pdf_storage_path: null,
+            active_version_number: 1,
+            filename: "nda.docx",
+        });
+        // Mixed list: the version-less doc still gets explicit nulls.
+        expect(docs[2]).toMatchObject({
+            storage_path: null,
+            filename: "Untitled document",
+        });
+    });
+
+    it("falls back to 'Untitled document' for blank filenames", async () => {
+        const db = makeDb({
+            document_versions: [{ ...FULL_VERSION, filename: "   " }],
+        });
+        const [doc] = await attachActiveVersionPaths<TestDoc>(db, [
+            { id: "doc-1", current_version_id: "ver-1" },
+        ]);
+        expect(doc.filename).toBe("Untitled document");
+    });
+
+    it("ignores soft-deleted versions", async () => {
+        const db = makeDb({
+            document_versions: [
+                { ...FULL_VERSION, deleted_at: "2026-01-01T00:00:00Z" },
+            ],
+        });
+        const [doc] = await attachActiveVersionPaths<TestDoc>(db, [
+            { id: "doc-1", current_version_id: "ver-1" },
+        ]);
+        expect(doc.storage_path).toBeNull();
+        expect(doc.filename).toBe("Untitled document");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// attachLatestVersionNumbers
+// ---------------------------------------------------------------------------
+
+describe("attachLatestVersionNumbers", () => {
+    const versionRow = (
+        document_id: string,
+        version_number: number | null,
+        overrides: Row = {},
+    ) => ({
+        document_id,
+        version_number,
+        source: "assistant_edit",
+        deleted_at: null,
+        ...overrides,
+    });
+
+    it("returns the same empty array untouched", async () => {
+        const db = makeDb({ document_versions: [] });
+        const docs: TestDoc[] = [];
+        await expect(attachLatestVersionNumbers(db, docs)).resolves.toBe(docs);
+    });
+
+    it("attaches the max assistant_edit version number per document", async () => {
+        const db = makeDb({
+            document_versions: [
+                versionRow("doc-1", 1),
+                versionRow("doc-1", 4),
+                versionRow("doc-1", 2),
+                versionRow("doc-2", 7),
+            ],
+        });
+        const docs = await attachLatestVersionNumbers<TestDoc>(db, [
+            { id: "doc-1" },
+            { id: "doc-2" },
+            { id: "doc-3" },
+        ]);
+        expect(docs.map((d) => d.latest_version_number)).toEqual([4, 7, null]);
+    });
+
+    it("ignores non-assistant_edit and soft-deleted versions", async () => {
+        const db = makeDb({
+            document_versions: [
+                versionRow("doc-1", 9, { source: "upload" }),
+                versionRow("doc-1", 8, { deleted_at: "2026-01-01T00:00:00Z" }),
+                versionRow("doc-1", 2),
+            ],
+        });
+        const docs = await attachLatestVersionNumbers<TestDoc>(db, [{ id: "doc-1" }]);
+        expect(docs[0].latest_version_number).toBe(2);
+    });
+});

--- a/backend/src/lib/__tests__/downloadTokens.test.ts
+++ b/backend/src/lib/__tests__/downloadTokens.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { signDownload, verifyDownload, buildDownloadUrl } from "../downloadTokens";
+
+const SECRET = "test-secret-32-bytes-long-enough!!";
+
+beforeAll(() => {
+    process.env.DOWNLOAD_SIGNING_SECRET = SECRET;
+});
+
+afterAll(() => {
+    delete process.env.DOWNLOAD_SIGNING_SECRET;
+});
+
+describe("signDownload", () => {
+    it("returns a two-part dot-separated token", () => {
+        const token = signDownload("documents/user/doc.pdf", "contract.pdf");
+        const parts = token.split(".");
+        expect(parts).toHaveLength(2);
+        expect(parts[0].length).toBeGreaterThan(0);
+        expect(parts[1].length).toBeGreaterThan(0);
+    });
+
+    it("produces different tokens for different paths", () => {
+        const t1 = signDownload("documents/a/file.pdf", "a.pdf");
+        const t2 = signDownload("documents/b/file.pdf", "b.pdf");
+        expect(t1).not.toBe(t2);
+    });
+
+    it("uses base64url characters only (no +, /, =)", () => {
+        const token = signDownload("documents/user/file.pdf", "file.pdf");
+        expect(token).not.toMatch(/[+/=]/);
+    });
+});
+
+describe("verifyDownload", () => {
+    it("round-trips a valid token", () => {
+        const path = "documents/user123/doc456/source.pdf";
+        const filename = "Contract Final v2.pdf";
+        const token = signDownload(path, filename);
+        const result = verifyDownload(token);
+        expect(result).not.toBeNull();
+        expect(result!.path).toBe(path);
+        expect(result!.filename).toBe(filename);
+    });
+
+    it("returns null for a tampered payload", () => {
+        const token = signDownload("documents/user/file.pdf", "file.pdf");
+        const [, sig] = token.split(".");
+        const fakePayload = Buffer.from(
+            JSON.stringify({ p: "documents/attacker/file.pdf", f: "file.pdf" }),
+        )
+            .toString("base64")
+            .replace(/\+/g, "-")
+            .replace(/\//g, "_")
+            .replace(/=+$/g, "");
+        expect(verifyDownload(`${fakePayload}.${sig}`)).toBeNull();
+    });
+
+    it("returns null for a tampered signature", () => {
+        const token = signDownload("documents/user/file.pdf", "file.pdf");
+        const [enc] = token.split(".");
+        const fakeSig = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        expect(verifyDownload(`${enc}.${fakeSig}`)).toBeNull();
+    });
+
+    it("returns null for a token with too many parts", () => {
+        expect(verifyDownload("a.b.c")).toBeNull();
+    });
+
+    it("returns null for a token with too few parts", () => {
+        expect(verifyDownload("onlyonepart")).toBeNull();
+    });
+
+    it("returns null when payload JSON is missing required fields", () => {
+        const bad = Buffer.from(JSON.stringify({ x: 1 }))
+            .toString("base64")
+            .replace(/\+/g, "-")
+            .replace(/\//g, "_")
+            .replace(/=+$/g, "");
+        const sig = Buffer.alloc(32).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+        expect(verifyDownload(`${bad}.${sig}`)).toBeNull();
+    });
+
+    it("returns null when signed with a different secret", () => {
+        const token = signDownload("documents/user/file.pdf", "file.pdf");
+        process.env.DOWNLOAD_SIGNING_SECRET = "different-secret-value-!!";
+        const result = verifyDownload(token);
+        process.env.DOWNLOAD_SIGNING_SECRET = SECRET;
+        expect(result).toBeNull();
+    });
+});
+
+describe("buildDownloadUrl", () => {
+    it("returns a path starting with /download/", () => {
+        const url = buildDownloadUrl("documents/user/file.pdf", "file.pdf");
+        expect(url).toMatch(/^\/download\//);
+    });
+
+    it("embeds a verifiable token in the URL", () => {
+        const path = "documents/user/file.pdf";
+        const filename = "file.pdf";
+        const url = buildDownloadUrl(path, filename);
+        const token = url.replace("/download/", "");
+        const result = verifyDownload(token);
+        expect(result).not.toBeNull();
+        expect(result!.path).toBe(path);
+        expect(result!.filename).toBe(filename);
+    });
+});

--- a/backend/src/lib/__tests__/llmModels.test.ts
+++ b/backend/src/lib/__tests__/llmModels.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+    CLAUDE_MAIN_MODELS,
+    GEMINI_MAIN_MODELS,
+    OPENAI_MAIN_MODELS,
+    CLAUDE_MID_MODELS,
+    GEMINI_MID_MODELS,
+    OPENAI_MID_MODELS,
+    CLAUDE_LOW_MODELS,
+    GEMINI_LOW_MODELS,
+    OPENAI_LOW_MODELS,
+    DEFAULT_MAIN_MODEL,
+    DEFAULT_TITLE_MODEL,
+    DEFAULT_TABULAR_MODEL,
+    providerForModel,
+    resolveModel,
+} from "../llm/models";
+
+// ---------------------------------------------------------------------------
+// providerForModel
+// ---------------------------------------------------------------------------
+
+describe("providerForModel", () => {
+    it("maps claude-* ids to the claude provider", () => {
+        for (const model of [...CLAUDE_MAIN_MODELS, ...CLAUDE_MID_MODELS, ...CLAUDE_LOW_MODELS]) {
+            expect(providerForModel(model)).toBe("claude");
+        }
+    });
+
+    it("maps gemini-* ids to the gemini provider", () => {
+        for (const model of [...GEMINI_MAIN_MODELS, ...GEMINI_MID_MODELS, ...GEMINI_LOW_MODELS]) {
+            expect(providerForModel(model)).toBe("gemini");
+        }
+    });
+
+    it("maps gpt-* ids to the openai provider", () => {
+        for (const model of [...OPENAI_MAIN_MODELS, ...OPENAI_MID_MODELS, ...OPENAI_LOW_MODELS]) {
+            expect(providerForModel(model)).toBe("openai");
+        }
+    });
+
+    it("throws on an unknown model id", () => {
+        expect(() => providerForModel("llama-3")).toThrow(/Unknown model id/);
+        expect(() => providerForModel("")).toThrow(/Unknown model id/);
+    });
+
+    it("infers by prefix only, without validating against the catalog", () => {
+        // Documents current behavior: any claude-/gemini-/gpt- prefix is
+        // accepted even if the id is not a canonical model.
+        expect(providerForModel("claude-nonexistent")).toBe("claude");
+        expect(providerForModel("gpt-nonexistent")).toBe("openai");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// resolveModel
+// ---------------------------------------------------------------------------
+
+describe("resolveModel", () => {
+    it("returns a known model id unchanged", () => {
+        expect(resolveModel("claude-sonnet-4-6", DEFAULT_MAIN_MODEL)).toBe(
+            "claude-sonnet-4-6",
+        );
+        expect(resolveModel("gpt-5.4-lite", DEFAULT_TITLE_MODEL)).toBe(
+            "gpt-5.4-lite",
+        );
+    });
+
+    it("falls back for unknown model ids", () => {
+        expect(resolveModel("gpt-3.5-turbo", DEFAULT_MAIN_MODEL)).toBe(
+            DEFAULT_MAIN_MODEL,
+        );
+    });
+
+    it("falls back for null, undefined, and empty ids", () => {
+        expect(resolveModel(null, DEFAULT_MAIN_MODEL)).toBe(DEFAULT_MAIN_MODEL);
+        expect(resolveModel(undefined, DEFAULT_TABULAR_MODEL)).toBe(
+            DEFAULT_TABULAR_MODEL,
+        );
+        expect(resolveModel("", DEFAULT_TITLE_MODEL)).toBe(DEFAULT_TITLE_MODEL);
+    });
+
+    it("accepts models from every tier of the catalog", () => {
+        const catalog = [
+            ...CLAUDE_MAIN_MODELS,
+            ...GEMINI_MAIN_MODELS,
+            ...OPENAI_MAIN_MODELS,
+            ...CLAUDE_MID_MODELS,
+            ...GEMINI_MID_MODELS,
+            ...OPENAI_MID_MODELS,
+            ...CLAUDE_LOW_MODELS,
+            ...GEMINI_LOW_MODELS,
+            ...OPENAI_LOW_MODELS,
+        ];
+        for (const model of catalog) {
+            expect(resolveModel(model, "fallback-model")).toBe(model);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Default model sanity
+// ---------------------------------------------------------------------------
+
+describe("default models", () => {
+    it("every default resolves to itself (defaults are in the catalog)", () => {
+        expect(resolveModel(DEFAULT_MAIN_MODEL, "x")).toBe(DEFAULT_MAIN_MODEL);
+        expect(resolveModel(DEFAULT_TITLE_MODEL, "x")).toBe(DEFAULT_TITLE_MODEL);
+        expect(resolveModel(DEFAULT_TABULAR_MODEL, "x")).toBe(
+            DEFAULT_TABULAR_MODEL,
+        );
+    });
+
+    it("every default has a resolvable provider", () => {
+        expect(providerForModel(DEFAULT_MAIN_MODEL)).toBe("gemini");
+        expect(providerForModel(DEFAULT_TITLE_MODEL)).toBe("gemini");
+        expect(providerForModel(DEFAULT_TABULAR_MODEL)).toBe("gemini");
+    });
+});

--- a/backend/src/lib/__tests__/safeError.test.ts
+++ b/backend/src/lib/__tests__/safeError.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import {
+    redactSensitiveText,
+    safeErrorMessage,
+    safeErrorLog,
+} from "../safeError";
+
+// ---------------------------------------------------------------------------
+// redactSensitiveText
+// ---------------------------------------------------------------------------
+
+describe("redactSensitiveText", () => {
+    it('redacts the OpenAI "Incorrect API key provided" message', () => {
+        expect(
+            redactSensitiveText(
+                "Incorrect API key provided: sk-proj-abc123def456ghi789.",
+            ),
+        ).toBe("Incorrect API key provided: [redacted].");
+    });
+
+    it("keeps the trailing period optional in the incorrect-key message", () => {
+        expect(
+            redactSensitiveText("Incorrect API key provided: badkey123"),
+        ).toBe("Incorrect API key provided: [redacted]");
+    });
+
+    it("redacts secrets after api_key labels", () => {
+        expect(redactSensitiveText("api_key: mysecret123")).toBe(
+            "api_key: [redacted]",
+        );
+        expect(redactSensitiveText("api key = mysecret123")).toBe(
+            "api key = [redacted]",
+        );
+    });
+
+    it("redacts secrets after token/secret/authorization labels", () => {
+        expect(redactSensitiveText("token: abcdef123456")).toBe(
+            "token: [redacted]",
+        );
+        expect(redactSensitiveText("secret is abcdef123456")).toBe(
+            "secret is [redacted]",
+        );
+        expect(redactSensitiveText("authorization: abcdef123456")).toBe(
+            "authorization: [redacted]",
+        );
+    });
+
+    it("leaves short values after labels alone (below 6 chars)", () => {
+        expect(redactSensitiveText("token: abc")).toBe("token: abc");
+    });
+
+    it("redacts bare OpenAI-style sk- keys anywhere in the text", () => {
+        expect(
+            redactSensitiveText("request failed for sk-abc123def456ghi789 today"),
+        ).toBe("request failed for [redacted] today");
+    });
+
+    it("redacts bare Anthropic-style sk-ant- keys", () => {
+        expect(
+            redactSensitiveText("used sk-ant-api03-abc123def456"),
+        ).toBe("used [redacted]");
+    });
+
+    it("redacts bare Google AIza keys", () => {
+        expect(
+            redactSensitiveText("key AIzaSyA1234567890abcdefghij failed"),
+        ).toBe("key [redacted] failed");
+    });
+
+    it("redacts multiple secrets in one string", () => {
+        const result = redactSensitiveText(
+            "first sk-abc123def456ghi789 then AIzaSyA1234567890abcdefghij",
+        );
+        expect(result).toBe("first [redacted] then [redacted]");
+    });
+
+    it("leaves ordinary text unchanged", () => {
+        expect(redactSensitiveText("Document not found")).toBe(
+            "Document not found",
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// safeErrorMessage
+// ---------------------------------------------------------------------------
+
+describe("safeErrorMessage", () => {
+    it("uses the message of an Error instance", () => {
+        expect(safeErrorMessage(new Error("boom"))).toBe("boom");
+    });
+
+    it("redacts secrets inside an Error message", () => {
+        expect(
+            safeErrorMessage(new Error("bad key sk-abc123def456ghi789")),
+        ).toBe("bad key [redacted]");
+    });
+
+    it("passes plain strings through (redacted)", () => {
+        expect(safeErrorMessage("token: abcdef123456")).toBe(
+            "token: [redacted]",
+        );
+    });
+
+    it("falls back for non-Error, non-string values", () => {
+        expect(safeErrorMessage(42)).toBe("Unexpected error");
+        expect(safeErrorMessage(null)).toBe("Unexpected error");
+        expect(safeErrorMessage({ message: "obj" })).toBe("Unexpected error");
+    });
+
+    it("falls back for an Error with an empty message", () => {
+        expect(safeErrorMessage(new Error(""))).toBe("Unexpected error");
+    });
+
+    it("honors a custom fallback", () => {
+        expect(safeErrorMessage(undefined, "Chat failed")).toBe("Chat failed");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// safeErrorLog
+// ---------------------------------------------------------------------------
+
+describe("safeErrorLog", () => {
+    it("captures name, message, and stack for an Error", () => {
+        const error = new Error("boom");
+        const log = safeErrorLog(error);
+        expect(log.name).toBe("Error");
+        expect(log.message).toBe("boom");
+        expect(log.stack).toContain("boom");
+    });
+
+    it("redacts secrets in the message and stack", () => {
+        const error = new Error("bad key sk-abc123def456ghi789");
+        const log = safeErrorLog(error);
+        expect(log.message).toBe("bad key [redacted]");
+        expect(log.stack).not.toContain("sk-abc123def456ghi789");
+    });
+
+    it("falls back to 'Unexpected error' for an empty Error message", () => {
+        expect(safeErrorLog(new Error("")).message).toBe("Unexpected error");
+    });
+
+    it("omits the stack when the Error has none", () => {
+        const error = new Error("boom");
+        error.stack = undefined;
+        expect(safeErrorLog(error).stack).toBeUndefined();
+    });
+
+    it("handles non-Error values with a null name and no stack", () => {
+        const log = safeErrorLog("plain failure");
+        expect(log).toEqual({ name: null, message: "plain failure" });
+    });
+});

--- a/backend/src/lib/__tests__/storage.test.ts
+++ b/backend/src/lib/__tests__/storage.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+
+import {
+    normalizeDownloadFilename,
+    sanitizeDispositionFilename,
+    encodeRFC5987,
+    buildContentDisposition,
+    storageKey,
+    pdfStorageKey,
+    generatedDocKey,
+    versionStorageKey,
+} from "../storage";
+
+describe("normalizeDownloadFilename", () => {
+    it("trims surrounding whitespace", () => {
+        expect(normalizeDownloadFilename("  file.pdf  ")).toBe("file.pdf");
+    });
+
+    it("falls back to 'download' for empty string", () => {
+        expect(normalizeDownloadFilename("")).toBe("download");
+        expect(normalizeDownloadFilename("   ")).toBe("download");
+    });
+
+    it("replaces control characters with underscore", () => {
+        expect(normalizeDownloadFilename("file\x00name.pdf")).toBe("file_name.pdf");
+        expect(normalizeDownloadFilename("file\x1fname.pdf")).toBe("file_name.pdf");
+    });
+
+    it("replaces forward and backward slashes with underscore", () => {
+        expect(normalizeDownloadFilename("dir/file.pdf")).toBe("dir_file.pdf");
+        expect(normalizeDownloadFilename("dir\\file.pdf")).toBe("dir_file.pdf");
+    });
+
+    it("preserves normal filenames unchanged", () => {
+        expect(normalizeDownloadFilename("Contract v2 (Final).pdf")).toBe(
+            "Contract v2 (Final).pdf",
+        );
+    });
+});
+
+describe("sanitizeDispositionFilename", () => {
+    it("strips double-quote characters", () => {
+        expect(sanitizeDispositionFilename('file"name.pdf')).toBe("file_name.pdf");
+    });
+
+    it("strips backslash characters", () => {
+        expect(sanitizeDispositionFilename("file\\name.pdf")).toBe("file_name.pdf");
+    });
+
+    it("strips non-ASCII characters", () => {
+        expect(sanitizeDispositionFilename("filéname.pdf")).toBe("fil_name.pdf");
+    });
+
+    it("still applies normalizeDownloadFilename rules first", () => {
+        expect(sanitizeDispositionFilename("  ")).toBe("download");
+    });
+});
+
+describe("encodeRFC5987", () => {
+    it("encodes spaces as %20", () => {
+        expect(encodeRFC5987("hello world")).toBe("hello%20world");
+    });
+
+    it("encodes single-quote as %27", () => {
+        expect(encodeRFC5987("it's")).toContain("%27");
+    });
+
+    it("encodes ( and ) as %28 and %29", () => {
+        const result = encodeRFC5987("a(b)c");
+        expect(result).toContain("%28");
+        expect(result).toContain("%29");
+    });
+
+    it("encodes * as %2A", () => {
+        expect(encodeRFC5987("a*b")).toContain("%2A");
+    });
+
+    it("leaves safe ASCII characters unencoded", () => {
+        expect(encodeRFC5987("file.pdf")).toBe("file.pdf");
+    });
+});
+
+describe("buildContentDisposition", () => {
+    it("produces an attachment header with ASCII filename", () => {
+        const header = buildContentDisposition("attachment", "contract.pdf");
+        expect(header).toMatch(/^attachment;/);
+        expect(header).toContain('filename="contract.pdf"');
+        expect(header).toContain("filename*=UTF-8''contract.pdf");
+    });
+
+    it("produces an inline header", () => {
+        const header = buildContentDisposition("inline", "preview.pdf");
+        expect(header).toMatch(/^inline;/);
+    });
+
+    it("encodes unicode filename in filename* param", () => {
+        const header = buildContentDisposition("attachment", "Ünïcödé.pdf");
+        expect(header).toContain("filename*=UTF-8''");
+        expect(header).not.toContain("Ü");
+    });
+});
+
+describe("storageKey", () => {
+    it("includes userId, docId, and correct extension", () => {
+        const key = storageKey("user1", "doc1", "contract.pdf");
+        expect(key).toBe("documents/user1/doc1/source.pdf");
+    });
+
+    it("falls back to .bin for extensions longer than 16 chars", () => {
+        const key = storageKey("user1", "doc1", "file.toolongextension1234");
+        expect(key).toBe("documents/user1/doc1/source.bin");
+    });
+
+    it("falls back to .bin when no extension", () => {
+        const key = storageKey("user1", "doc1", "noextension");
+        expect(key).toBe("documents/user1/doc1/source.bin");
+    });
+});
+
+describe("pdfStorageKey", () => {
+    it("places PDF in the correct path with stem", () => {
+        const key = pdfStorageKey("user1", "doc1", "contract");
+        expect(key).toBe("documents/user1/doc1/contract.pdf");
+    });
+});
+
+describe("generatedDocKey", () => {
+    it("uses generated/ prefix and .docx extension for docx files", () => {
+        const key = generatedDocKey("user1", "doc1", "output.docx");
+        expect(key).toBe("generated/user1/doc1/generated.docx");
+    });
+
+    it("falls back to .docx for extensions longer than 16 chars", () => {
+        const key = generatedDocKey("user1", "doc1", "output.toolongextension1234");
+        expect(key).toBe("generated/user1/doc1/generated.docx");
+    });
+});
+
+describe("versionStorageKey", () => {
+    it("includes userId, docId, versionSlug, and extension", () => {
+        const key = versionStorageKey("user1", "doc1", "v2", "contract.pdf");
+        expect(key).toBe("documents/user1/doc1/versions/v2.pdf");
+    });
+
+    it("falls back to .bin for unknown extensions", () => {
+        const key = versionStorageKey("user1", "doc1", "v2", "file");
+        expect(key).toBe("documents/user1/doc1/versions/v2.bin");
+    });
+});

--- a/backend/src/lib/__tests__/userApiKeys.test.ts
+++ b/backend/src/lib/__tests__/userApiKeys.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { normalizeApiKeyProvider, hasEnvApiKey } from "../userApiKeys";
+
+describe("normalizeApiKeyProvider", () => {
+    it('returns "claude" for "claude"', () => {
+        expect(normalizeApiKeyProvider("claude")).toBe("claude");
+    });
+
+    it('returns "openai" for "openai"', () => {
+        expect(normalizeApiKeyProvider("openai")).toBe("openai");
+    });
+
+    it('returns "gemini" for "gemini"', () => {
+        expect(normalizeApiKeyProvider("gemini")).toBe("gemini");
+    });
+
+    it("returns null for unknown provider strings", () => {
+        expect(normalizeApiKeyProvider("unknown")).toBeNull();
+        expect(normalizeApiKeyProvider("")).toBeNull();
+        expect(normalizeApiKeyProvider("Claude")).toBeNull();
+        expect(normalizeApiKeyProvider("OPENAI")).toBeNull();
+    });
+});
+
+describe("hasEnvApiKey", () => {
+    const envVars = [
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+    ];
+
+    // Clear before AND after each test so keys exported in the developer's
+    // shell (or CI) can't leak into assertions.
+    beforeEach(() => {
+        for (const v of envVars) delete process.env[v];
+    });
+
+    afterEach(() => {
+        for (const v of envVars) delete process.env[v];
+    });
+
+    it("returns true for claude when ANTHROPIC_API_KEY is set", () => {
+        process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+        expect(hasEnvApiKey("claude")).toBe(true);
+    });
+
+    it("returns true for claude when CLAUDE_API_KEY is set as fallback", () => {
+        process.env.CLAUDE_API_KEY = "sk-claude-test";
+        expect(hasEnvApiKey("claude")).toBe(true);
+    });
+
+    it("returns true for openai when OPENAI_API_KEY is set", () => {
+        process.env.OPENAI_API_KEY = "sk-openai-test";
+        expect(hasEnvApiKey("openai")).toBe(true);
+    });
+
+    it("returns true for gemini when GEMINI_API_KEY is set", () => {
+        process.env.GEMINI_API_KEY = "gemini-key-test";
+        expect(hasEnvApiKey("gemini")).toBe(true);
+    });
+
+    it("returns false when no env key is set for the provider", () => {
+        expect(hasEnvApiKey("claude")).toBe(false);
+        expect(hasEnvApiKey("openai")).toBe(false);
+        expect(hasEnvApiKey("gemini")).toBe(false);
+    });
+
+    it("ignores whitespace-only env values", () => {
+        process.env.ANTHROPIC_API_KEY = "   ";
+        expect(hasEnvApiKey("claude")).toBe(false);
+    });
+});

--- a/backend/src/lib/__tests__/userDataCleanup.test.ts
+++ b/backend/src/lib/__tests__/userDataCleanup.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../storage", () => ({
+    deleteFile: vi.fn(async () => {}),
+    listFiles: vi.fn(async () => [] as string[]),
+}));
+
+import { deleteFile, listFiles } from "../storage";
+import {
+    deleteAllUserChats,
+    deleteAllUserTabularReviews,
+    deleteUserProjects,
+    deleteUserAccountData,
+} from "../userDataCleanup";
+
+const deleteFileMock = vi.mocked(deleteFile);
+const listFilesMock = vi.mocked(listFiles);
+
+type Row = Record<string, unknown>;
+
+/**
+ * Stateful Supabase mock: deletes and updates mutate `tables`, so tests can
+ * assert on exactly which rows survived a cleanup call. Supports the chains
+ * userDataCleanup uses (select/delete/update + eq/in/filter-cs) and can
+ * inject a delete error per table to exercise error propagation.
+ */
+function makeDb(
+    initialTables: Record<string, Row[]>,
+    options: { deleteErrors?: Record<string, string> } = {},
+) {
+    const tables: Record<string, Row[]> = {};
+    for (const [name, rows] of Object.entries(initialTables)) {
+        tables[name] = rows.map((row) => ({ ...row }));
+    }
+    const db = {
+        from(table: string) {
+            const rowsOf = () => tables[table] ?? (tables[table] = []);
+            let predicate: (row: Row) => boolean = () => true;
+            let mode: "select" | "delete" | "update" = "select";
+            let patch: Row = {};
+            const narrow = (next: (row: Row) => boolean) => {
+                const prev = predicate;
+                predicate = (row) => prev(row) && next(row);
+            };
+            const query: any = {
+                select: () => query,
+                delete: () => {
+                    mode = "delete";
+                    return query;
+                },
+                update: (value: Row) => {
+                    mode = "update";
+                    patch = value;
+                    return query;
+                },
+                eq: (column: string, value: unknown) => {
+                    narrow((row) => row[column] === value);
+                    return query;
+                },
+                in: (column: string, values: unknown[]) => {
+                    narrow((row) => values.includes(row[column]));
+                    return query;
+                },
+                filter: (column: string, operator: string, value: string) => {
+                    if (operator !== "cs") return query;
+                    const expected = (JSON.parse(value) as string[]).map((item) =>
+                        item.toLowerCase(),
+                    );
+                    narrow((row) => {
+                        const actual = row[column];
+                        if (!Array.isArray(actual)) return false;
+                        const normalized = actual.map((item) =>
+                            String(item).toLowerCase(),
+                        );
+                        return expected.every((item) => normalized.includes(item));
+                    });
+                    return query;
+                },
+                then: (
+                    resolve: (value: { data: Row[] | null; error: unknown }) => unknown,
+                    reject?: (reason: unknown) => unknown,
+                ) => {
+                    let result: { data: Row[] | null; error: unknown };
+                    if (mode === "delete") {
+                        const message = options.deleteErrors?.[table];
+                        if (message) {
+                            result = { data: null, error: { message } };
+                        } else {
+                            tables[table] = rowsOf().filter((row) => !predicate(row));
+                            result = { data: null, error: null };
+                        }
+                    } else if (mode === "update") {
+                        for (const row of rowsOf().filter(predicate)) {
+                            Object.assign(row, patch);
+                        }
+                        result = { data: null, error: null };
+                    } else {
+                        result = {
+                            data: rowsOf().filter(predicate).map((row) => ({ ...row })),
+                            error: null,
+                        };
+                    }
+                    return Promise.resolve(result).then(resolve, reject);
+                },
+            };
+            return query;
+        },
+    };
+    return { db: db as any, tables };
+}
+
+const ids = (rows: Row[] | undefined) => (rows ?? []).map((row) => row.id);
+
+beforeEach(() => {
+    deleteFileMock.mockClear();
+    deleteFileMock.mockResolvedValue(undefined as never);
+    listFilesMock.mockClear();
+    listFilesMock.mockResolvedValue([]);
+});
+
+// ---------------------------------------------------------------------------
+// deleteAllUserChats
+// ---------------------------------------------------------------------------
+
+describe("deleteAllUserChats", () => {
+    it("deletes only the target user's assistant and tabular chats", async () => {
+        const { db, tables } = makeDb({
+            chats: [
+                { id: "c1", user_id: "u1" },
+                { id: "c2", user_id: "u2" },
+            ],
+            tabular_review_chats: [
+                { id: "tc1", user_id: "u1" },
+                { id: "tc2", user_id: "u2" },
+            ],
+        });
+        await deleteAllUserChats(db, "u1");
+        expect(ids(tables.chats)).toEqual(["c2"]);
+        expect(ids(tables.tabular_review_chats)).toEqual(["tc2"]);
+    });
+
+    it("surfaces delete failures with context", async () => {
+        const { db } = makeDb(
+            { chats: [{ id: "c1", user_id: "u1" }], tabular_review_chats: [] },
+            { deleteErrors: { chats: "boom" } },
+        );
+        await expect(deleteAllUserChats(db, "u1")).rejects.toThrow(
+            "Failed to delete assistant chats: boom",
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// deleteAllUserTabularReviews
+// ---------------------------------------------------------------------------
+
+describe("deleteAllUserTabularReviews", () => {
+    const fixture = () =>
+        makeDb({
+            tabular_reviews: [
+                { id: "r1", user_id: "u1" },
+                { id: "r2", user_id: "u1" },
+                { id: "r-other", user_id: "u2" },
+            ],
+            tabular_review_chats: [
+                { id: "rc1", review_id: "r1" },
+                { id: "rc-other", review_id: "r-other" },
+            ],
+            tabular_review_chat_messages: [
+                { id: "rm1", chat_id: "rc1" },
+                { id: "rm-other", chat_id: "rc-other" },
+            ],
+            tabular_cells: [
+                { id: "cell1", review_id: "r1" },
+                { id: "cell-other", review_id: "r-other" },
+            ],
+        });
+
+    it("cascades messages, chats, and cells before the reviews", async () => {
+        const { db, tables } = fixture();
+        await expect(deleteAllUserTabularReviews(db, "u1")).resolves.toBe(2);
+        expect(ids(tables.tabular_reviews)).toEqual(["r-other"]);
+        expect(ids(tables.tabular_review_chats)).toEqual(["rc-other"]);
+        expect(ids(tables.tabular_review_chat_messages)).toEqual(["rm-other"]);
+        expect(ids(tables.tabular_cells)).toEqual(["cell-other"]);
+    });
+
+    it("returns 0 and deletes nothing for a user with no reviews", async () => {
+        const { db, tables } = fixture();
+        await expect(deleteAllUserTabularReviews(db, "u3")).resolves.toBe(0);
+        expect(tables.tabular_reviews).toHaveLength(3);
+        expect(tables.tabular_cells).toHaveLength(2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// deleteUserProjects
+// ---------------------------------------------------------------------------
+
+describe("deleteUserProjects", () => {
+    const fixture = () =>
+        makeDb({
+            projects: [
+                { id: "p1", user_id: "u1" },
+                { id: "p2", user_id: "u1" },
+                { id: "p-other", user_id: "u2" },
+            ],
+            documents: [
+                { id: "d1", user_id: "u1", project_id: "p1" },
+                { id: "d-loose", user_id: "u1", project_id: null },
+                { id: "d-other", user_id: "u2", project_id: "p-other" },
+            ],
+            document_versions: [
+                {
+                    id: "v1",
+                    document_id: "d1",
+                    storage_path: "documents/u1/d1/source.pdf",
+                    pdf_storage_path: "documents/u1/d1/converted.pdf",
+                },
+                {
+                    id: "v-other",
+                    document_id: "d-other",
+                    storage_path: "documents/u2/d-other/source.pdf",
+                    pdf_storage_path: null,
+                },
+            ],
+            chats: [
+                { id: "c1", project_id: "p1" },
+                { id: "c-other", project_id: "p-other" },
+            ],
+            chat_messages: [
+                { id: "m1", chat_id: "c1" },
+                { id: "m-other", chat_id: "c-other" },
+            ],
+            tabular_reviews: [
+                { id: "r1", project_id: "p1" },
+                { id: "r-other", project_id: "p-other" },
+            ],
+            tabular_review_chats: [
+                { id: "rc1", review_id: "r1" },
+                { id: "rc-other", review_id: "r-other" },
+            ],
+            tabular_review_chat_messages: [
+                { id: "rm1", chat_id: "rc1" },
+                { id: "rm-other", chat_id: "rc-other" },
+            ],
+            tabular_cells: [
+                { id: "cell1", review_id: "r1" },
+                { id: "cell-other", review_id: "r-other" },
+            ],
+            project_subfolders: [
+                { id: "f1", project_id: "p1" },
+                { id: "f-other", project_id: "p-other" },
+            ],
+        });
+
+    it("cascades project contents and storage files for owned projects", async () => {
+        const { db, tables } = fixture();
+        await expect(deleteUserProjects(db, "u1")).resolves.toBe(2);
+
+        expect(ids(tables.projects)).toEqual(["p-other"]);
+        expect(ids(tables.documents)).toEqual(["d-loose", "d-other"]);
+        expect(ids(tables.chats)).toEqual(["c-other"]);
+        expect(ids(tables.chat_messages)).toEqual(["m-other"]);
+        expect(ids(tables.tabular_reviews)).toEqual(["r-other"]);
+        expect(ids(tables.tabular_review_chats)).toEqual(["rc-other"]);
+        expect(ids(tables.tabular_review_chat_messages)).toEqual(["rm-other"]);
+        expect(ids(tables.tabular_cells)).toEqual(["cell-other"]);
+        expect(ids(tables.project_subfolders)).toEqual(["f-other"]);
+
+        const deletedPaths = deleteFileMock.mock.calls.map(([path]) => path);
+        expect(deletedPaths.sort()).toEqual([
+            "documents/u1/d1/converted.pdf",
+            "documents/u1/d1/source.pdf",
+        ]);
+    });
+
+    it("restricts deletion to the requested owned projects", async () => {
+        const { db, tables } = fixture();
+        // p-other belongs to u2, so requesting it must not delete anything of theirs.
+        await expect(
+            deleteUserProjects(db, "u1", ["p2", "p-other", "p2"]),
+        ).resolves.toBe(1);
+        expect(ids(tables.projects)).toEqual(["p1", "p-other"]);
+        expect(ids(tables.documents)).toEqual(["d1", "d-loose", "d-other"]);
+    });
+
+    it("returns 0 for an explicitly empty project list", async () => {
+        const { db, tables } = fixture();
+        await expect(deleteUserProjects(db, "u1", [])).resolves.toBe(0);
+        expect(tables.projects).toHaveLength(3);
+    });
+
+    it("returns 0 when the user owns no projects", async () => {
+        const { db, tables } = fixture();
+        await expect(deleteUserProjects(db, "u3")).resolves.toBe(0);
+        expect(tables.projects).toHaveLength(3);
+        expect(deleteFileMock).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// deleteUserAccountData
+// ---------------------------------------------------------------------------
+
+describe("deleteUserAccountData", () => {
+    const fixture = () =>
+        makeDb({
+            projects: [
+                { id: "p1", user_id: "u1", shared_with: [] },
+                {
+                    id: "p-other",
+                    user_id: "u2",
+                    shared_with: ["u1@example.com", " U1@Example.com ", "keep@example.com"],
+                },
+            ],
+            tabular_reviews: [
+                { id: "r1", user_id: "u1", shared_with: [] },
+                { id: "r-other", user_id: "u2", shared_with: ["u1@example.com"] },
+            ],
+            documents: [
+                { id: "d1", user_id: "u1", project_id: null },
+                // Guest doc uploaded by another user into u1's project: deleted too.
+                { id: "d-guest", user_id: "u2", project_id: "p1" },
+                { id: "d-other", user_id: "u2", project_id: "p-other" },
+            ],
+            document_versions: [
+                {
+                    id: "v1",
+                    document_id: "d1",
+                    storage_path: "documents/u1/d1/source.pdf",
+                    pdf_storage_path: "documents/u1/d1/converted.pdf",
+                },
+                {
+                    id: "v-guest",
+                    document_id: "d-guest",
+                    storage_path: "documents/u2/d-guest/source.docx",
+                    pdf_storage_path: null,
+                },
+                {
+                    id: "v-other",
+                    document_id: "d-other",
+                    storage_path: "documents/u2/d-other/source.pdf",
+                    pdf_storage_path: null,
+                },
+            ],
+            chats: [
+                { id: "c1", user_id: "u1" },
+                { id: "c-other", user_id: "u2" },
+            ],
+            tabular_review_chats: [{ id: "rc1", user_id: "u1" }],
+            project_subfolders: [{ id: "f1", user_id: "u1" }],
+            hidden_workflows: [{ id: "h1", user_id: "u1" }],
+            workflow_open_source_submissions: [
+                { id: "s1", submitted_by_user_id: "u1" },
+            ],
+            workflow_shares: [
+                { id: "ws-by", shared_by_user_id: "u1", shared_with_email: "x@y.z" },
+                {
+                    id: "ws-to",
+                    shared_by_user_id: "u2",
+                    shared_with_email: "u1@example.com",
+                },
+                {
+                    id: "ws-keep",
+                    shared_by_user_id: "u2",
+                    shared_with_email: "keep@example.com",
+                },
+            ],
+            workflows: [
+                { id: "w1", user_id: "u1" },
+                { id: "w-other", user_id: "u2" },
+            ],
+        });
+
+    it("removes the user's rows, files, and share references everywhere", async () => {
+        const { db, tables } = fixture();
+        listFilesMock.mockResolvedValue(["documents/u1/orphan.bin"]);
+
+        await deleteUserAccountData(db, "u1", " U1@Example.COM ");
+
+        // Owned docs and guest docs inside owned projects are gone.
+        expect(ids(tables.documents)).toEqual(["d-other"]);
+        expect(ids(tables.projects)).toEqual(["p-other"]);
+        expect(ids(tables.chats)).toEqual(["c-other"]);
+        expect(tables.tabular_review_chats).toEqual([]);
+        expect(ids(tables.tabular_reviews)).toEqual(["r-other"]);
+        expect(tables.project_subfolders).toEqual([]);
+        expect(tables.hidden_workflows).toEqual([]);
+        expect(tables.workflow_open_source_submissions).toEqual([]);
+        expect(ids(tables.workflows)).toEqual(["w-other"]);
+
+        // Shares by the user and shares to the user's email are both removed.
+        expect(ids(tables.workflow_shares)).toEqual(["ws-keep"]);
+
+        // The email is scrubbed from other users' shared_with lists
+        // (case-insensitively), preserving other collaborators.
+        expect(tables.projects[0].shared_with).toEqual(["keep@example.com"]);
+        expect(tables.tabular_reviews[0].shared_with).toEqual([]);
+
+        // Version files for deleted docs plus orphans under the user's prefix.
+        const deletedPaths = deleteFileMock.mock.calls.map(([path]) => path);
+        expect(deletedPaths.sort()).toEqual([
+            "documents/u1/d1/converted.pdf",
+            "documents/u1/d1/source.pdf",
+            "documents/u1/orphan.bin",
+            "documents/u2/d-guest/source.docx",
+        ]);
+        expect(listFilesMock).toHaveBeenCalledWith("documents/u1/");
+    });
+
+    it("treats storage prefix cleanup as best-effort", async () => {
+        const { db, tables } = fixture();
+        listFilesMock.mockRejectedValue(new Error("storage unavailable"));
+        await expect(
+            deleteUserAccountData(db, "u1", "u1@example.com"),
+        ).resolves.toBeUndefined();
+        expect(ids(tables.documents)).toEqual(["d-other"]);
+    });
+
+    it("skips shared_with scrubbing when no email is known", async () => {
+        const { db, tables } = fixture();
+        await deleteUserAccountData(db, "u1", null);
+        // Rows referencing the email by value are left in place...
+        expect(tables.projects.find((row) => row.id === "p-other")?.shared_with)
+            .toContain("u1@example.com");
+        expect(ids(tables.workflow_shares)).toEqual(["ws-to", "ws-keep"]);
+        // ...but the user's own data is still deleted.
+        expect(ids(tables.documents)).toEqual(["d-other"]);
+        expect(tables.workflows.map((row) => row.id)).toEqual(["w-other"]);
+    });
+});

--- a/backend/src/lib/__tests__/userLookup.test.ts
+++ b/backend/src/lib/__tests__/userLookup.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from "vitest";
+import {
+    normalizeEmail,
+    normalizeDisplayName,
+    loadProfileUsersByEmail,
+    findProfileUserByEmail,
+    findMissingUserEmails,
+    syncProfileEmail,
+} from "../userLookup";
+
+type Row = Record<string, unknown>;
+
+/**
+ * Minimal user_profiles-shaped Supabase mock. Supports the query chains
+ * userLookup uses (select/eq/in/not + single-row readers) plus insert and
+ * update so syncProfileEmail can be exercised end to end.
+ */
+function makeDb(initialRows: Row[]) {
+    const tables: Record<string, Row[]> = {
+        user_profiles: initialRows.map((row) => ({ ...row })),
+    };
+    return {
+        tables,
+        from(table: string) {
+            const all = () => tables[table] ?? [];
+            let predicate: (row: Row) => boolean = () => true;
+            let mode: "select" | "insert" | "update" = "select";
+            let pendingRow: Row = {};
+            const narrow = (next: (row: Row) => boolean) => {
+                const prev = predicate;
+                predicate = (row) => prev(row) && next(row);
+            };
+            const query: any = {
+                select: () => query,
+                insert: (row: Row) => {
+                    mode = "insert";
+                    pendingRow = row;
+                    return query;
+                },
+                update: (patch: Row) => {
+                    mode = "update";
+                    pendingRow = patch;
+                    return query;
+                },
+                eq: (column: string, value: unknown) => {
+                    narrow((row) => row[column] === value);
+                    return query;
+                },
+                in: (column: string, values: unknown[]) => {
+                    narrow((row) => values.includes(row[column]));
+                    return query;
+                },
+                not: (column: string, operator: string, value: unknown) => {
+                    if (operator === "is" && value === null) {
+                        narrow((row) => row[column] != null);
+                    }
+                    return query;
+                },
+                maybeSingle: async () => ({
+                    data: all().filter(predicate)[0] ?? null,
+                    error: null,
+                }),
+                then: (
+                    resolve: (value: { data: Row[] | null; error: null }) => unknown,
+                    reject?: (reason: unknown) => unknown,
+                ) => {
+                    if (mode === "insert") {
+                        all().push({ ...pendingRow });
+                        return Promise.resolve({ data: null, error: null }).then(
+                            resolve,
+                            reject,
+                        );
+                    }
+                    if (mode === "update") {
+                        for (const row of all().filter(predicate)) {
+                            Object.assign(row, pendingRow);
+                        }
+                        return Promise.resolve({ data: null, error: null }).then(
+                            resolve,
+                            reject,
+                        );
+                    }
+                    return Promise.resolve({
+                        data: all().filter(predicate),
+                        error: null,
+                    }).then(resolve, reject);
+                },
+            };
+            return query;
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// normalizeEmail / normalizeDisplayName
+// ---------------------------------------------------------------------------
+
+describe("normalizeEmail", () => {
+    it("trims and lowercases", () => {
+        expect(normalizeEmail("  User@Example.COM  ")).toBe("user@example.com");
+    });
+
+    it("returns empty string for non-strings", () => {
+        expect(normalizeEmail(null)).toBe("");
+        expect(normalizeEmail(undefined)).toBe("");
+        expect(normalizeEmail(42)).toBe("");
+    });
+});
+
+describe("normalizeDisplayName", () => {
+    it("trims usable names", () => {
+        expect(normalizeDisplayName("  Ada Lovelace ")).toBe("Ada Lovelace");
+    });
+
+    it("returns null for empty or non-string values", () => {
+        expect(normalizeDisplayName("   ")).toBeNull();
+        expect(normalizeDisplayName("")).toBeNull();
+        expect(normalizeDisplayName(null)).toBeNull();
+        expect(normalizeDisplayName(7)).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// loadProfileUsersByEmail
+// ---------------------------------------------------------------------------
+
+describe("loadProfileUsersByEmail", () => {
+    it("indexes profiles by normalized email and by id", async () => {
+        const db = makeDb([
+            { user_id: "u1", email: "Alice@Example.com", display_name: " Alice " },
+            { user_id: "u2", email: "bob@example.com", display_name: null },
+        ]);
+        const { userByEmail, userById } = await loadProfileUsersByEmail(
+            db as any,
+        );
+        expect(userByEmail.get("alice@example.com")).toEqual({
+            id: "u1",
+            email: "alice@example.com",
+            display_name: "Alice",
+        });
+        expect(userById.get("u2")).toEqual({
+            id: "u2",
+            email: "bob@example.com",
+            display_name: null,
+        });
+        expect(userByEmail.size).toBe(2);
+    });
+
+    it("skips rows whose email normalizes to empty", async () => {
+        const db = makeDb([
+            { user_id: "u1", email: "   ", display_name: null },
+            { user_id: "u2", email: "ok@example.com", display_name: null },
+        ]);
+        const { userByEmail } = await loadProfileUsersByEmail(db as any);
+        expect(userByEmail.size).toBe(1);
+        expect(userByEmail.has("ok@example.com")).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// findProfileUserByEmail
+// ---------------------------------------------------------------------------
+
+describe("findProfileUserByEmail", () => {
+    const rows = [
+        { user_id: "u1", email: "alice@example.com", display_name: "Alice" },
+    ];
+
+    it("finds a profile by normalized email", async () => {
+        const db = makeDb(rows);
+        await expect(
+            findProfileUserByEmail(db as any, "  ALICE@example.com "),
+        ).resolves.toEqual({
+            id: "u1",
+            email: "alice@example.com",
+            display_name: "Alice",
+        });
+    });
+
+    it("returns null when no profile matches", async () => {
+        const db = makeDb(rows);
+        await expect(
+            findProfileUserByEmail(db as any, "missing@example.com"),
+        ).resolves.toBeNull();
+    });
+
+    it("returns null without querying for empty input", async () => {
+        const db = makeDb(rows);
+        await expect(findProfileUserByEmail(db as any, "   ")).resolves.toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// findMissingUserEmails
+// ---------------------------------------------------------------------------
+
+describe("findMissingUserEmails", () => {
+    const db = makeDb([
+        { user_id: "u1", email: "alice@example.com", display_name: null },
+    ]);
+
+    it("returns only emails with no matching profile", async () => {
+        await expect(
+            findMissingUserEmails(db as any, [
+                "Alice@Example.com",
+                "carol@example.com",
+            ]),
+        ).resolves.toEqual(["carol@example.com"]);
+    });
+
+    it("dedupes and drops empty entries before querying", async () => {
+        await expect(
+            findMissingUserEmails(db as any, [
+                "carol@example.com",
+                " CAROL@example.com ",
+                "",
+                "   ",
+            ]),
+        ).resolves.toEqual(["carol@example.com"]);
+    });
+
+    it("returns [] for an empty input list", async () => {
+        await expect(findMissingUserEmails(db as any, [])).resolves.toEqual([]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// syncProfileEmail
+// ---------------------------------------------------------------------------
+
+describe("syncProfileEmail", () => {
+    it("inserts a profile row when none exists", async () => {
+        const db = makeDb([]);
+        const result = await syncProfileEmail(db as any, "u1", "New@Example.com");
+        expect(result).toBeNull();
+        expect(db.tables.user_profiles).toEqual([
+            { user_id: "u1", email: "new@example.com" },
+        ]);
+    });
+
+    it("is a no-op when the stored email already matches (case-insensitive)", async () => {
+        const db = makeDb([
+            { user_id: "u1", email: "Same@Example.com", display_name: null },
+        ]);
+        const result = await syncProfileEmail(db as any, "u1", "same@example.com");
+        expect(result).toBeNull();
+        expect(db.tables.user_profiles[0].email).toBe("Same@Example.com");
+    });
+
+    it("updates the stored email when it changed", async () => {
+        const db = makeDb([
+            { user_id: "u1", email: "old@example.com", display_name: null },
+        ]);
+        const result = await syncProfileEmail(db as any, "u1", "New@Example.com");
+        expect(result).toBeNull();
+        expect(db.tables.user_profiles[0].email).toBe("new@example.com");
+        expect(db.tables.user_profiles[0].updated_at).toEqual(expect.any(String));
+    });
+
+    it("returns null without touching the table for missing inputs", async () => {
+        const db = makeDb([]);
+        await expect(syncProfileEmail(db as any, "", "a@b.com")).resolves.toBeNull();
+        await expect(syncProfileEmail(db as any, "u1", null)).resolves.toBeNull();
+        await expect(syncProfileEmail(db as any, "u1", "   ")).resolves.toBeNull();
+        expect(db.tables.user_profiles).toEqual([]);
+    });
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -16,5 +16,5 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/__tests__/**"]
 }

--- a/backend/vitest.config.mts
+++ b/backend/vitest.config.mts
@@ -1,0 +1,36 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        environment: "node",
+        include: ["src/**/*.test.ts"],
+        exclude: ["dist/**", "node_modules/**"],
+        // Generous timeouts so cold-start module transform/import latency
+        // can't cause spurious timeout failures on a cold CI runner. Warm
+        // tests finish in ~1s; this only guards the pathological cold case —
+        // it does not mask hangs.
+        testTimeout: 20000,
+        hookTimeout: 20000,
+        coverage: {
+            provider: "v8",
+            reporter: ["text", "lcov"],
+            include: ["src/lib/**"],
+            // No-regression RATCHET floor, not a target. src/lib/** spans the
+            // small, tested libs (access, storage keys/dispositions,
+            // downloadTokens, userApiKeys provider/env checks, chat doc
+            // resolution) AND the large, still-untested feature libs
+            // (courtlistener, mcp, chat tool dispatch, llm providers,
+            // spreadsheet/docx handling), so the global number is low.
+            // Measured on this tree: 2.58% statements, 2.00% branches,
+            // 4.61% functions, 2.58% lines. These floors sit just below
+            // that (rounded down to whole percents) so CI fails on a
+            // *drop*; raise them as the feature-lib backlog gets covered.
+            thresholds: {
+                statements: 2,
+                branches: 2,
+                functions: 4,
+                lines: 2,
+            },
+        },
+    },
+});

--- a/backend/vitest.config.mts
+++ b/backend/vitest.config.mts
@@ -16,20 +16,22 @@ export default defineConfig({
             reporter: ["text", "lcov"],
             include: ["src/lib/**"],
             // No-regression RATCHET floor, not a target. src/lib/** spans the
-            // small, tested libs (access, storage keys/dispositions,
-            // downloadTokens, userApiKeys provider/env checks, chat doc
-            // resolution) AND the large, still-untested feature libs
-            // (courtlistener, mcp, chat tool dispatch, llm providers,
-            // spreadsheet/docx handling), so the global number is low.
-            // Measured on this tree: 2.58% statements, 2.00% branches,
-            // 4.61% functions, 2.58% lines. These floors sit just below
-            // that (rounded down to whole percents) so CI fails on a
-            // *drop*; raise them as the feature-lib backlog gets covered.
+            // tested libs (access, storage keys/dispositions, downloadTokens,
+            // userApiKeys provider/env checks, chat doc resolution, safeError,
+            // llm model resolution, chat citations, userLookup,
+            // documentVersions, userDataCleanup) AND the large, still-untested
+            // feature libs (courtlistener, mcp, chat tool dispatch, llm
+            // providers, spreadsheet/docx handling), so the global number is
+            // still low. Measured on this tree: 11.18% statements, 10.98%
+            // branches, 14.43% functions, 10.91% lines. These floors sit just
+            // below that (rounded down to whole percents) so CI fails on a
+            // *drop*. Floors only go up: when you add tests, raise them in the
+            // same PR. Backlog + per-area status: docs/testing-coverage.md.
             thresholds: {
-                statements: 2,
-                branches: 2,
-                functions: 4,
-                lines: 2,
+                statements: 11,
+                branches: 10,
+                functions: 14,
+                lines: 10,
             },
         },
     },

--- a/docs/testing-coverage.md
+++ b/docs/testing-coverage.md
@@ -1,0 +1,122 @@
+# Backend unit-test coverage
+
+The backend has a Vitest unit-test harness over `backend/src/lib/**`. This doc
+tracks what is covered, what still needs tests, and how the coverage ratchet
+works — so you can pick up a checkbox below and land it as a small PR.
+
+## Running the tests
+
+```bash
+cd backend
+npm install
+npm test              # run all unit tests
+npm run test:coverage # same, plus the per-file coverage table + floor check
+```
+
+Tests live in `backend/src/lib/__tests__/*.test.ts`. Read a couple of the
+existing suites first (`access.test.ts`, `userDataCleanup.test.ts`) and match
+their conventions: plain in-memory Supabase query mocks (no network, no real
+database), one `describe` block per exported function, and tests that assert
+current behavior.
+
+## Current coverage (measured 2026-07)
+
+Per-area statement coverage from `npm run test:coverage`:
+
+| Lib area | % statements | Tested? |
+| --- | ---: | :---: |
+| `lib/safeError.ts` | 100 | ✓ |
+| `lib/userDataCleanup.ts` | 100 | ✓ |
+| `lib/llm/models.ts` | 100 | ✓ |
+| `lib/documentVersions.ts` | 98 | ✓ |
+| `lib/chat/citations.ts` | 98 | ✓ |
+| `lib/userLookup.ts` | 91 | ✓ |
+| `lib/downloadTokens.ts` | 87 | ✓ |
+| `lib/chat/types.ts` | 85 | ✓ |
+| `lib/access.ts` | 76 | ✓ |
+| `lib/storage.ts` | 33 | partial — key/disposition helpers only |
+| `lib/userApiKeys.ts` | 13 | partial — provider/env helpers only |
+| `lib/documentTypes.ts`, `lib/userSettings.ts`, `lib/upload.ts`, `lib/officeText.ts` | 0 | ✗ |
+| `lib/convert.ts`, `lib/spreadsheet.ts`, `lib/docxTrackedChanges.ts` | 0 | ✗ |
+| `lib/userDataExport.ts` | 0 | ✗ |
+| `lib/courtlistener.ts`, `lib/systemWorkflows.ts` | 0 | ✗ |
+| `lib/chat/prompts.ts`, `lib/chat/contextBuilders.ts`, `lib/chat/streaming.ts` | 0 | ✗ |
+| `lib/chat/tools/**` (schemas, documentOps, toolDispatcher) | 0 | ✗ |
+| `lib/llm/**` (providers, tools, index, rawStreamLog) | ~4 | ✗ (only models.ts) |
+| `lib/mcp/**` (client, servers, oauth, types) | 0 | ✗ |
+
+Global: **11.18% statements / 10.98% branches / 14.43% functions / 10.91%
+lines**. The global number is low because `src/lib/**` includes several very
+large feature libs (toolDispatcher, documentOps, systemWorkflows,
+courtlistener, docxTrackedChanges) that dominate the line count.
+
+## TODO — untested libs, in priority order
+
+Each item is meant to be one self-contained PR: add the suite, then raise the
+floors in `backend/vitest.config.mts` to just below the new measured numbers.
+Size is a rough guess: S ≈ an hour, M ≈ an afternoon.
+
+- [ ] `lib/documentTypes.ts` — pure catalog/lookup of document types; assert
+      known types resolve and unknown inputs fall back sanely. (S)
+- [ ] `lib/chat/prompts.ts` — pure prompt builders; assert key instructions and
+      interpolated values appear in the output strings. (S)
+- [ ] `lib/userSettings.ts` — title/tabular model resolution from which API
+      keys a user has; reuse the Supabase mock pattern from
+      `userLookup.test.ts`. (S)
+- [ ] `lib/upload.ts` — multer wrapper: assert LIMIT_FILE_SIZE maps to a 413
+      with the right message and other errors pass through. (S)
+- [ ] `lib/officeText.ts` — office XML text extraction; build a tiny in-memory
+      zip fixture with JSZip and assert extracted/decoded text. (S)
+- [ ] `lib/chat/tools/toolSchemas.ts` — assert every tool schema has a name,
+      description, and well-formed parameters (guards against schema drift). (S)
+- [ ] `lib/userApiKeys.ts` (rest) — encrypt/decrypt round-trip and DB
+      load/store paths with a mocked Supabase client. (M)
+- [ ] `lib/storage.ts` (rest) — S3 upload/download/list/delete wrappers with a
+      mocked AWS SDK client. (M)
+- [ ] `lib/userDataExport.ts` — export assembly: given seeded mock tables,
+      assert the export contains the user's data and nobody else's. (M)
+- [ ] `lib/spreadsheet.ts` — parse a small in-memory xlsx fixture; assert sheet
+      and cell extraction, including empty/edge cells. (M)
+- [ ] `lib/chat/contextBuilders.ts` — context assembly from doc stores; assert
+      doc labels, truncation, and ordering. (M)
+- [ ] `lib/docxTrackedChanges.ts` — tracked-changes XML round-trip on a minimal
+      docx fixture: insert/delete runs, accept/reject. High value: document
+      integrity. (M)
+- [ ] `lib/courtlistener.ts` — API client with mocked fetch: query building,
+      pagination, and error paths. Legal-research correctness. (M)
+- [ ] `lib/systemWorkflows.ts` — mostly data: assert workflow definitions are
+      well-formed (unique ids, non-empty skill markdown). (S)
+- [ ] `lib/llm/tools.ts` + `lib/llm/index.ts` — provider-neutral tool plumbing
+      and provider selection with mocked provider modules. (M)
+- [ ] `lib/mcp/types.ts` + `lib/mcp/servers.ts` — server config validation and
+      allow-listing logic; security relevant. (M)
+- [ ] `lib/mcp/client.ts` + `lib/mcp/oauth.ts` — connection lifecycle and OAuth
+      token handling with a mocked MCP SDK; security relevant. (M)
+- [ ] `lib/llm/rawStreamLog.ts` — log path construction and redaction with a
+      mocked fs. (S)
+- [ ] `lib/chat/tools/documentOps.ts` — start with the pure helpers (diff/match
+      utilities), not the full tool handlers. (M)
+- [ ] `lib/chat/tools/toolDispatcher.ts` — dispatch table routing and argument
+      validation with stubbed tools; don't try to cover every tool body. (M)
+- [ ] `lib/chat/streaming.ts` + `lib/llm/{claude,gemini,openai}.ts` — streaming
+      loops and provider adapters; hardest to unit test, consider extracting
+      pure chunk-parsing helpers first. (M)
+
+Not worth unit testing directly: `lib/supabase.ts` and `lib/convert.ts` are
+thin wrappers around external services (Supabase auth, LibreOffice); they are
+better exercised by the e2e suite.
+
+## Ratchet policy
+
+`backend/vitest.config.mts` enforces global coverage **floors** (currently
+statements 11 / branches 10 / functions 14 / lines 10). They are a
+no-regression ratchet, not a target:
+
+- **Floors only go up.** Never lower them to get a PR green — that means your
+  change removed tested behavior or added a large untested lib; add tests
+  instead.
+- **Raise them in the same PR that adds tests.** After your suite passes, run
+  `npm run test:coverage`, take the new global numbers, and set each floor to
+  the measured value rounded down to a whole percent.
+- Keep the measured numbers in the config comment and the table above honest
+  when you do.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "mike",
             "version": "0.1.0",
+            "license": "AGPL-3.0-only",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.1025.0",
                 "@aws-sdk/s3-request-presigner": "^3.1025.0",
@@ -68,6 +69,7 @@
                 "tailwindcss": "^4",
                 "tw-animate-css": "^1.4.0",
                 "typescript": "^5",
+                "vitest": "^4.1.9",
                 "wrangler": "^4.90.0"
             }
         },
@@ -1872,21 +1874,21 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
+                "@emnapi/wasi-threads": "1.2.2",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -1894,9 +1896,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -3986,6 +3988,16 @@
                 "zod": "^3.25.0 || ^4.0.0"
             }
         },
+        "node_modules/@oxc-project/types": {
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@poppinss/colors": {
             "version": "4.1.6",
             "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
@@ -4648,6 +4660,289 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
             "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+            "license": "MIT"
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.3"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@rtsao/scc": {
@@ -6304,14 +6599,25 @@
             "license": "MIT"
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
             }
         },
         "node_modules/@types/d3-array": {
@@ -6385,6 +6691,13 @@
             "dependencies": {
                 "@types/ms": "*"
             }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
@@ -7201,6 +7514,92 @@
                 "win32"
             ]
         },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@xmldom/xmldom": {
             "version": "0.8.12",
             "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
@@ -7582,6 +7981,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/ast-types-flow": {
@@ -8035,6 +8444,16 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/chainsaw": {
@@ -9145,6 +9564,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -9745,6 +10171,16 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -9843,6 +10279,16 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/express": {
@@ -14066,6 +14512,20 @@
             "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
             "license": "MIT"
         },
+        "node_modules/obug": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+            "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
         "node_modules/on-finished": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -14365,9 +14825,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -14393,9 +14853,9 @@
             "license": "MIT-0"
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.20",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+            "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
             "dev": true,
             "funding": [
                 {
@@ -14413,7 +14873,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -14422,9 +14882,9 @@
             }
         },
         "node_modules/postcss/node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {
@@ -15500,6 +15960,40 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/rolldown": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.139.0",
+                "@rolldown/pluginutils": "^1.0.0"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
+            }
+        },
         "node_modules/rope-sequence": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
@@ -15935,6 +16429,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/signal-exit": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -15992,6 +16493,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/standardwebhooks": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
@@ -16010,6 +16518,13 @@
             "engines": {
                 "node": ">= 0.8"
             }
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
@@ -16440,21 +16955,48 @@
             "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
             "license": "MIT"
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/tiptap-markdown": {
@@ -17201,6 +17743,713 @@
                 "d3-timer": "^3.0.1"
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+            "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-arm": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+            "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+            "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+            "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+            "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+            "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+            "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+            "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+            "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+            "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+            "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+            "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+            "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+            "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+            "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+            "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+            "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+            "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+            "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+            "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/esbuild": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+            "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.1",
+                "@esbuild/android-arm": "0.28.1",
+                "@esbuild/android-arm64": "0.28.1",
+                "@esbuild/android-x64": "0.28.1",
+                "@esbuild/darwin-arm64": "0.28.1",
+                "@esbuild/darwin-x64": "0.28.1",
+                "@esbuild/freebsd-arm64": "0.28.1",
+                "@esbuild/freebsd-x64": "0.28.1",
+                "@esbuild/linux-arm": "0.28.1",
+                "@esbuild/linux-arm64": "0.28.1",
+                "@esbuild/linux-ia32": "0.28.1",
+                "@esbuild/linux-loong64": "0.28.1",
+                "@esbuild/linux-mips64el": "0.28.1",
+                "@esbuild/linux-ppc64": "0.28.1",
+                "@esbuild/linux-riscv64": "0.28.1",
+                "@esbuild/linux-s390x": "0.28.1",
+                "@esbuild/linux-x64": "0.28.1",
+                "@esbuild/netbsd-arm64": "0.28.1",
+                "@esbuild/netbsd-x64": "0.28.1",
+                "@esbuild/openbsd-arm64": "0.28.1",
+                "@esbuild/openbsd-x64": "0.28.1",
+                "@esbuild/openharmony-arm64": "0.28.1",
+                "@esbuild/sunos-x64": "0.28.1",
+                "@esbuild/win32-arm64": "0.28.1",
+                "@esbuild/win32-ia32": "0.28.1",
+                "@esbuild/win32-x64": "0.28.1"
+            }
+        },
+        "node_modules/vitest/node_modules/vite": {
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.17",
+                "rolldown": "~1.1.5",
+                "tinyglobby": "^0.2.17"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.3.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/w3c-keyname": {
             "version": "2.2.8",
             "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -17351,6 +18600,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
         "build": "next build",
         "start": "next start",
         "lint": "eslint",
+        "test": "vitest run",
         "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
         "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
         "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
@@ -73,6 +74,7 @@
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5",
+        "vitest": "^4.1.9",
         "wrangler": "^4.90.0"
     },
     "license": "AGPL-3.0-only"

--- a/frontend/src/app/lib/utils.test.ts
+++ b/frontend/src/app/lib/utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { cn, diceCoefficient, isFuzzyMatch } from "./utils";
+
+describe("cn", () => {
+    it("joins truthy class names and drops falsy ones", () => {
+        expect(cn("a", false && "b", undefined, "c")).toBe("a c");
+    });
+
+    it("merges conflicting tailwind classes, keeping the last", () => {
+        expect(cn("px-2", "px-4")).toBe("px-4");
+    });
+});
+
+describe("diceCoefficient", () => {
+    it("returns 1 for identical strings (ignoring case and punctuation)", () => {
+        expect(diceCoefficient("Hello, World!", "hello world")).toBe(1);
+    });
+
+    it("returns 0 when either input is empty", () => {
+        expect(diceCoefficient("", "anything")).toBe(0);
+        expect(diceCoefficient("anything", "")).toBe(0);
+    });
+
+    it("returns a partial score for partially overlapping strings", () => {
+        const score = diceCoefficient("night", "nacht");
+        expect(score).toBeGreaterThan(0);
+        expect(score).toBeLessThan(1);
+    });
+});
+
+describe("isFuzzyMatch", () => {
+    it("matches near-identical strings above the default threshold", () => {
+        expect(isFuzzyMatch("organization", "organisation")).toBe(true);
+    });
+
+    it("rejects clearly different strings", () => {
+        expect(isFuzzyMatch("apple", "zebra")).toBe(false);
+    });
+
+    it("respects a custom threshold", () => {
+        // "night" vs "nacht" scores ~0.25 — passes a low bar, fails a high one.
+        expect(isFuzzyMatch("night", "nacht", 0.1)).toBe(true);
+        expect(isFuzzyMatch("night", "nacht", 0.9)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Follow-up to #229: adds six unit suites (102 new tests, 165 total) for the highest-risk untested backend libs, raises the coverage ratchet floors to match, and adds `docs/testing-coverage.md` — a prioritized, checkbox-style backlog so any contributor can pick up the next lib.

## Changes

New suites in `backend/src/lib/__tests__/`, following the existing in-memory Supabase mock conventions:

- `userDataCleanup.test.ts` (11 tests) — destructive account/project deletes: cascade order, ownership scoping (requesting another user's project deletes nothing of theirs), shared_with email scrubbing, storage-file cleanup, best-effort prefix cleanup, error propagation.
- `documentVersions.test.ts` (15) — document integrity: active-version resolution, cross-document versionId spoof guard, soft-delete filtering, `Untitled document` fallbacks, max assistant_edit version numbers.
- `citations.test.ts` (28) — legal-citation parsing: CITATIONS block diagnostics, document + case citation normalization (marker refs, page ranges, quote limits, sheet/cell locators, opinion metadata), the streaming partial-object parser (escapes, braces-in-strings, close-tag handling), and citation payload assembly.
- `safeError.test.ts` (21) — secret redaction: provider key patterns (sk-, sk-ant-, AIza), labeled secrets, the OpenAI "Incorrect API key provided" message, and safeErrorMessage/safeErrorLog fallbacks.
- `llmModels.test.ts` (11) — provider inference and model-id resolution across the full catalog; asserts every default model is resolvable.
- `userLookup.test.ts` (16) — email normalization, profile indexing, missing-email detection, and syncProfileEmail insert/no-op/update paths.

Plus:

- `backend/vitest.config.mts` — ratchet floors raised, comment updated, links the roadmap doc.
- `docs/testing-coverage.md` — how to run coverage, per-area status table, prioritized TODO checklist (each with a what-to-test hint and S/M size), and the ratchet policy.

## Why

These libs were chosen by risk, not by ease: `userDataCleanup` performs irreversible bulk deletes, `documentVersions` gates every read-from-storage path, `citations` is the core legal-citation product surface, `safeError` prevents API-key leakage into responses/logs, and `models`/`userLookup` sit on every request path. All were at 0% coverage.

Coverage (global over `backend/src/lib/**`):

| Metric | Before | After | New floor |
| --- | ---: | ---: | ---: |
| Statements | 2.58% | 11.18% | 11 |
| Branches | 2.00% | 10.98% | 10 |
| Functions | 4.61% | 14.43% | 14 |
| Lines | 2.58% | 10.91% | 10 |

The remaining untested libs are enumerated in `docs/testing-coverage.md` as a checkbox backlog, so contributors can take one checkbox per PR and keep ratcheting the floors up.

## Testing

- `npm test` — 11 files, 165 tests, all green.
- `npm run test:coverage` — passes the new 11/10/14/10 floors.
- `npm run build` — clean (test files stay excluded from tsc).

Note: this branch stacks on #229 (it includes the #228 + #229 commits — please review the top commit only; I'll Graphite-restack once write access allows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
