### PR TITLE
[Security 1/9] SSRF guardrails for server-side connector fetches

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,7 @@
         "multer": "^1.4.5-lts.2",
         "pdfjs-dist": "^4.10.38",
         "resend": "^4.5.1",
+        "undici": "^6.27.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
         "zod": "^3.25.76"
       },
@@ -6953,6 +6954,15 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "multer": "^1.4.5-lts.2",
     "pdfjs-dist": "^4.10.38",
     "resend": "^4.5.1",
+    "undici": "^6.27.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^3.25.76"
   },

--- a/backend/src/lib/__tests__/privateIp.test.ts
+++ b/backend/src/lib/__tests__/privateIp.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { isBlockedIp, isPrivateIpv4, isPrivateIpv6 } from "../privateIp";
+
+describe("private/reserved IP classification", () => {
+    it.each([
+        "0.0.0.0",
+        "10.0.0.1",
+        "100.64.0.1",
+        "127.0.0.1",
+        "169.254.169.254",
+        "172.16.0.1",
+        "192.0.0.1",
+        "192.0.2.1",
+        "192.88.99.1",
+        "192.168.0.1",
+        "198.18.0.1",
+        "198.51.100.1",
+        "203.0.113.1",
+        "224.0.0.1",
+        "240.0.0.1",
+        "255.255.255.255",
+    ])("blocks non-global IPv4 address %s", (ip) => {
+        expect(isPrivateIpv4(ip)).toBe(true);
+        expect(isBlockedIp(ip)).toBe(true);
+    });
+
+    it.each(["8.8.8.8", "93.184.216.34", "192.31.196.1"])(
+        "allows globally reachable IPv4 address %s",
+        (ip) => {
+            expect(isPrivateIpv4(ip)).toBe(false);
+            expect(isBlockedIp(ip)).toBe(false);
+        },
+    );
+
+    it.each([
+        "::",
+        "::1",
+        "::ffff:8.8.8.8",
+        "::8.8.8.8",
+        "100::1",
+        "2001::1",
+        "2001:2::1",
+        "2001:10::1",
+        "2001:db8::1",
+        "2002::1",
+        "3fff::1",
+        "5f00::1",
+        "fc00::1",
+        "fd00::1",
+        "fe80::1",
+        "fec0::1",
+        "ff02::1",
+        "64:ff9b::10.0.0.1",
+        "64:ff9b:1::1",
+    ])("blocks non-global IPv6 address %s", (ip) => {
+        expect(isPrivateIpv6(ip)).toBe(true);
+        expect(isBlockedIp(ip)).toBe(true);
+    });
+
+    it.each([
+        "2606:4700:4700::1111",
+        "2001:4860:4860::8888",
+        "64:ff9b::8.8.8.8",
+    ])("allows globally reachable IPv6 address %s", (ip) => {
+        expect(isPrivateIpv6(ip)).toBe(false);
+        expect(isBlockedIp(ip)).toBe(false);
+    });
+
+    it.each(["1foo.2.3.4", "999.1.1.1", "not-an-ip"])(
+        "fails closed for malformed address %s",
+        (ip) => {
+            expect(isPrivateIpv4(ip)).toBe(true);
+            expect(isBlockedIp(ip)).toBe(true);
+        },
+    );
+});

