### PR TITLE
[Security 2/9] Encrypt MCP connector secrets with per-record derived keys

### DIFF
--- a/backend/src/lib/mcp/__tests__/crypto.test.ts
+++ b/backend/src/lib/mcp/__tests__/crypto.test.ts
@@ -1,0 +1,65 @@
+import crypto from "crypto";
+import { beforeAll, describe, expect, it } from "vitest";
+
+// The MCP secret crypto reads its master secret from the environment lazily
+// (per call), so setting it before importing the module under test is enough.
+const SECRET = "test-mcp-master-secret-at-least-32-chars-long";
+
+let encryptString: typeof import("../client").encryptString;
+let decryptString: typeof import("../client").decryptString;
+
+beforeAll(async () => {
+    process.env.MCP_CONNECTORS_ENCRYPTION_SECRET = SECRET;
+    const mod = await import("../client");
+    encryptString = mod.encryptString;
+    decryptString = mod.decryptString;
+});
+
+// Reproduce the pre-HKDF format: one static-salt scrypt key for every secret,
+// ciphertext stored as bare base64 with no version prefix.
+function legacyEncrypt(value: string) {
+    const key = crypto.scryptSync(SECRET, "mike-user-mcp-v1", 32);
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+    const encrypted = Buffer.concat([cipher.update(value, "utf8"), cipher.final()]);
+    return {
+        encrypted: encrypted.toString("base64"),
+        iv: iv.toString("base64"),
+        tag: cipher.getAuthTag().toString("base64"),
+    };
+}
+
+describe("mcp secret crypto", () => {
+    it("round-trips a value through the versioned per-row scheme", () => {
+        const secret = "sk-connector-abc123";
+        const row = encryptString(secret);
+        expect(row.encrypted.startsWith("v2.")).toBe(true);
+        expect(decryptString(row.encrypted, row.iv, row.tag)).toBe(secret);
+    });
+
+    it("derives a fresh salt per encryption (no shared key across rows)", () => {
+        const a = encryptString("same-value");
+        const b = encryptString("same-value");
+        // Different salt (packed in `encrypted`) and IV → different ciphertext,
+        // yet both decrypt back to the same plaintext.
+        expect(a.encrypted).not.toBe(b.encrypted);
+        expect(decryptString(a.encrypted, a.iv, a.tag)).toBe("same-value");
+        expect(decryptString(b.encrypted, b.iv, b.tag)).toBe("same-value");
+    });
+
+    it("still decrypts legacy static-salt ciphertext (no v2. prefix)", () => {
+        const legacy = legacyEncrypt("legacy-token");
+        expect(legacy.encrypted.startsWith("v2.")).toBe(false);
+        expect(decryptString(legacy.encrypted, legacy.iv, legacy.tag)).toBe(
+            "legacy-token",
+        );
+    });
+
+    it("fails closed when the packed salt/ciphertext is tampered", () => {
+        const row = encryptString("tamper-me");
+        const raw = Buffer.from(row.encrypted.slice("v2.".length), "base64");
+        raw[0] ^= 0xff; // flip a salt byte → wrong derived key → GCM auth fails
+        const tampered = "v2." + raw.toString("base64");
+        expect(decryptString(tampered, row.iv, row.tag)).toBeNull();
+    });
+});

--- a/backend/src/lib/mcp/client.ts
+++ b/backend/src/lib/mcp/client.ts
@@ -27,8 +27,48 @@ function encryptionSecret(): string {
     return secret;
 }
 
