### PR TITLE
[Security 7/9] Download-token expiry (with legacy back-compat)

### DIFF
--- a/backend/src/core/downloadTokens.ts
+++ b/backend/src/core/downloadTokens.ts
@@ -80,15 +80,25 @@ export function verifyDownloadPayload(
       return null;
     }
     if (!parsed.p || !parsed.f) return null;
-    // Every token must carry an expiry. A token without `e` is legacy (issued
-    // before expiry existed) and would otherwise be valid forever, so reject it
-    // — any such link is long stale (all issuers have set `e` since), and a
-    // fresh, expiring token is re-issued on next access.
-    if (
-      typeof parsed.e !== "number" ||
-      parsed.e < Math.floor(Date.now() / 1000)
-    ) {
-      return null;
+    // Expiry policy:
+    // - All NEW tokens are signed with an `e` (exp) claim; expired tokens are
+    //   rejected, and a malformed `e` is rejected as tampering.
+    // - Tokens WITHOUT an `e` claim are legacy: upstream signed `{p, f}` with
+    //   no expiry until this change, and those permalinks are baked into
+    //   persisted chat messages. Rejecting them would 404 every historical
+    //   download link on deploy (a silent flag-day), so we accept them as a
+    //   transitional back-compat measure. They are still HMAC-verified —
+    //   only the server can have minted them. Once historical links have
+    //   aged out (or been re-issued on access), this branch can be tightened
+    //   to reject missing `e` as well.
+    if ("e" in parsed && parsed.e !== undefined) {
+      if (
+        typeof parsed.e !== "number" ||
+        !Number.isFinite(parsed.e) ||
+        parsed.e < Math.floor(Date.now() / 1000)
+      ) {
+        return null;
+      }
     }
     return { path: parsed.p, filename: parsed.f };
   } catch {

--- a/backend/src/core/downloadTokens.ts
+++ b/backend/src/core/downloadTokens.ts
@@ -1,0 +1,97 @@
+import crypto from "crypto";
+
+export type DownloadTokenPayload = {
+  path: string;
+  filename: string;
+  /** Unix timestamp (seconds) after which the token is invalid. */
+  exp?: number;
+};
+
+function b64urlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function b64urlDecode(s: string): Buffer {
+  let t = s.replace(/-/g, "+").replace(/_/g, "/");
+  while (t.length % 4) t += "=";
+  return Buffer.from(t, "base64");
+}
+
+function timingSafeEqStr(a: string, b: string): boolean {
+  const maxLen = Math.max(a.length, b.length, 1);
+  const aBuf = Buffer.alloc(maxLen, 0);
+  const bBuf = Buffer.alloc(maxLen, 0);
+  Buffer.from(a).copy(aBuf);
+  Buffer.from(b).copy(bBuf);
+  return crypto.timingSafeEqual(aBuf, bBuf) && a.length === b.length;
+}
+
+const DEFAULT_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+export function signDownloadPayload(
+  payload: DownloadTokenPayload,
+  secret: string,
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+): string {
+  const exp = payload.exp ?? Math.floor(Date.now() / 1000) + ttlSeconds;
+  const encodedPayload = b64urlEncode(
+    Buffer.from(
+      JSON.stringify({ p: payload.path, f: payload.filename, e: exp }),
+      "utf8",
+    ),
+  );
+  const signature = crypto
+    .createHmac("sha256", secret)
+    .update(encodedPayload)
+    .digest();
+  return `${encodedPayload}.${b64urlEncode(signature)}`;
+}
+
+export function verifyDownloadPayload(
+  token: string,
+  secret: string,
+): DownloadTokenPayload | null {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+
+  const [encodedPayload, encodedSignature] = parts;
+  const expectedSignature = crypto
+    .createHmac("sha256", secret)
+    .update(encodedPayload)
+    .digest();
+
+  if (!timingSafeEqStr(encodedSignature, b64urlEncode(expectedSignature))) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(
+      b64urlDecode(encodedPayload).toString("utf8"),
+    ) as {
+      p: unknown;
+      f: unknown;
+      e?: unknown;
+    };
+    if (typeof parsed.p !== "string" || typeof parsed.f !== "string") {
+      return null;
+    }
+    if (!parsed.p || !parsed.f) return null;
+    // Every token must carry an expiry. A token without `e` is legacy (issued
+    // before expiry existed) and would otherwise be valid forever, so reject it
+    // — any such link is long stale (all issuers have set `e` since), and a
+    // fresh, expiring token is re-issued on next access.
+    if (
+      typeof parsed.e !== "number" ||
+      parsed.e < Math.floor(Date.now() / 1000)
+    ) {
+      return null;
+    }
+    return { path: parsed.p, filename: parsed.f };
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/lib/__tests__/downloadTokens.expiry.test.ts
+++ b/backend/src/lib/__tests__/downloadTokens.expiry.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { signDownloadPayload, verifyDownloadPayload } from "../../core/downloadTokens";
+
+describe("token expiry", () => {
+    const SECRET = "expiry-test-secret-value-32bytes!";
+
+    it("accepts a token whose exp is in the future", () => {
+        const futureExp = Math.floor(Date.now() / 1000) + 3600;
+        const token = signDownloadPayload(
+            { path: "p", filename: "f.pdf", exp: futureExp },
+            SECRET,
+        );
+        expect(verifyDownloadPayload(token, SECRET)).not.toBeNull();
+    });
+
+    it("rejects a token whose exp is in the past", () => {
+        const pastExp = Math.floor(Date.now() / 1000) - 1;
+        const token = signDownloadPayload(
+            { path: "p", filename: "f.pdf", exp: pastExp },
+            SECRET,
+        );
+        expect(verifyDownloadPayload(token, SECRET)).toBeNull();
+    });
+
+    it("rejects a legacy token with no exp field (would otherwise never expire)", () => {
+        // Manually build a well-signed token without the 'e' field to simulate
+        // old tokens. Such a token was previously accepted forever; it must now
+        // be rejected so every valid token carries an expiry.
+        const b64u = (buf: Buffer) =>
+            buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+        const crypto = require("crypto") as typeof import("crypto");
+        const payload = b64u(Buffer.from(JSON.stringify({ p: "path", f: "file.pdf" })));
+        const sig = b64u(crypto.createHmac("sha256", SECRET).update(payload).digest());
+        const token = `${payload}.${sig}`;
+        expect(verifyDownloadPayload(token, SECRET)).toBeNull();
+    });
+});

--- a/backend/src/lib/__tests__/downloadTokens.expiry.test.ts
+++ b/backend/src/lib/__tests__/downloadTokens.expiry.test.ts
@@ -4,6 +4,30 @@ import { signDownloadPayload, verifyDownloadPayload } from "../../core/downloadT
 describe("token expiry", () => {
     const SECRET = "expiry-test-secret-value-32bytes!";
 
+    const b64u = (buf: Buffer) =>
+        buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+    const nodeCrypto = require("crypto") as typeof import("crypto");
+    const signRaw = (payloadObj: unknown) => {
+        const payload = b64u(Buffer.from(JSON.stringify(payloadObj)));
+        const sig = b64u(
+            nodeCrypto.createHmac("sha256", SECRET).update(payload).digest(),
+        );
+        return `${payload}.${sig}`;
+    };
+
+    it("issues fresh tokens with an exp claim by default and accepts them", () => {
+        const token = signDownloadPayload({ path: "p", filename: "f.pdf" }, SECRET);
+        const decoded = JSON.parse(
+            Buffer.from(
+                token.split(".")[0].replace(/-/g, "+").replace(/_/g, "/"),
+                "base64",
+            ).toString("utf8"),
+        );
+        expect(typeof decoded.e).toBe("number");
+        expect(decoded.e).toBeGreaterThan(Math.floor(Date.now() / 1000));
+        expect(verifyDownloadPayload(token, SECRET)).not.toBeNull();
+    });
+
     it("accepts a token whose exp is in the future", () => {
         const futureExp = Math.floor(Date.now() / 1000) + 3600;
         const token = signDownloadPayload(
@@ -22,16 +46,39 @@ describe("token expiry", () => {
         expect(verifyDownloadPayload(token, SECRET)).toBeNull();
     });
 
-    it("rejects a legacy token with no exp field (would otherwise never expire)", () => {
-        // Manually build a well-signed token without the 'e' field to simulate
-        // old tokens. Such a token was previously accepted forever; it must now
-        // be rejected so every valid token carries an expiry.
-        const b64u = (buf: Buffer) =>
-            buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
-        const crypto = require("crypto") as typeof import("crypto");
-        const payload = b64u(Buffer.from(JSON.stringify({ p: "path", f: "file.pdf" })));
-        const sig = b64u(crypto.createHmac("sha256", SECRET).update(payload).digest());
-        const token = `${payload}.${sig}`;
+    it("accepts a legacy token with no exp field (transitional back-compat)", () => {
+        // Upstream signed {p, f} with no expiry until this change, and those
+        // permalinks live on in persisted chat messages. A well-signed legacy
+        // token must stay valid so historical download links don't 404 on
+        // deploy; only the server could have minted it (HMAC still verified).
+        const token = signRaw({ p: "path", f: "file.pdf" });
+        const result = verifyDownloadPayload(token, SECRET);
+        expect(result).not.toBeNull();
+        expect(result!.path).toBe("path");
+        expect(result!.filename).toBe("file.pdf");
+    });
+
+    it("rejects a legacy-shaped token whose signature does not verify", () => {
+        const token = signRaw({ p: "path", f: "file.pdf" });
+        const [payload] = token.split(".");
+        const badSig = b64u(
+            nodeCrypto.createHmac("sha256", "wrong-secret").update(payload).digest(),
+        );
+        expect(verifyDownloadPayload(`${payload}.${badSig}`, SECRET)).toBeNull();
+    });
+
+    it("rejects a tampered payload even if it drops the exp claim", () => {
+        // Take a valid expiring token, strip `e` / change the path, keep the
+        // old signature: the HMAC check must fail. Removing the expiry is not
+        // a route around it.
+        const token = signDownloadPayload({ path: "p", filename: "f.pdf" }, SECRET);
+        const [, sig] = token.split(".");
+        const forged = b64u(Buffer.from(JSON.stringify({ p: "other", f: "f.pdf" })));
+        expect(verifyDownloadPayload(`${forged}.${sig}`, SECRET)).toBeNull();
+    });
+
+    it("rejects a token whose exp claim is malformed (non-numeric)", () => {
+        const token = signRaw({ p: "path", f: "file.pdf", e: "never" });
         expect(verifyDownloadPayload(token, SECRET)).toBeNull();
     });
 });

--- a/backend/src/lib/downloadTokens.ts
+++ b/backend/src/lib/downloadTokens.ts
@@ -1,4 +1,7 @@
-import crypto from "crypto";
+import {
+  signDownloadPayload,
+  verifyDownloadPayload,
+} from "../core/downloadTokens";
 
 /**
  * HMAC-signed, non-expiring download tokens.
@@ -10,66 +13,24 @@ import crypto from "crypto";
  */
 
 function getSecret(): string {
-    const secret = process.env.DOWNLOAD_SIGNING_SECRET;
-    if (!secret) {
-        throw new Error(
-            "DOWNLOAD_SIGNING_SECRET must be set. " +
-                "Generate a strong random value (e.g. `openssl rand -hex 32`) and set it in the environment.",
-        );
-    }
-    return secret;
-}
-
-function b64urlEncode(buf: Buffer): string {
-    return buf
-        .toString("base64")
-        .replace(/\+/g, "-")
-        .replace(/\//g, "_")
-        .replace(/=+$/g, "");
-}
-
-function b64urlDecode(s: string): Buffer {
-    let t = s.replace(/-/g, "+").replace(/_/g, "/");
-    while (t.length % 4) t += "=";
-    return Buffer.from(t, "base64");
-}
-
-function timingSafeEqStr(a: string, b: string): boolean {
-    if (a.length !== b.length) return false;
-    return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  const secret = process.env.DOWNLOAD_SIGNING_SECRET;
+  if (!secret) {
+    throw new Error(
+      "DOWNLOAD_SIGNING_SECRET must be set. " +
+        "Generate a strong random value (e.g. `openssl rand -hex 32`) and set it in the environment.",
+    );
+  }
+  return secret;
 }
 
 export function signDownload(path: string, filename: string): string {
-    const payload = JSON.stringify({ p: path, f: filename });
-    const enc = b64urlEncode(Buffer.from(payload, "utf8"));
-    const sig = crypto
-        .createHmac("sha256", getSecret())
-        .update(enc)
-        .digest();
-    return `${enc}.${b64urlEncode(sig)}`;
+  return signDownloadPayload({ path, filename }, getSecret());
 }
 
 export function verifyDownload(
-    token: string,
+  token: string,
 ): { path: string; filename: string } | null {
-    const parts = token.split(".");
-    if (parts.length !== 2) return null;
-    const [enc, sigEnc] = parts;
-    const expected = crypto
-        .createHmac("sha256", getSecret())
-        .update(enc)
-        .digest();
-    if (!timingSafeEqStr(sigEnc, b64urlEncode(expected))) return null;
-    try {
-        const parsed = JSON.parse(b64urlDecode(enc).toString("utf8")) as {
-            p: string;
-            f: string;
-        };
-        if (!parsed?.p || !parsed?.f) return null;
-        return { path: parsed.p, filename: parsed.f };
-    } catch {
-        return null;
-    }
+  return verifyDownloadPayload(token, getSecret());
 }
 
 /**
@@ -77,5 +38,5 @@ export function verifyDownload(
  * prefixes it with NEXT_PUBLIC_API_BASE_URL when rendering `<a href=…>`.
  */
 export function buildDownloadUrl(path: string, filename: string): string {
-    return `/download/${signDownload(path, filename)}`;
+  return `/download/${signDownload(path, filename)}`;
 }

--- a/backend/src/lib/downloadTokens.ts
+++ b/backend/src/lib/downloadTokens.ts
@@ -4,12 +4,13 @@ import {
 } from "../core/downloadTokens";
 
 /**
- * HMAC-signed, non-expiring download tokens.
+ * HMAC-signed download tokens with a mandatory expiry (30 days by default).
  *
- * The token encodes the R2 storage path + filename; the backend route
- * `/download/:token` validates the signature and streams the file. This
- * gives persistent links safe to store in chat history without signed-URL
- * expiry or R2 CORS headaches.
+ * The token encodes the R2 storage path + filename + expiry; the backend
+ * route `/download/:token` validates the signature and expiry and streams
+ * the file. Links stored in chat history go stale after the TTL — a fresh
+ * token is re-issued on next access — and tokens without an expiry are
+ * rejected outright so no link is valid forever.
  */
 
 function getSecret(): string {

--- a/backend/src/lib/downloadTokens.ts
+++ b/backend/src/lib/downloadTokens.ts
@@ -4,13 +4,15 @@ import {
 } from "../core/downloadTokens";
 
 /**
- * HMAC-signed download tokens with a mandatory expiry (30 days by default).
+ * HMAC-signed download tokens with an expiry (30 days by default).
  *
  * The token encodes the R2 storage path + filename + expiry; the backend
  * route `/download/:token` validates the signature and expiry and streams
- * the file. Links stored in chat history go stale after the TTL — a fresh
- * token is re-issued on next access — and tokens without an expiry are
- * rejected outright so no link is valid forever.
+ * the file. All newly issued tokens carry an expiry, and expired tokens are
+ * rejected. Legacy tokens issued before expiry existed (no `e` claim, but
+ * still HMAC-verified) are accepted transitionally so historical download
+ * links persisted in chat messages keep working — see
+ * core/downloadTokens.ts for the policy details.
  */
 
 function getSecret(): string {


### PR DESCRIPTION
## [Security 7/9] Download-token expiry (with legacy back-compat)

> Part of the split of #227 into single-topic PRs. Index: tracking comment on #227.

### TL;DR
Download links are HMAC-signed tokens encoding an R2 path + filename. This PR adds a **mandatory `exp` claim to every newly issued token** (30-day default TTL) and rejects expired or malformed-`exp` tokens. Well-signed *legacy* tokens without an `exp` claim are accepted **transitionally** so historical links baked into chat history don't 404 on deploy.

### Risk to user data
**Severity: medium–high.** A non-expiring download token is a **permanent capability**. In a legal product it points at a confidential document, and it leaks the way URLs always leak — chat logs, browser history, forwarded emails, referrer headers. A leaked eternal link is a confidential document exposed forever, to anyone who ever sees the URL. Time-boxing bounds that exposure window.

### Flows affected
- Download link issuance (`signDownload` / `signDownloadPayload`).
- `/download/:token` verification (`verifyDownload` / `verifyDownloadPayload`).
- Links persisted in historical chat messages (the back-compat concern).

### Attack precedent
The general principle — **credentials must be time-boxed** — is codified for signed tokens in [RFC 8725 (JWT BCP)](https://www.rfc-editor.org/rfc/rfc8725): always set and validate `exp`. Long-lived bearer URLs are a recurring source of data exposure (leaked pre-signed S3 URLs, permalink leaks via referrer).

### Possible fixes, and what we chose

| Option | Verdict |
|---|---|
| Keep non-expiring tokens | The status quo. Eternal capability. Rejected. |
| Add `exp` and **reject** any token without one | Correct end-state, but upstream's *entire issuance history* signed `{p, f}` with no `exp`, and those permalinks live in persisted chat messages — this would **404 every historical link the instant it deploys** (a silent flag-day). |
| Switch to short-lived pre-signed R2 URLs | Larger change; loses the "safe to store in chat history" property this token scheme was built for. Out of scope here. |
| **New tokens carry `exp` and are enforced; legacy no-`exp` tokens accepted transitionally (still HMAC-verified)** | **Chosen.** Bounds all *new* exposure immediately while keeping existing links working. Legacy tokens are still signature-verified, so only the server could have minted them. |

```mermaid
flowchart TD
    T["/download/:token"] --> S{HMAC signature valid?}
    S -- no --> Rej["reject (404)"]
    S -- yes --> E{has exp claim?}
    E -- "yes" --> V{exp well-formed<br/>and in the future?}
    V -- yes --> OK["serve file"]
    V -- "no / expired / malformed" --> Rej
    E -- "no (legacy)" --> OK2["serve file<br/>(transitional back-compat)"]
```

**Disclosed trade-off:** accepting legacy `exp`-less tokens is a deliberate, temporary compromise, called out in-code. The intended end state is strict `exp` enforcement once historical links have aged out or been re-issued on access — a one-line tightening. `downloadTokens.expiry.test.ts` locks in all four behaviours: fresh accepted (exp present), legacy accepted, expired rejected, tampered/malformed-`exp` rejected (including stripping `exp` as a tamper route). This PR reflects the reviewed final policy (the strict-then-relaxed history from #227 is collapsed into the transitional policy plus its tests).

### What's in this PR
- `backend/src/core/downloadTokens.ts` — new signer/verifier with `exp`, timing-safe compare, legacy branch.
- `backend/src/lib/downloadTokens.ts` — delegates to core; doc header reflects the policy.
- Tests: `downloadTokens.expiry.test.ts` (7 tests).

### Reading
[RFC 8725 (JWT Best Current Practices)](https://www.rfc-editor.org/rfc/rfc8725) · [OWASP Access Control Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Access_Control_Cheat_Sheet.html)
