### PR TITLE
[Testing 20] test(e2e): accessibility scans + nightly run (stacked on #220)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,16 @@ on:
     # `main` is the destination upstream; `upstream-main` is the fork's mirror of
     # it, so the suite is exercised on the fork PR and stays correct once merged.
     branches: [main, upstream-main]
+  # Nightly run against the default branch, so drift that lands BETWEEN pull
+  # requests (a dependency bump, a Supabase CLI change, an upstream UI tweak
+  # breaking a selector) is caught within a day instead of surfacing on the next
+  # unrelated PR. 03:47 UTC is a quiet hour for GitHub's cron pool (on-the-hour
+  # slots are congested and can be delayed or dropped). Scheduled runs exercise
+  # the 4 LLM-gated specs only when the ANTHROPIC_API_KEY repository secret is
+  # configured — without it they self-skip (e2e/llm.ts) and the run still
+  # covers the other specs.
+  schedule:
+    - cron: "47 3 * * *"
 
 # Don't pile up runs on rapid pushes to the same PR.
 concurrency:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,9 +7,9 @@
 # this job "e2e / playwright" as a required status check in branch protection —
 # see docs/e2e-ci.md ("Make it merge-blocking").
 #
-# The suite is green with NO secret: the 4 LLM-dependent specs (chat + critical
-# path) skip themselves when ANTHROPIC_API_KEY is absent (see e2e/llm.ts), so a
-# keyless run passes the other 23 specs. The gate exists because the app has no
+# The suite is green with NO secret: of the 31 specs, the 4 LLM-dependent ones
+# (chat + critical path) skip themselves when ANTHROPIC_API_KEY is absent (see
+# e2e/llm.ts), so a keyless run passes the other 27 specs. The gate exists because the app has no
 # keyless model — with no provider key configured, ChatInput blocks every send —
 # not because of the (best-effort) title-generation call. To run and enforce
 # those 4, set the ANTHROPIC_API_KEY repository secret; exact steps, the
@@ -56,7 +56,7 @@ jobs:
       # specs can skip themselves when no key is present — see e2e/llm.ts. When the
       # secret is set they run and are enforced; when absent they skip, so a keyless
       # run (e.g. a fork PR, which never receives this secret) is still green on
-      # the other 23 specs. Setup: docs/e2e-ci.md, "Enable the LLM specs".
+      # the other 27 of the 31 specs. Setup: docs/e2e-ci.md, "Enable the LLM specs".
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@v4

--- a/docs/e2e-ci.md
+++ b/docs/e2e-ci.md
@@ -9,7 +9,10 @@ makes that check *required*.
 ## What the workflow does
 
 On every `pull_request` targeting `main` (or `upstream-main`, the fork mirror),
-and on manual `workflow_dispatch`, the `e2e / playwright` job:
+on manual `workflow_dispatch`, and **nightly at 03:47 UTC** (a `schedule` cron,
+so drift that lands between PRs — dependency bumps, Supabase CLI changes,
+selector-breaking UI tweaks — is caught within a day), the `e2e / playwright`
+job:
 
 1. installs the root (Playwright), `backend/`, and `frontend/` dependencies;
 2. boots **MinIO** (S3-compatible object storage — several specs upload documents);
@@ -37,6 +40,27 @@ baked into that file are the single source of truth.
 
 A keyless run is expected to end **23 passed / 4 skipped / 0 failed** — the
 suite has 27 specs, 4 of them LLM-gated (see "Confirm the specs ran" below).
+Typical run: **~7 minutes**.
+
+## Accessibility scans
+
+`e2e/accessibility.spec.ts` runs an [axe-core](https://github.com/dequelabs/axe-core)
+scan (via `@axe-core/playwright`) over the core pages: `/login` (pre-auth),
+`/assistant`, `/projects`, and `/tabular-reviews`. The policy is two-tier:
+**`critical`-impact violations fail the build**; `serious`-impact violations are
+printed to the test output but do not fail — enforce at critical first, then
+ratchet `serious` into the failing tier (`BLOCKING_IMPACTS` in the spec) once
+that backlog is cleared. The scans need no LLM key and run on every trigger.
+
+## Failure artifacts
+
+Playwright retries failed specs up to twice on CI and records a **trace** on the
+first retry (`retries` / `trace: "on-first-retry"` in `playwright.config.ts`).
+On pass, fail, or timeout, the job uploads `playwright-report/` and
+`test-results/` as the **`playwright-report`** artifact (14-day retention): from
+the failed run's page in the Actions tab, download it, then
+`npx playwright show-report playwright-report` locally to see per-spec results,
+screenshots, and step-by-step traces of what the browser did.
 
 ## Optional secret (fuller coverage)
 

--- a/docs/e2e-ci.md
+++ b/docs/e2e-ci.md
@@ -38,8 +38,8 @@ job:
 the local Supabase admin API, so no login secret is needed — the credentials
 baked into that file are the single source of truth.
 
-A keyless run is expected to end **23 passed / 4 skipped / 0 failed** — the
-suite has 27 specs, 4 of them LLM-gated (see "Confirm the specs ran" below).
+A keyless run is expected to end **27 passed / 4 skipped / 0 failed** — the
+suite has 31 specs, 4 of them LLM-gated (see "Confirm the specs ran" below).
 Typical run: **~7 minutes**.
 
 ## Accessibility scans
@@ -66,7 +66,7 @@ screenshots, and step-by-step traces of what the browser did.
 
 | Secret | What it unlocks | Without it |
 |---|---|---|
-| `ANTHROPIC_API_KEY` | The 4 LLM-dependent specs (chat rename/delete/submit, critical-path "ask a question") send a message and assert a **streamed** answer. With the key set they run and are enforced. | Those 4 specs **skip** (see `e2e/llm.ts`) instead of hanging, so the run is still green on the other 23 specs. |
+| `ANTHROPIC_API_KEY` | The 4 LLM-dependent specs (chat rename/delete/submit, critical-path "ask a question") send a message and assert a **streamed** answer. With the key set they run and are enforced. | Those 4 specs **skip** (see `e2e/llm.ts`) instead of hanging, so the run is still green on the other 27 specs. |
 
 The suite is green **without** any secret — the LLM specs skip themselves via
 `test.skip(!process.env.ANTHROPIC_API_KEY, …)`, which keeps keyless runs (local,
@@ -123,10 +123,10 @@ few cents per run — negligible next to the CI minutes.
 
 Open the **Run Playwright** step in the Actions log:
 
-- **Keyless run:** the summary ends with `4 skipped` / `23 passed`, and each
+- **Keyless run:** the summary ends with `4 skipped` / `27 passed`, and each
   skipped spec carries the reason
   `requires a model key — set the ANTHROPIC_API_KEY secret to run LLM-dependent specs`.
-- **With the secret:** the summary shows `27 passed` and **no `skipped` line**;
+- **With the secret:** the summary shows `31 passed` and **no `skipped` line**;
   searching the log for `requires a model key` finds nothing.
 
 The uploaded `playwright-report` artifact shows the same per-spec statuses.
@@ -141,9 +141,10 @@ carries the fix (commit `test(e2e): select a real Claude model in LLM-gated
 specs`): the specs' `selectClaudeModel` helper picks **Claude Sonnet 4.6** in
 the ModelToggle whenever the key is set, and the critical-path response
 assertion checks for a nonempty streamed assistant answer instead of the
-fork's canned demo reply. The **23 passed / 4 skipped** keyless and
-**27 passed / 0 skipped** with-key figures come from that commit's own
-verification against a full local stack (backend, prod-build frontend, local
+fork's canned demo reply. That commit measured **23 passed / 4 skipped**
+keyless and **27 passed / 0 skipped** with the key (the 4 accessibility specs
+this branch adds raise those totals to 27 and 31); the figures come from its
+own verification against a full local stack (backend, prod-build frontend, local
 Supabase + MinIO — see its commit message); they have not been re-measured
 since this branch was rebased onto current `main`. The secret setup above is
 all that is needed.

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Accessibility (axe-core) E2E scans:
+ *   1. /login — the unauthenticated entry point
+ *   2. /assistant — the main chat/home surface
+ *   3. /projects — the projects list
+ *   4. /tabular-reviews — the tabular review list
+ *
+ * Each test loads a core page, waits for a page-specific anchor element (so the
+ * scan runs against the real rendered UI, not a loading state), then runs an
+ * axe-core scan via @axe-core/playwright.
+ *
+ * TWO-TIER POLICY — why only `critical` fails the build:
+ * axe grades each violation minor → moderate → serious → critical. Turning the
+ * scanner on with everything blocking would land a wall of red on day one and
+ * the check would get ignored or reverted. So we start by ENFORCING only
+ * `critical` (zero tolerance — these break the page outright for assistive
+ * tech), while `serious` violations are LOGGED to the test output on every run
+ * so the backlog stays visible. Once the serious backlog is cleared, ratchet:
+ * move "serious" into the failing tier by adding it to BLOCKING_IMPACTS below.
+ *
+ * No selector exclusions are currently needed — the app renders no third-party
+ * embedded widgets (chat bubbles, cookie banners, analytics iframes) on these
+ * pages. If one appears, exclude it with `.exclude("<selector>")` on the
+ * AxeBuilder and document here what the selector is and why it's out of scope.
+ *
+ * Prerequisite: auth.setup.ts has already saved the session to e2e/.auth/user.json
+ * (tests 2–4 inherit the authenticated storageState from playwright.config.ts).
+ */
+import { test, expect, type Page } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+/** Impact levels that fail the test. Ratchet by adding "serious" here. */
+const BLOCKING_IMPACTS = ["critical"];
+
+/** Impact levels that are reported in the test output but do not fail. */
+const LOGGED_IMPACTS = ["serious"];
+
+/**
+ * One-line summary per violation: rule id, impact, how many DOM nodes are
+ * affected, and the axe help URL (which explains the rule and how to fix it).
+ */
+function formatViolation(v: {
+    id: string;
+    impact?: string | null;
+    nodes: unknown[];
+    helpUrl: string;
+}): string {
+    return `[${v.impact}] ${v.id} (${v.nodes.length} node${
+        v.nodes.length === 1 ? "" : "s"
+    }) — ${v.helpUrl}`;
+}
+
+/**
+ * Run an axe scan on the current page. Violations at BLOCKING_IMPACTS fail the
+ * test with a readable list; violations at LOGGED_IMPACTS are printed to the
+ * test output (visible in the report and CI logs) without failing.
+ */
+async function expectNoBlockingViolations(page: Page, pageLabel: string) {
+    const results = await new AxeBuilder({ page }).analyze();
+
+    const blocking = results.violations.filter((v) =>
+        BLOCKING_IMPACTS.includes(v.impact ?? ""),
+    );
+    const logged = results.violations.filter((v) =>
+        LOGGED_IMPACTS.includes(v.impact ?? ""),
+    );
+
+    if (logged.length > 0) {
+        /* Non-failing tier: surface the backlog on every run so it can be
+           burned down, then promoted into BLOCKING_IMPACTS. */
+        console.log(
+            `[a11y] ${pageLabel}: ${logged.length} serious violation(s) ` +
+                `(logged, not yet enforced):\n` +
+                logged.map((v) => `  ${formatViolation(v)}`).join("\n"),
+        );
+    }
+
+    expect(
+        blocking.map(formatViolation),
+        `critical-impact axe violations on ${pageLabel}`,
+    ).toEqual([]);
+}
+
+/* ─── Test 1: login page (pre-auth) ──────────────────────────────────────── */
+
+/* describe-scoped test.use so only this test runs without a stored session.
+   File-level test.use would wipe the storageState for the authenticated
+   scans below. */
+test.describe("unauthenticated", () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test("login page has no critical accessibility violations", async ({
+        page,
+    }) => {
+        await page.goto("/login");
+        await expect(page).toHaveURL(/\/login/);
+        /* The login form's email field renders once the page is interactive. */
+        await expect(page.locator("#email")).toBeVisible({ timeout: 10_000 });
+
+        await expectNoBlockingViolations(page, "/login");
+    });
+});
+
+/* ─── Test 2: assistant (main chat/home) ─────────────────────────────────── */
+
+test("assistant page has no critical accessibility violations", async ({
+    page,
+}) => {
+    await page.goto("/assistant");
+    await expect(page).toHaveURL(/\/assistant/);
+    /* The InitialView renders a greeting heading once loaded. */
+    await expect(page.locator("h1, h2").first()).toBeVisible({
+        timeout: 10_000,
+    });
+
+    await expectNoBlockingViolations(page, "/assistant");
+});
+
+/* ─── Test 3: projects list ──────────────────────────────────────────────── */
+
+test("projects page has no critical accessibility violations", async ({
+    page,
+}) => {
+    await page.goto("/projects");
+    await expect(page).toHaveURL(/\/projects/);
+    /* The Plus icon button (aria-label="New project") renders with the list. */
+    await expect(
+        page.getByRole("button", { name: "New project" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    await expectNoBlockingViolations(page, "/projects");
+});
+
+/* ─── Test 4: tabular reviews list ───────────────────────────────────────── */
+
+test("tabular reviews page has no critical accessibility violations", async ({
+    page,
+}) => {
+    await page.goto("/tabular-reviews");
+    await expect(page).toHaveURL(/\/tabular-reviews/);
+    await expect(
+        page.getByRole("heading", { name: "Tabular Reviews" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    await expectNoBlockingViolations(page, "/tabular-reviews");
+});

--- a/frontend/src/app/(pages)/tabular-reviews/page.tsx
+++ b/frontend/src/app/(pages)/tabular-reviews/page.tsx
@@ -461,6 +461,7 @@ export default function TabularReviewsPage() {
                                     }}
                                     onChange={toggleAll}
                                     className={TABLE_CHECKBOX_CLASS}
+                                    aria-label="Select all reviews"
                                 />
                             )}
                             <span className="mr-1">Name</span>

--- a/frontend/src/app/components/assistant/ChatInput.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.tsx
@@ -562,6 +562,9 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                             />
                             <button
                                 type="button"
+                                aria-label={
+                                    isLoading ? "Stop response" : "Send message"
+                                }
                                 className={cn(
                                     "relative bg-gradient-to-b from-neutral-700 to-black text-white rounded-[10px] h-8 w-8 flex items-center justify-center cursor-pointer disabled:cursor-default disabled:from-neutral-600 disabled:to-black backdrop-blur-xl border border-white/30 active:enabled:scale-95 transition-all duration-150",
                                     "shadow-[0_5px_14px_rgba(15,23,42,0.18),inset_0_1px_0_rgba(255,255,255,0.24)]",

--- a/frontend/src/app/components/projects/ProjectsOverview.tsx
+++ b/frontend/src/app/components/projects/ProjectsOverview.tsx
@@ -526,6 +526,7 @@ export function ProjectsOverview() {
                                     }}
                                     onChange={toggleAll}
                                     className={TABLE_CHECKBOX_CLASS}
+                                    aria-label="Select all projects"
                                 />
                             )}
                             <span className="mr-1">Name</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,26 @@
             "name": "mike",
             "license": "AGPL-3.0-only",
             "devDependencies": {
+                "@axe-core/playwright": "^4.12.1",
                 "@playwright/test": "^1.61.1",
                 "@types/node": "^22.14.1",
                 "typescript": "^5.8.3"
             },
             "engines": {
                 "node": ">=22"
+            }
+        },
+        "node_modules/@axe-core/playwright": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+            "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "axe-core": "~4.12.1"
+            },
+            "peerDependencies": {
+                "playwright-core": ">= 1.0.0"
             }
         },
         "node_modules/@playwright/test": {
@@ -39,6 +53,16 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
+            }
+        },
+        "node_modules/axe-core": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+            "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "test:e2e:ui": "playwright test --ui"
     },
     "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.61.1",
         "@types/node": "^22.14.1",
         "typescript": "^5.8.3"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,8 +17,15 @@ export default defineConfig({
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */
     retries: process.env.CI ? 2 : 0,
-    /* Reporter */
-    reporter: process.env.CI ? "github" : "list",
+    /* Reporter. On CI, "github" alone would REPLACE Playwright's default html
+       reporter, so playwright-report/ would never be written and the workflow's
+       artifact upload (docs/e2e-ci.md, "Failure artifacts") would have nothing
+       to ship. Listing both keeps the inline PR annotations AND generates the
+       HTML report; `open: "never"` stops the reporter from trying to launch a
+       browser on the CI box after the run. */
+    reporter: process.env.CI
+        ? [["github"], ["html", { open: "never" }]]
+        : "list",
     /* Shared settings for all the projects below */
     use: {
         baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",


### PR DESCRIPTION
**Stacked on #220 — merge that first; this diff includes its commits until then.** Once #220 lands, this PR shrinks to just the one commit described below (`300d91a`).

Three additions that make the e2e suite from #220 catch more problems with no extra work on your part:

**1. Accessibility scans (`e2e/accessibility.spec.ts`)**
Every run now scans the login page, the assistant, the projects list, and the tabular reviews list with [axe-core](https://github.com/dequelabs/axe-core), the standard tool for automated accessibility checks. The policy is deliberately gentle to start: only **critical** problems (things that outright break the page for screen-reader users) fail the check; **serious** problems are printed in the test output so the backlog stays visible without blocking merges. Once that backlog is cleared, one line in the spec (`BLOCKING_IMPACTS`) promotes "serious" to blocking too. These scans need no API key and run on every trigger.

**2. Nightly run**
The workflow now also runs every night at 03:47 UTC against `main`. That catches breakage that lands *between* PRs — a dependency update, a Supabase CLI change — within a day instead of surfacing on someone's unrelated PR.

**3. When something fails, you get the evidence**
This was mostly in place from #220 and is now documented in `docs/e2e-ci.md`: failed specs retry twice on CI, record a step-by-step trace of what the browser did, and the report + traces upload as a downloadable artifact (`playwright-report`) even when the job times out. From a red run's page in the Actions tab: download the artifact, then `npx playwright show-report playwright-report` locally.

One new dev dependency at the repo root: `@axe-core/playwright` (installed via npm; lockfile updated by npm itself).

The first CI run of this PR proved the spec earns its keep: it flagged 3 real critical violations — the icon-only send button on the assistant page had no accessible name, and the select-all checkboxes on the projects and tabular-reviews lists had no labels. The second commit on this branch fixes all three (5 lines of `aria-label`, no markup or styling changes), so screen-reader users get a working send button and checkboxes out of this PR, not just a scanner.

### Maintainer action required

1. **Set the `ANTHROPIC_API_KEY` secret** (Settings → Secrets and variables → Actions → New repository secret). Without it everything still passes, but the 4 specs that send a real chat message and check the streamed answer skip themselves. With it, they run on every PR and every nightly. (#236 documents the exact setup.)
2. **Make the checks required** (Settings → Branches → rule for `main` → "Require status checks to pass before merging"): add **`e2e / playwright`** plus the existing CI jobs. Until a check is marked required, a red run does not actually block the Merge button. Step-by-step in `docs/e2e-ci.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