-function encryptionKey(): Buffer {
+// Legacy path: one scrypt-derived key for every connector secret (static salt).
+// Kept only to decrypt rows written before per-row HKDF was introduced.
+function legacyEncryptionKey(): Buffer {
     return crypto.scryptSync(encryptionSecret(), "mike-user-mcp-v1", 32);
+}
+
+// New path: HKDF (RFC 5869) derives a unique 256-bit key per secret from a random
+// 16-byte salt. One key's compromise no longer exposes every other connector
+// secret.
+function deriveKey(salt: Buffer): Buffer {
+    return Buffer.from(
+        crypto.hkdfSync(
+            "sha256",
+            Buffer.from(encryptionSecret(), "utf8"),
+            salt,
+            Buffer.from("mike-user-mcp-v2", "utf8"),
+            32,
+        ),
+    );
+}
+
+// The salt has to travel with the ciphertext, but the connector tables have no
+// salt column. Rather than a migration across four encrypted fields, pack it
+// into the stored value: `v2.` + base64(salt(16) || ciphertext). A wrong/forged
+// salt derives a wrong key, so GCM auth fails closed on decrypt. Legacy rows
+// have no `v2.` prefix and decrypt with the static key.
+const V2_PREFIX = "v2.";
+
+function packCiphertext(salt: Buffer, ciphertext: Buffer): string {
+    return V2_PREFIX + Buffer.concat([salt, ciphertext]).toString("base64");
+}
+
+// Resolve stored ciphertext to the key that decrypts it and the raw bytes.
+function unpackCiphertext(stored: string): { key: Buffer; data: Buffer } {
+    if (stored.startsWith(V2_PREFIX)) {
+        const buf = Buffer.from(stored.slice(V2_PREFIX.length), "base64");
+        return {
+            key: deriveKey(buf.subarray(0, 16)),
+            data: buf.subarray(16),
+        };
+    }
+    return { key: legacyEncryptionKey(), data: Buffer.from(stored, "base64") };
 }
 
 export function mcpOAuthCallbackUrl() {
@@ -45,14 +85,15 @@ function encryptJson(value: Record<string, unknown>): {
     auth_config_iv: string;
     auth_config_tag: string;
 } {
+    const salt = crypto.randomBytes(16);
     const iv = crypto.randomBytes(12);
-    const cipher = crypto.createCipheriv("aes-256-gcm", encryptionKey(), iv);
+    const cipher = crypto.createCipheriv("aes-256-gcm", deriveKey(salt), iv);
     const encrypted = Buffer.concat([
         cipher.update(JSON.stringify(value), "utf8"),
         cipher.final(),
     ]);
     return {
-        encrypted_auth_config: encrypted.toString("base64"),
+        encrypted_auth_config: packCiphertext(salt, encrypted),
         auth_config_iv: iv.toString("base64"),
         auth_config_tag: cipher.getAuthTag().toString("base64"),
     };
@@ -63,14 +104,15 @@ export function encryptString(value: string): {
     iv: string;
     tag: string;
 } {
+    const salt = crypto.randomBytes(16);
     const iv = crypto.randomBytes(12);
-    const cipher = crypto.createCipheriv("aes-256-gcm", encryptionKey(), iv);
+    const cipher = crypto.createCipheriv("aes-256-gcm", deriveKey(salt), iv);
     const encrypted = Buffer.concat([
         cipher.update(value, "utf8"),
         cipher.final(),
     ]);
     return {
-        encrypted: encrypted.toString("base64"),
+        encrypted: packCiphertext(salt, encrypted),
         iv: iv.toString("base64"),
         tag: cipher.getAuthTag().toString("base64"),
     };
@@ -83,14 +125,15 @@ export function decryptString(
 ): string | null {
     if (!encrypted || !iv || !tag) return null;
     try {
+        const { key, data } = unpackCiphertext(encrypted);
         const decipher = crypto.createDecipheriv(
             "aes-256-gcm",
-            encryptionKey(),
+            key,
             Buffer.from(iv, "base64"),
         );
         decipher.setAuthTag(Buffer.from(tag, "base64"));
         const decrypted = Buffer.concat([
-            decipher.update(Buffer.from(encrypted, "base64")),
+            decipher.update(data),
             decipher.final(),
         ]);
         return decrypted.toString("utf8");
@@ -111,14 +154,15 @@ export function decryptAuthConfig(row: ConnectorRow): McpConnectorAuthConfig {
         return {};
     }
     try {
+        const { key, data } = unpackCiphertext(row.encrypted_auth_config);
         const decipher = crypto.createDecipheriv(
             "aes-256-gcm",
-            encryptionKey(),
+            key,
             Buffer.from(row.auth_config_iv, "base64"),
         );
         decipher.setAuthTag(Buffer.from(row.auth_config_tag, "base64"));
         const decrypted = Buffer.concat([
-            decipher.update(Buffer.from(row.encrypted_auth_config, "base64")),
+            decipher.update(data),
             decipher.final(),
         ]);
         const parsed = JSON.parse(decrypted.toString("utf8"));


### PR DESCRIPTION
## [Security 2/9] Encrypt MCP connector secrets with per-record derived keys

> Part of the split of #227 into single-topic PRs. Index: tracking comment on #227.

### TL;DR
OAuth access/refresh tokens and client secrets for third-party connectors are stored in our database. This PR encrypts them at rest with **AES-256-GCM**, a **fresh random IV** per encryption, and a **per-record derived key** (random salt per row, key derived from a master secret via HKDF). Legacy rows still decrypt, so there is no migration flag-day.

### Risk to user data
**Severity: high.** These secrets are live credentials to a user's *other* accounts — Gmail, Slack, GitHub, whatever they connected. Stored in plaintext, any single read-path leak (a stolen backup, a mis-permissioned replica, a SQL-injection read) turns into a compromise of every connected third-party account for every user. Encryption at rest means the leaked bytes are useless without the master key, which lives outside the database.

### Flows affected
- MCP connector creation and auth-config storage (`encryptString`, `encryptJson`)
- Connector use / token refresh (`decryptString`, `decryptAuthConfig`)
- No API or behavior change for users; purely at-rest representation.

### Attack precedent
Read-path leaks of at-rest secrets are among the most common breach mechanics: exposed backups and public database snapshots, over-permissioned read replicas, and SQL injection that exfiltrates rows. The [OWASP Cryptographic Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html) exists precisely because "the DB is behind a firewall" has failed so many times.

### Possible fixes, and what we chose

| Option | Verdict |
|---|---|
| Store plaintext, rely on DB access controls | The status quo we're removing. One leak = full compromise. |
| Single static key for all rows | Better, but a dump can be attacked in bulk, and **equal plaintexts produce equal ciphertexts** (leaks structure). |
| AES-256-CBC / encryption without authentication | Rejected — no tamper detection; an attacker who can write rows can flip bits undetectably. |
| **AES-256-GCM + per-record HKDF-derived key + random IV** | **Chosen.** Authenticated (GCM tag detects tampering), semantically secure (random IV, per-row salt), and bulk-attack-resistant (one key's compromise ≠ all rows). |

**The composition is the whole game** — you never invent primitives, you compose standard ones correctly:
- **AES-256-GCM** — authenticated encryption; the auth tag detects tampering (encryption alone does not).
- **Random 12-byte IV per encryption** — GCM fails catastrophically on IV reuse, so this is non-negotiable.
- **Per-record key via HKDF (RFC 5869)** — random 16-byte salt per row → unique key. Bulk dump can't be attacked with one key, and equal plaintexts don't collide.

```mermaid
flowchart LR
    P["secret plaintext"] --> E
    MK["master secret<br/>(env, outside DB)"] --> HKDF
    Salt["random 16-byte salt<br/>(per record)"] --> HKDF
    HKDF["HKDF-SHA256"] --> K["per-record key"]
    K --> E["AES-256-GCM<br/>+ random 12-byte IV"]
    P --> E
    E --> C["v2. || base64(salt ‖ ciphertext)"]
    E --> Tag["auth tag"]
    C --> DB[(database)]
    Tag --> DB
```

**Migration without a flag-day:** the connector tables have no salt column, so the salt is packed into the stored value: `v2.` + `base64(salt(16) ‖ ciphertext)`. Legacy rows have no `v2.` prefix and decrypt with the old static key. A wrong/forged salt derives a wrong key, so GCM auth *fails closed* on decrypt. `crypto.test.ts` covers round-trips and tamper detection.

### What's in this PR
- `backend/src/lib/mcp/client.ts` — HKDF key derivation, packed salt format, GCM encrypt/decrypt with legacy fallback.
- Tests: `crypto.test.ts` (4 tests: round-trip, legacy decrypt, tamper detection).

### Reading
[OWASP Cryptographic Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html) · [Galois/Counter Mode](https://en.wikipedia.org/wiki/Galois/Counter_Mode) · [RFC 5869 (HKDF)](https://www.rfc-editor.org/rfc/rfc5869)