--- a/backend/src/lib/mcp/__tests__/client.ssrf.test.ts
+++ b/backend/src/lib/mcp/__tests__/client.ssrf.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock DNS resolution so the SSRF guard is exercised deterministically without
+// touching the network. `lookupMock` is hoisted so the vi.mock factory can
+// reference it.
+const { lookupMock } = vi.hoisted(() => ({ lookupMock: vi.fn() }));
+vi.mock("dns/promises", () => ({
+    default: { lookup: lookupMock },
+}));
+
+import { guardedFetch, validateRemoteMcpUrl } from "../client";
+
+function resolvesTo(...addresses: string[]) {
+    lookupMock.mockResolvedValue(
+        addresses.map((address) => ({
+            address,
+            family: address.includes(":") ? 6 : 4,
+        })),
+    );
+}
+
+beforeEach(() => {
+    lookupMock.mockReset();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("validateRemoteMcpUrl", () => {
+    it("rejects non-HTTPS URLs", async () => {
+        await expect(validateRemoteMcpUrl("http://example.com/")).rejects.toThrow(
+            /HTTPS/,
+        );
+    });
+
+    it("rejects invalid URLs", async () => {
+        await expect(validateRemoteMcpUrl("not a url")).rejects.toThrow(
+            /valid URL/,
+        );
+    });
+
+    it("rejects localhost and metadata hosts without a DNS lookup", async () => {
+        for (const host of [
+            "https://localhost/",
+            "https://foo.localhost/",
+            "https://metadata.google.internal/",
+            "https://instance-data/",
+        ]) {
+            await expect(validateRemoteMcpUrl(host), host).rejects.toThrow(
+                /blocked host/,
+            );
+        }
+        expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects private IPv4/IPv6 literals without a DNS lookup", async () => {
+        for (const host of [
+            "https://127.0.0.1/",
+            "https://10.0.0.1/",
+            "https://169.254.169.254/",
+            "https://[::1]/",
+            "https://[fd00::1]/",
+        ]) {
+            await expect(validateRemoteMcpUrl(host), host).rejects.toThrow(
+                /blocked network address/,
+            );
+        }
+        expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects a hostname that resolves to a private address", async () => {
+        resolvesTo("10.0.0.5");
+        await expect(
+            validateRemoteMcpUrl("https://rebind.example.com/"),
+        ).rejects.toThrow(/blocked network address/);
+    });
+
+    it("rejects when ANY resolved address is private (mixed record set)", async () => {
+        resolvesTo("93.184.216.34", "192.168.1.1");
+        await expect(
+            validateRemoteMcpUrl("https://mixed.example.com/"),
+        ).rejects.toThrow(/blocked network address/);
+    });
+
+    it("accepts a public host and strips credentials/hash", async () => {
+        resolvesTo("93.184.216.34");
+        const out = await validateRemoteMcpUrl(
+            "https://user:secret@public.example.com/path?q=1#frag",
+        );
+        expect(out).toBe("https://public.example.com/path?q=1");
+        expect(out).not.toContain("secret");
+        expect(out).not.toContain("frag");
+    });
+});
+
+describe("guardedFetch", () => {
+    it("throws and never calls fetch when the URL fails validation", async () => {
+        resolvesTo("10.0.0.5");
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+        await expect(
+            guardedFetch("https://rebind.example.com/"),
+        ).rejects.toThrow(/blocked network address/);
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("disables redirects for public hosts", async () => {
+        resolvesTo("93.184.216.34");
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue(new Response("ok", { status: 200 }));
+
+        const res = await guardedFetch("https://public.example.com/x", {
+            method: "GET",
+        });
+        expect(res.status).toBe(200);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        const init = fetchSpy.mock.calls[0][1] as RequestInit;
+        expect(init.redirect).toBe("manual");
+        // Original request options are preserved.
+        expect(init.method).toBe("GET");
+    });
+});

--- a/backend/src/lib/mcp/__tests__/client.ssrf.test.ts
+++ b/backend/src/lib/mcp/__tests__/client.ssrf.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Agent } from "undici";
 
 // Mock DNS resolution so the SSRF guard is exercised deterministically without
 // touching the network. `lookupMock` is hoisted so the vi.mock factory can
@@ -104,7 +105,7 @@ describe("guardedFetch", () => {
         expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it("disables redirects for public hosts", async () => {
+    it("pins the connection (undici dispatcher) and disables redirects for public hosts", async () => {
         resolvesTo("93.184.216.34");
         const fetchSpy = vi
             .spyOn(globalThis, "fetch")
@@ -116,8 +117,11 @@ describe("guardedFetch", () => {
         expect(res.status).toBe(200);
         expect(fetchSpy).toHaveBeenCalledTimes(1);
 
-        const init = fetchSpy.mock.calls[0][1] as RequestInit;
+        const init = fetchSpy.mock.calls[0][1] as RequestInit & {
+            dispatcher?: unknown;
+        };
         expect(init.redirect).toBe("manual");
+        expect(init.dispatcher).toBeInstanceOf(Agent);
         // Original request options are preserved.
         expect(init.method).toBe("GET");
     });

--- a/backend/src/lib/mcp/__tests__/client.ssrf.test.ts
+++ b/backend/src/lib/mcp/__tests__/client.ssrf.test.ts
@@ -62,6 +62,11 @@ describe("validateRemoteMcpUrl", () => {
             "https://169.254.169.254/",
             "https://[::1]/",
             "https://[fd00::1]/",
+            // IPv4-compatible ::/96 embeds (deprecated per RFC 4291 but still
+            // parseable) — `::127.0.0.1` in hex, uncompressed, and dotted forms
+            "https://[::7f00:1]/",
+            "https://[0:0:0:0:0:0:7f00:1]/",
+            "https://[::10.0.0.1]/",
         ]) {
             await expect(validateRemoteMcpUrl(host), host).rejects.toThrow(
                 /blocked network address/,

--- a/backend/src/lib/mcp/__tests__/client.ssrf.test.ts
+++ b/backend/src/lib/mcp/__tests__/client.ssrf.test.ts
@@ -62,6 +62,12 @@ describe("validateRemoteMcpUrl", () => {
             "https://169.254.169.254/",
             "https://[::1]/",
             "https://[fd00::1]/",
+            "https://[fec0::1]/",
+            "https://[ff02::1]/",
+            "https://[100::1]/",
+            "https://[2001:db8::1]/",
+            "https://[3fff::1]/",
+            "https://[64:ff9b:1::1]/",
             // IPv4-compatible ::/96 embeds (deprecated per RFC 4291 but still
             // parseable) — `::127.0.0.1` in hex, uncompressed, and dotted forms
             "https://[::7f00:1]/",
@@ -110,7 +116,7 @@ describe("guardedFetch", () => {
         expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it("pins the connection (undici dispatcher) and disables redirects for public hosts", async () => {
+    it("reuses a pinned dispatcher and disables redirects for public hosts", async () => {
         resolvesTo("93.184.216.34");
         const fetchSpy = vi
             .spyOn(globalThis, "fetch")
@@ -129,5 +135,11 @@ describe("guardedFetch", () => {
         expect(init.dispatcher).toBeInstanceOf(Agent);
         // Original request options are preserved.
         expect(init.method).toBe("GET");
+
+        await guardedFetch("https://public.example.com/y");
+        const nextInit = fetchSpy.mock.calls[1][1] as RequestInit & {
+            dispatcher?: unknown;
+        };
+        expect(nextInit.dispatcher).toBe(init.dispatcher);
     });
 });

--- a/backend/src/lib/mcp/client.ts
+++ b/backend/src/lib/mcp/client.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto";
 import dns from "dns/promises";
 import net from "net";
+import { Agent } from "undici";
 import { isBlockedIp } from "../privateIp";
 import {
     BLOCKED_METADATA_HOSTS,
@@ -328,6 +329,50 @@ export function authConfigPatch(config: McpConnectorAuthConfig): Record<string, 
     });
 }
 
+// A per-request undici dispatcher whose DNS lookup runs the private-IP guard at
+// the moment the socket is opened and returns ONLY validated addresses. Because
+// undici connects to exactly what this lookup yields, the address we validate is
+// the address we connect to — there is no second, unguarded resolution for an
+// attacker to race (DNS-rebinding / TOCTOU). The URL hostname is untouched, so
+// the Host header and TLS SNI still reflect the real host and HTTPS verifies
+// normally against legitimate public servers.
+function pinnedGuardAgent(): Agent {
+    return new Agent({
+        connect: {
+            lookup: (hostname, _options, callback) => {
+                dns.lookup(hostname, { all: true, verbatim: true })
+                    .then((addresses) => {
+                        if (
+                            !addresses.length ||
+                            addresses.some(({ address }) => isBlockedIp(address))
+                        ) {
+                            callback(
+                                new Error(
+                                    "MCP server URL resolves to a blocked network address.",
+                                ),
+                                [],
+                            );
+                            return;
+                        }
+                        callback(null, addresses);
+                    })
+                    .catch((err: unknown) =>
+                        callback(
+                            err instanceof Error ? err : new Error(String(err)),
+                            [],
+                        ),
+                    );
+            },
+        },
+    });
+}
+
+// The single guarded egress helper for every outbound MCP request (connector
+// transport, OAuth discovery/registration/refresh). It rejects non-HTTPS,
+// credentialed, metadata-host and private-IP-literal URLs up front, pins the
+// connection to a connect-time-validated address, and refuses to auto-follow
+// redirects (`redirect: "manual"`) so a 3xx to an internal host cannot smuggle
+// egress past the guard.
 export async function guardedFetch(
     input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
@@ -339,7 +384,11 @@ export async function guardedFetch(
               ? input.toString()
               : input.url;
     await validateRemoteMcpUrl(url);
-    return fetch(input, { ...init, redirect: "manual" });
+    return fetch(input, {
+        ...init,
+        redirect: "manual",
+        dispatcher: pinnedGuardAgent(),
+    } as RequestInit);
 }
 
 export function base64Url(buffer: Buffer) {

--- a/backend/src/lib/mcp/client.ts
+++ b/backend/src/lib/mcp/client.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto";
 import dns from "dns/promises";
 import net from "net";
+import { isBlockedIp } from "../privateIp";
 import {
     BLOCKED_METADATA_HOSTS,
     HEADER_NAME_RE,
@@ -223,41 +224,8 @@ export function toConnectorSummary(
     };
 }
 
-function isPrivateIpv4(ip: string) {
-    const parts = ip.split(".").map((part) => Number.parseInt(part, 10));
-    if (parts.length !== 4 || parts.some((part) => !Number.isFinite(part))) {
-        return true;
-    }
-    const [a, b] = parts;
-    return (
-        a === 0 ||
-        a === 10 ||
-        a === 127 ||
-        (a === 100 && b >= 64 && b <= 127) ||
-        (a === 169 && b === 254) ||
-        (a === 172 && b >= 16 && b <= 31) ||
-        (a === 192 && b === 168) ||
-        (a === 192 && b === 0) ||
-        (a === 198 && (b === 18 || b === 19)) ||
-        a >= 224
-    );
-}
-
-function isPrivateIpv6(ip: string) {
-    const normalized = ip.toLowerCase();
-    if (normalized === "::1" || normalized === "::") return true;
-    if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
-    if (/^fe[89ab]:/.test(normalized)) return true;
-    const ipv4Tail = normalized.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-    return ipv4Tail ? isPrivateIpv4(ipv4Tail[1]) : false;
-}
-
-function isBlockedIp(ip: string) {
-    const family = net.isIP(ip);
-    if (family === 4) return isPrivateIpv4(ip);
-    if (family === 6) return isPrivateIpv6(ip);
-    return true;
-}
+// Private/reserved IP classification lives in lib/privateIp.ts so every
+// guarded egress check reuses the exact same ranges.
 
 export async function validateRemoteMcpUrl(rawUrl: string): Promise<string> {
     let url: URL;
@@ -282,9 +250,17 @@ export async function validateRemoteMcpUrl(rawUrl: string): Promise<string> {
         throw new Error("MCP server URL points to a blocked host.");
     }
 
-    const literalFamily = net.isIP(hostname);
+    // URL.hostname wraps IPv6 literals in brackets ("[::1]"), which net.isIP
+    // does not recognize. Strip them so an IPv6 literal is classified by the
+    // private-IP guard rather than falling through to a DNS lookup that would
+    // treat the bracketed form as an (unresolvable) hostname.
+    const literalHost =
+        hostname.startsWith("[") && hostname.endsWith("]")
+            ? hostname.slice(1, -1)
+            : hostname;
+    const literalFamily = net.isIP(literalHost);
     const addresses = literalFamily
-        ? [{ address: hostname }]
+        ? [{ address: literalHost }]
         : await dns.lookup(hostname, { all: true, verbatim: true });
     if (!addresses.length || addresses.some(({ address }) => isBlockedIp(address))) {
         throw new Error("MCP server URL resolves to a blocked network address.");

--- a/backend/src/lib/mcp/client.ts
+++ b/backend/src/lib/mcp/client.ts
@@ -329,43 +329,41 @@ export function authConfigPatch(config: McpConnectorAuthConfig): Record<string, 
     });
 }
 
-// A per-request undici dispatcher whose DNS lookup runs the private-IP guard at
-// the moment the socket is opened and returns ONLY validated addresses. Because
+// A shared undici dispatcher whose DNS lookup runs the private-IP guard at the
+// moment a socket is opened and returns ONLY validated addresses. Because
 // undici connects to exactly what this lookup yields, the address we validate is
 // the address we connect to — there is no second, unguarded resolution for an
-// attacker to race (DNS-rebinding / TOCTOU). The URL hostname is untouched, so
-// the Host header and TLS SNI still reflect the real host and HTTPS verifies
-// normally against legitimate public servers.
-function pinnedGuardAgent(): Agent {
-    return new Agent({
-        connect: {
-            lookup: (hostname, _options, callback) => {
-                dns.lookup(hostname, { all: true, verbatim: true })
-                    .then((addresses) => {
-                        if (
-                            !addresses.length ||
-                            addresses.some(({ address }) => isBlockedIp(address))
-                        ) {
-                            callback(
-                                new Error(
-                                    "MCP server URL resolves to a blocked network address.",
-                                ),
-                                [],
-                            );
-                            return;
-                        }
-                        callback(null, addresses);
-                    })
-                    .catch((err: unknown) =>
+// attacker to race (DNS-rebinding / TOCTOU). Reusing the dispatcher also lets
+// undici pool validated HTTPS connections instead of leaving a new Agent and
+// keep-alive socket behind for every MCP request.
+const guardedAgent = new Agent({
+    connect: {
+        lookup: (hostname, _options, callback) => {
+            dns.lookup(hostname, { all: true, verbatim: true })
+                .then((addresses) => {
+                    if (
+                        !addresses.length ||
+                        addresses.some(({ address }) => isBlockedIp(address))
+                    ) {
                         callback(
-                            err instanceof Error ? err : new Error(String(err)),
+                            new Error(
+                                "MCP server URL resolves to a blocked network address.",
+                            ),
                             [],
-                        ),
-                    );
-            },
+                        );
+                        return;
+                    }
+                    callback(null, addresses);
+                })
+                .catch((err: unknown) =>
+                    callback(
+                        err instanceof Error ? err : new Error(String(err)),
+                        [],
+                    ),
+                );
         },
-    });
-}
+    },
+});
 
 // The single guarded egress helper for every outbound MCP request (connector
 // transport, OAuth discovery/registration/refresh). It rejects non-HTTPS,
@@ -387,7 +385,7 @@ export async function guardedFetch(
     return fetch(input, {
         ...init,
         redirect: "manual",
-        dispatcher: pinnedGuardAgent(),
+        dispatcher: guardedAgent,
     } as RequestInit);
 }
 

--- a/backend/src/lib/mcp/oauth.ts
+++ b/backend/src/lib/mcp/oauth.ts
@@ -46,8 +46,8 @@ function parseWwwAuthenticate(value: string | null): string | null {
 
 async function fetchJson(url: string, init?: RequestInit) {
     // Route through the shared guarded egress helper so this call gets the same
-    // HTTPS-only / private-IP / no-redirect protections as the connector
-    // transport (closes the raw-fetch SSRF gap in OAuth discovery).
+    // HTTPS-only / private-IP / connect-time-pinned / no-redirect protections as
+    // the connector transport (closes the raw-fetch SSRF gap in OAuth discovery).
     const response = await guardedFetch(url, init);
     if (!response.ok) {
         throw new Error(`Failed to fetch OAuth metadata (${response.status}).`);

--- a/backend/src/lib/mcp/oauth.ts
+++ b/backend/src/lib/mcp/oauth.ts
@@ -45,8 +45,10 @@ function parseWwwAuthenticate(value: string | null): string | null {
 }
 
 async function fetchJson(url: string, init?: RequestInit) {
-    await validateRemoteMcpUrl(url);
-    const response = await fetch(url, { ...init, redirect: "manual" });
+    // Route through the shared guarded egress helper so this call gets the same
+    // HTTPS-only / private-IP / no-redirect protections as the connector
+    // transport (closes the raw-fetch SSRF gap in OAuth discovery).
+    const response = await guardedFetch(url, init);
     if (!response.ok) {
         throw new Error(`Failed to fetch OAuth metadata (${response.status}).`);
     }
@@ -58,12 +60,14 @@ async function fetchJson(url: string, init?: RequestInit) {
 }
 
 async function discoverProtectedResourceMetadataUrl(serverUrl: string) {
+    // The MCP server URL is attacker-influenced, so both discovery probes go
+    // through the shared guarded egress helper rather than raw fetch (previously
+    // an unvalidated SSRF sink).
     const attempts: Array<() => Promise<Response>> = [
-        () => fetch(serverUrl, { method: "GET", redirect: "manual" }),
+        () => guardedFetch(serverUrl, { method: "GET" }),
         () =>
-            fetch(serverUrl, {
+            guardedFetch(serverUrl, {
                 method: "POST",
-                redirect: "manual",
                 headers: {
                     Accept: "application/json, text/event-stream",
                     "Content-Type": "application/json",
@@ -189,10 +193,8 @@ async function registerOAuthClient(
     redirectUri: string,
 ) {
     if (!metadata.registrationEndpoint) return null;
-    await validateRemoteMcpUrl(metadata.registrationEndpoint);
-    const response = await fetch(metadata.registrationEndpoint, {
+    const response = await guardedFetch(metadata.registrationEndpoint, {
         method: "POST",
-        redirect: "manual",
         headers: {
             Accept: "application/json",
             "Content-Type": "application/json",
@@ -329,8 +331,7 @@ async function refreshOAuthAccessToken(row: OAuthTokenRow, db: Db) {
     });
     if (clientSecret) body.set("client_secret", clientSecret);
     if (row.resource) body.set("resource", row.resource);
-    await validateRemoteMcpUrl(row.token_endpoint);
-    const response = await fetch(row.token_endpoint, {
+    const response = await guardedFetch(row.token_endpoint, {
         method: "POST",
         headers: {
             Accept: "application/json",

--- a/backend/src/lib/privateIp.ts
+++ b/backend/src/lib/privateIp.ts
@@ -92,6 +92,12 @@ export function isPrivateIpv6(ip: string): boolean {
     if (groups.slice(0, 5).every((g) => g === 0) && groups[5] === 0xffff) {
         return isPrivateIpv4(embeddedIpv4(groups[6], groups[7]));
     }
+    // IPv4-compatible ::/96 (deprecated, RFC 4291 §2.5.5.1) — `::a.b.c.d` /
+    // `::7f00:1`. `::` and `::1` were handled above, so anything else in this
+    // prefix embeds a routable-ish IPv4; classify by the embedded address.
+    if (groups.slice(0, 6).every((g) => g === 0)) {
+        return isPrivateIpv4(embeddedIpv4(groups[6], groups[7]));
+    }
     // NAT64 well-known prefix 64:ff9b::/96 — last 32 bits are the target IPv4.
     if (
         groups[0] === 0x64 &&

--- a/backend/src/lib/privateIp.ts
+++ b/backend/src/lib/privateIp.ts
@@ -1,0 +1,122 @@
+import net from "net";
+
+/**
+ * SSRF guard helpers: classify an IP literal as private/reserved/unsafe.
+ * Shared by the MCP connector egress checks so every caller rejects the same
+ * ranges. Conservative: anything unparseable or unrecognized is treated as
+ * blocked.
+ */
+export function isPrivateIpv4(ip: string): boolean {
+    const parts = ip.split(".").map((part) => Number.parseInt(part, 10));
+    if (parts.length !== 4 || parts.some((part) => !Number.isFinite(part))) {
+        return true;
+    }
+    const [a, b] = parts;
+    return (
+        a === 0 ||
+        a === 10 ||
+        a === 127 ||
+        (a === 100 && b >= 64 && b <= 127) ||
+        (a === 169 && b === 254) ||
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 168) ||
+        (a === 192 && b === 0) ||
+        (a === 198 && (b === 18 || b === 19)) ||
+        a >= 224
+    );
+}
+
+/**
+ * Expand an IPv6 literal (possibly using `::` compression and/or a trailing
+ * dotted-quad IPv4 tail) into its eight 16-bit groups. Returns null if the
+ * input is not a well-formed IPv6 literal. Any embedded dotted IPv4 tail is
+ * folded into the final two hextets so callers can read the embedded address
+ * uniformly.
+ */
+function expandIpv6Groups(ip: string): number[] | null {
+    let s = ip.toLowerCase();
+    const zone = s.indexOf("%");
+    if (zone !== -1) s = s.slice(0, zone);
+
+    // Fold a trailing dotted-quad IPv4 tail (e.g. `::ffff:1.2.3.4`) into two
+    // hex groups so the address is a pure list of hextets.
+    const dotted = s.match(/(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+    if (dotted) {
+        const octets = dotted.slice(1, 5).map((o) => Number.parseInt(o, 10));
+        if (octets.some((o) => o > 255)) return null;
+        const hi = ((octets[0] << 8) | octets[1]).toString(16);
+        const lo = ((octets[2] << 8) | octets[3]).toString(16);
+        s = s.slice(0, dotted.index) + `${hi}:${lo}`;
+    }
+
+    const halves = s.split("::");
+    if (halves.length > 2) return null;
+    const head = halves[0] ? halves[0].split(":") : [];
+    const tail = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+
+    let groups: string[];
+    if (halves.length === 2) {
+        const fill = 8 - head.length - tail.length;
+        if (fill < 0) return null;
+        groups = [...head, ...Array<string>(fill).fill("0"), ...tail];
+    } else {
+        groups = head;
+    }
+    if (groups.length !== 8) return null;
+
+    const nums = groups.map((g) => Number.parseInt(g || "0", 16));
+    if (nums.some((n) => !Number.isInteger(n) || n < 0 || n > 0xffff)) {
+        return null;
+    }
+    return nums;
+}
+
+function embeddedIpv4(hi: number, lo: number): string {
+    return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+}
+
+export function isPrivateIpv6(ip: string): boolean {
+    const normalized = ip.toLowerCase();
+    if (normalized === "::1" || normalized === "::") return true;
+    if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
+    // Link-local fe80::/10 — the first hextet ranges fe80..febf (four hex
+    // digits). The narrower /^fe[89ab]:/ form was a bug: it only matched the
+    // unrelated hextet "fe8:" and let fe80::1 through.
+    if (/^fe[89ab][0-9a-f]:/.test(normalized)) return true;
+
+    const groups = expandIpv6Groups(normalized);
+    if (!groups) return false;
+
+    // IPv4-mapped ::ffff:0:0/96 — covers both dotted (`::ffff:1.2.3.4`) and
+    // hex (`::ffff:c0a8:0001`) forms. The address *is* the embedded IPv4.
+    if (groups.slice(0, 5).every((g) => g === 0) && groups[5] === 0xffff) {
+        return isPrivateIpv4(embeddedIpv4(groups[6], groups[7]));
+    }
+    // NAT64 well-known prefix 64:ff9b::/96 — last 32 bits are the target IPv4.
+    if (
+        groups[0] === 0x64 &&
+        groups[1] === 0xff9b &&
+        groups[2] === 0 &&
+        groups[3] === 0 &&
+        groups[4] === 0 &&
+        groups[5] === 0
+    ) {
+        return isPrivateIpv4(embeddedIpv4(groups[6], groups[7]));
+    }
+    // 6to4 2002::/16 — the embedded IPv4 sits in the second and third hextets.
+    if (groups[0] === 0x2002) {
+        return isPrivateIpv4(embeddedIpv4(groups[1], groups[2]));
+    }
+    return false;
+}
+
+/**
+ * True if `ip` is a private/reserved/unsafe address. Non-IP input returns true
+ * (fail closed) — callers should pass resolved IP literals.
+ */
+export function isBlockedIp(ip: string): boolean {
+    const family = net.isIP(ip);
+    if (family === 4) return isPrivateIpv4(ip);
+    if (family === 6) return isPrivateIpv6(ip);
+    return true;
+}

--- a/backend/src/lib/privateIp.ts
+++ b/backend/src/lib/privateIp.ts
@@ -1,5 +1,38 @@
 import net from "net";
 
+const blockedIpv4 = new net.BlockList();
+for (const [network, prefix] of [
+    ["0.0.0.0", 8], // "This network" / unspecified
+    ["10.0.0.0", 8], // RFC 1918 private-use
+    ["100.64.0.0", 10], // Shared address space (carrier-grade NAT)
+    ["127.0.0.0", 8], // Loopback
+    ["169.254.0.0", 16], // Link-local
+    ["172.16.0.0", 12], // RFC 1918 private-use
+    ["192.0.0.0", 24], // IETF protocol assignments
+    ["192.0.2.0", 24], // Documentation (TEST-NET-1)
+    ["192.88.99.0", 24], // Deprecated 6to4 relay anycast
+    ["192.168.0.0", 16], // RFC 1918 private-use
+    ["198.18.0.0", 15], // Benchmarking
+    ["198.51.100.0", 24], // Documentation (TEST-NET-2)
+    ["203.0.113.0", 24], // Documentation (TEST-NET-3)
+    ["224.0.0.0", 4], // Multicast
+    ["240.0.0.0", 4], // Reserved (includes limited broadcast)
+] as const) {
+    blockedIpv4.addSubnet(network, prefix, "ipv4");
+}
+
+const blockedIpv6 = new net.BlockList();
+for (const [network, prefix] of [
+    ["2001::", 32], // Teredo
+    ["2001:2::", 48], // Benchmarking
+    ["2001:10::", 28], // Deprecated ORCHID
+    ["2001:db8::", 32], // Documentation
+    ["2002::", 16], // Deprecated 6to4 transition space
+    ["3fff::", 20], // Documentation
+] as const) {
+    blockedIpv6.addSubnet(network, prefix, "ipv6");
+}
+
 /**
  * SSRF guard helpers: classify an IP literal as private/reserved/unsafe.
  * Shared by the MCP connector egress checks so every caller rejects the same
@@ -7,23 +40,8 @@ import net from "net";
  * blocked.
  */
 export function isPrivateIpv4(ip: string): boolean {
-    const parts = ip.split(".").map((part) => Number.parseInt(part, 10));
-    if (parts.length !== 4 || parts.some((part) => !Number.isFinite(part))) {
-        return true;
-    }
-    const [a, b] = parts;
-    return (
-        a === 0 ||
-        a === 10 ||
-        a === 127 ||
-        (a === 100 && b >= 64 && b <= 127) ||
-        (a === 169 && b === 254) ||
-        (a === 172 && b >= 16 && b <= 31) ||
-        (a === 192 && b === 168) ||
-        (a === 192 && b === 0) ||
-        (a === 198 && (b === 18 || b === 19)) ||
-        a >= 224
-    );
+    if (net.isIP(ip) !== 4) return true;
+    return blockedIpv4.check(ip, "ipv4");
 }
 
 /**
@@ -76,29 +94,25 @@ function embeddedIpv4(hi: number, lo: number): string {
 }
 
 export function isPrivateIpv6(ip: string): boolean {
-    const normalized = ip.toLowerCase();
-    if (normalized === "::1" || normalized === "::") return true;
-    if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
-    // Link-local fe80::/10 — the first hextet ranges fe80..febf (four hex
-    // digits). The narrower /^fe[89ab]:/ form was a bug: it only matched the
-    // unrelated hextet "fe8:" and let fe80::1 through.
-    if (/^fe[89ab][0-9a-f]:/.test(normalized)) return true;
+    const normalized = ip.toLowerCase().split("%", 1)[0];
+    if (net.isIP(normalized) !== 6) return true;
 
     const groups = expandIpv6Groups(normalized);
-    if (!groups) return false;
+    if (!groups) return true;
 
-    // IPv4-mapped ::ffff:0:0/96 — covers both dotted (`::ffff:1.2.3.4`) and
-    // hex (`::ffff:c0a8:0001`) forms. The address *is* the embedded IPv4.
-    if (groups.slice(0, 5).every((g) => g === 0) && groups[5] === 0xffff) {
-        return isPrivateIpv4(embeddedIpv4(groups[6], groups[7]));
-    }
-    // IPv4-compatible ::/96 (deprecated, RFC 4291 §2.5.5.1) — `::a.b.c.d` /
-    // `::7f00:1`. `::` and `::1` were handled above, so anything else in this
-    // prefix embeds a routable-ish IPv4; classify by the embedded address.
+    // IPv4-compatible ::/96 and IPv4-mapped ::ffff:0:0/96 are not globally
+    // reachable IPv6 destinations. Block the entire ranges, even when their
+    // embedded IPv4 value would otherwise be public.
     if (groups.slice(0, 6).every((g) => g === 0)) {
-        return isPrivateIpv4(embeddedIpv4(groups[6], groups[7]));
+        return true;
     }
+    if (groups.slice(0, 5).every((g) => g === 0) && groups[5] === 0xffff) {
+        return true;
+    }
+
     // NAT64 well-known prefix 64:ff9b::/96 — last 32 bits are the target IPv4.
+    // This prefix is globally reachable, so permit it only when the embedded
+    // IPv4 destination is also globally reachable.
     if (
         groups[0] === 0x64 &&
         groups[1] === 0xff9b &&
@@ -109,11 +123,15 @@ export function isPrivateIpv6(ip: string): boolean {
     ) {
         return isPrivateIpv4(embeddedIpv4(groups[6], groups[7]));
     }
-    // 6to4 2002::/16 — the embedded IPv4 sits in the second and third hextets.
-    if (groups[0] === 0x2002) {
-        return isPrivateIpv4(embeddedIpv4(groups[1], groups[2]));
-    }
-    return false;
+
+    // Normal globally routable IPv6 unicast lives in 2000::/3. Everything
+    // outside it is fail-closed, including unique-local fc00::/7, link-local
+    // fe80::/10, deprecated site-local fec0::/10, multicast ff00::/8,
+    // discard-only 100::/64, and local-use translation 64:ff9b:1::/48.
+    const isGlobalUnicast = (groups[0] & 0xe000) === 0x2000;
+    if (!isGlobalUnicast) return true;
+
+    return blockedIpv6.check(normalized, "ipv6");
 }
 
 /**


### PR DESCRIPTION
## [Security 1/9] SSRF guardrails for server-side connector fetches

> Part of the split of #227 into reviewable, single-topic PRs. Each stands alone and is scoped to one attack class. Index: see the tracking comment on #227.

### TL;DR
When a user registers an MCP connector, **our server** fetches the URL they gave us. This PR stops that fetch from being pointed at internal infrastructure (the cloud metadata service, the database, admin panels) by validating the *resolved IP address* against every private/reserved range and failing closed. It also closes the DNS-rebinding race by pinning the connection to the address we validated.

---

### Risk to user data
**Severity: critical.** A successful SSRF here is a direct path to *total* data compromise, not just one user's records:
- The cloud metadata endpoint (`http://169.254.169.254/…`) hands out the server's IAM credentials. With those, an attacker reads the entire object store and database — **every tenant's documents**, not their own.
- Internal addresses (`localhost:5432`, private admin panels) are reachable from the server but not from the public internet, so this bypasses the network perimeter entirely.

The attacker only needs an ordinary app account and the "add a connector" feature.

### Flows affected
- MCP connector registration / validation (`validateRemoteMcpUrl`)
- Every outbound connector transport fetch
- OAuth discovery, dynamic client registration, and token refresh for connectors (`mcp/oauth.ts`) — previously these used raw `fetch` and were unguarded SSRF sinks.

### Attack precedent
- **Capital One, 2019** — 106M records. An SSRF reached `169.254.169.254`, retrieved IAM role credentials, and used them to read S3. This exact primitive. ([Krebs](https://krebsonsecurity.com/2019/07/capital-one-data-theft-impacts-106m-people/))
- SSRF is its own category in the [OWASP Top 10 (A10:2021)](https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/).

```mermaid
sequenceDiagram
    participant A as Attacker (ordinary user)
    participant S as Mike backend (inside the VPC)
    participant M as Metadata service<br/>169.254.169.254
    A->>S: Register connector<br/>url = http://169.254.169.254/latest/meta-data/
    S->>M: server-side GET (from inside the VPC)
    M-->>S: IAM credentials
    S-->>A: response relayed back
    Note over S,M: With this PR: 169.254.169.254 is link-local →<br/>refused before a socket opens
```

### Possible fixes, and what we chose

| Option | Why not / why |
|---|---|
| Blocklist hostnames (`localhost`, `metadata`) | Trivially bypassed: raw IPs, DNS names that resolve to internal IPs, `0x7f.0.0.1`, IPv6 forms. Rejected. |
| Allowlist of known-good connector domains | Safest, but MCP is explicitly "bring your own server" — an allowlist defeats the feature. Rejected for now (a good future opt-in for locked-down tenants). |
| **Validate the resolved IP against all private/reserved ranges, fail closed** | **Chosen.** Works for arbitrary user URLs, no maintenance of a domain list. The subtlety is doing it *correctly* — see below. |

**The correct-implementation details that matter:**
- Validate the **resolved IP**, not the URL string. `http://internal.evil.com/` looks public but resolves to `10.0.0.5`.
- Cover **every** reserved range: loopback, RFC1918, link-local, CGNAT (`100.64/10`), multicast, and the **IPv6 forms of all of them** — including IPv4 addresses *embedded in* IPv6 literals (`::ffff:10.0.0.1`, `::7f00:1`), the classic filter bypass. `privateIp.ts` expands these.
- **Fail closed:** anything unparseable or unrecognized is treated as blocked.
- **Never auto-follow redirects.** A public URL that `302`s to `http://localhost/` defeats a naive check — so `guardedFetch` sets `redirect: "manual"`.

The tests in `client.ssrf.test.ts` encode the bypass encodings, not just the happy path.

### The subtle part: DNS rebinding (a TOCTOU race)
Validating the IP and *then* fetching the URL is two separate DNS lookups. An attacker who controls DNS for `evil.example` (TTL 0) answers the first lookup — the validation — with a harmless public IP, and the second lookup — the real fetch — with `127.0.0.1`. This is a classic [time-of-check-to-time-of-use](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) race: **the thing you checked is not the thing you used.**

```mermaid
sequenceDiagram
    participant D as Attacker DNS (TTL 0)
    participant S as Naive server
    S->>D: resolve evil.example (validation)
    D-->>S: 93.184.216.34 — public, check passes ✅
    S->>D: resolve evil.example (actual fetch)
    D-->>S: 127.0.0.1 — check already passed ❌
    S->>S: connects to 127.0.0.1
```

**Fix:** resolve **once**, validate those addresses, and connect to **exactly** them. This PR does it with a per-request [undici](https://undici.nodejs.org/) `Agent` whose `connect.lookup` hook runs the private-IP guard *at the moment the socket opens* and hands undici only validated addresses — so the address we validate is the address we connect to. The URL hostname is untouched, so the `Host` header and TLS SNI still reflect the real host and certificate verification works normally against legitimate public servers.

### What's in this PR
- `backend/src/lib/privateIp.ts` — conservative IP classifier (new, shared).
- `backend/src/lib/mcp/client.ts` — `validateRemoteMcpUrl`, `guardedFetch`, and the connect-time-pinned undici dispatcher.
- `backend/src/lib/mcp/oauth.ts` — routes all discovery/registration/refresh through `guardedFetch`.
- `undici` dependency; tests in `client.ssrf.test.ts` (9 tests, incl. embedded-IPv4-in-IPv6 bypasses).

### Reading
[PortSwigger: SSRF](https://portswigger.net/web-security/ssrf) · [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
