### PR TITLE
ci: guard against silently merge-corrupted lockfiles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Lockfiles are generated files. Git's line-level text merge can combine
+# both sides' insertions into syntactically invalid JSON *without raising a
+# conflict* (this silently broke backend/package.json + package-lock.json in
+# PR #233). Merge them as binary so any concurrent change surfaces as an
+# explicit conflict; resolve by taking main's copy and regenerating:
+#   git checkout origin/main -- package-lock.json && npm install
+package-lock.json merge=binary
+bun.lock merge=binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
           cache: npm
           cache-dependency-path: backend/package-lock.json
 
+      # Git's line-level merge can splice both sides of package(-lock).json
+      # into invalid JSON without a conflict (bit PR #233). npm's own error
+      # for an unparseable lockfile is the misleading "npm ci can only
+      # install with an existing package-lock.json" — fail fast with the real
+      # reason instead.
+      - name: Validate package.json and lockfile parse
+        run: node -e "for (const f of ['package.json','package-lock.json']) JSON.parse(require('fs').readFileSync(f, 'utf8'))"
+
       - run: npm ci
 
       # No-ops on a tree without a "test" script (e.g. before the vitest
@@ -54,6 +62,10 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
+
+      # Same silent-merge-corruption guard as the backend job.
+      - name: Validate package.json and lockfile parse
+        run: node -e "for (const f of ['package.json','package-lock.json']) JSON.parse(require('fs').readFileSync(f, 'utf8'))"
 
       - run: npm ci
 


### PR DESCRIPTION
## What happened on #233

The backend CI job on #233 failed at `npm ci` with:

> The `npm ci` command can only install with an existing package-lock.json …

The lockfile **did** exist. The real cause: a `Merge branch 'main'` commit on the PR branch auto-merged `backend/package.json` and `backend/package-lock.json` — both modified on each side — and git's line-level text merge spliced the two versions into **syntactically invalid JSON without raising a conflict**:

- `package.json` lost the comma after the branch's new `"test:stack"` script, right where main's `"test:coverage"` line was merged in.
- `package-lock.json` lost the two closing-brace lines of the `supertest/cookie-signature` entry, where both sides had inserted different package entries at the same alphabetical position.

npm (Arborist) swallows the lockfile parse error and treats the file as absent, hence the misleading "no existing package-lock.json" message. Since git saw no conflict, GitHub showed the branch as cleanly mergeable — nothing looked wrong until npm tried to read the file. (The immediate breakage is fixed on the #233 branch itself; this PR is the prevention.)

## Prevention (this PR)

1. **`.gitattributes`: `merge=binary` for `package-lock.json` and `bun.lock`.** Generated files shouldn't be text-merged. With the binary driver, any concurrent change surfaces as an explicit conflict, and the documented resolution is to regenerate (`git checkout origin/main -- package-lock.json && npm install`) instead of hand-merging.
2. **CI parse-check before `npm ci`** in both backend and frontend jobs: `JSON.parse` on `package.json` and `package-lock.json`. If corruption ever lands anyway, CI fails in one second with the actual reason instead of npm's misleading usage error.

## Habits that keep this away

- After merging `main` into a PR branch that touches dependencies, regenerate the lockfile rather than trusting the merge result, and re-run `npm ci` locally.
- Treat any lockfile diff a merge produced as suspect — it's generated output; only `npm install` should write it.

Verified: `node -e "JSON.parse(...)"` passes on both files at main; the workflow change is additive and job-local, so it's safe on trees with or without the other pending test PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)