### PR TITLE
[Fix 01] Batch the directory modal's project fetch (N+1 getProject storm)

### DIFF
--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -152,9 +152,16 @@ async function attachChatCreatorLabels(
 }
 
 // GET /projects
+// Pass ?include=documents to also receive each project's documents in the
+// same response. The directory pickers (useDirectoryData) previously fanned
+// out one GET /projects/:id per project to obtain those documents; with N
+// projects that burst — auth check plus several DB queries per request —
+// could overwhelm the Supabase gateway. Batching keeps it at one request
+// and a fixed number of queries regardless of project count.
 projectsRouter.get("/", requireAuth, async (req, res) => {
   const userId = res.locals.userId as string;
   const userEmail = res.locals.userEmail as string | undefined;
+  const includeDocuments = req.query.include === "documents";
   const db = createServerSupabase();
 
   const { data, error } = await db.rpc("get_projects_overview", {
@@ -163,7 +170,45 @@ projectsRouter.get("/", requireAuth, async (req, res) => {
   });
   if (error) return void res.status(500).json({ detail: error.message });
 
-  res.json(data ?? []);
+  const projects = (data ?? []) as { id: string }[];
+  if (!includeDocuments || projects.length === 0) {
+    return void res.json(projects);
+  }
+
+  const { data: docs, error: docsError } = await db
+    .from("documents")
+    .select("*")
+    .in(
+      "project_id",
+      projects.map((p) => p.id),
+    )
+    .order("created_at", { ascending: true });
+  if (docsError)
+    return void res.status(500).json({ detail: docsError.message });
+
+  const docsTyped = (docs ?? []) as unknown as {
+    id: string;
+    project_id?: string | null;
+    user_id?: string | null;
+    current_version_id?: string | null;
+  }[];
+  await attachLatestVersionNumbers(db, docsTyped);
+  await attachActiveVersionPaths(db, docsTyped);
+  await attachDocumentOwnerLabels(db, docsTyped);
+
+  const docsByProject = new Map<string, typeof docsTyped>();
+  for (const doc of docsTyped) {
+    if (!doc.project_id) continue;
+    const bucket = docsByProject.get(doc.project_id);
+    if (bucket) bucket.push(doc);
+    else docsByProject.set(doc.project_id, [doc]);
+  }
+  res.json(
+    projects.map((p) => ({
+      ...p,
+      documents: docsByProject.get(p.id) ?? [],
+    })),
+  );
 });
 
 // POST /projects

--- a/frontend/src/app/components/shared/useDirectoryData.ts
+++ b/frontend/src/app/components/shared/useDirectoryData.ts
@@ -1,11 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-    getLibrary,
-    getProject,
-    listProjects,
-} from "@/app/lib/mikeApi";
+import { getLibrary, listProjects } from "@/app/lib/mikeApi";
 import type { Document, LibraryFolder, Project } from "./types";
 
 export type DirectoryTab = "files" | "templates" | "projects";
@@ -45,17 +41,14 @@ async function loadTemplates() {
 }
 
 async function loadProjects() {
-    const projects = await listProjects();
-    const fullProjects = await Promise.all(
-        projects.map((project) => getProject(project.id)),
-    );
-    const projectCounts = new Map(
-        projects.map((project) => [project.id, project.document_count ?? 0]),
-    );
-    return fullProjects.map((project) => ({
+    // One batched request. Fanning out getProject(id) per project caused an
+    // N+1 burst on every directory-modal open that could overwhelm the
+    // Supabase gateway once an account had accumulated projects.
+    const projects = await listProjects({ includeDocuments: true });
+    return projects.map((project) => ({
         ...project,
         document_count:
-            project.documents?.length ?? projectCounts.get(project.id) ?? 0,
+            project.documents?.length ?? project.document_count ?? 0,
     }));
 }
 

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -163,8 +163,11 @@ async function toApiError(response: Response, path: string) {
 // Projects
 // ---------------------------------------------------------------------------
 
-export async function listProjects(): Promise<Project[]> {
-    return apiRequest<Project[]>("/projects");
+export async function listProjects(options?: {
+    includeDocuments?: boolean;
+}): Promise<Project[]> {
+    const query = options?.includeDocuments ? "?include=documents" : "";
+    return apiRequest<Project[]>(`/projects${query}`);
 }
 
 export async function createProject(


### PR DESCRIPTION
## Summary
Every directory picker (Add Documents modal, Use Workflow modal, the assistant project selector) loads its Projects tab through `useDirectoryData`, which fired one `GET /projects/:id` for **every existing project** the moment the modal opened. Each of those requests costs a GoTrue auth verification plus ~6 PostgREST queries, so an account with N projects hit the Supabase gateway with an ~8xN-request burst per modal open. This PR replaces the fan-out with a single batched request.

## Changes
- `backend/src/routes/projects.ts`: `GET /projects` accepts `?include=documents` and returns each project's documents from **one** batched `documents` query (`.in("project_id", ...)`), running the same attach helpers as `GET /projects/:id` once across all documents. Response shape without the flag is unchanged.
- `frontend/src/app/lib/mikeApi.ts`: `listProjects()` takes an optional `{ includeDocuments }`.
- `frontend/src/app/components/shared/useDirectoryData.ts`: `loadProjects()` makes one `listProjects({ includeDocuments: true })` call instead of `listProjects()` + `Promise.all(projects.map(getProject))`.

## Why
The burst is not just slow — it takes the gateway down. Reproduced against the Supabase CLI stack with a 43-project account: overlapping modal-open storms (6 concurrent opens, 8 rounds, a project-create POST fired mid-burst each time, i.e. exactly what the e2e suite does) drove GoTrue into Postgres connection exhaustion — `failed to connect to host=supabase_db_mike user=supabase_auth_admin ... context deadline exceeded` — producing **467x 500 + 641x 504 on `/auth/v1/user`** in a single run; 38/48 project creates and 1458/2064 project GETs failed. On slower CI runners Kong surfaces the same collapse as the intermittent 502 ("An invalid response was received from the upstream server") that the e2e suite (#220) had to retry around. Real users with accumulated projects hit the same wall.

## Testing
- Same storm harness after the fix (one batched request per modal open, same overlap and mid-burst POSTs): **0 failures** — 48/48 GETs and 48/48 creates OK, zero 5xx anywhere in the gateway logs.
- Backend `tsc --noEmit` clean; frontend production build clean.
- Full Playwright e2e suite run 5x consecutively against a production build with this fix (including 3 runs after the retry scaffolding was stripped from the specs in #220): 23/23 non-LLM specs green every run, zero Playwright retries, with ~40 accumulated projects in the test account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)