### PR TITLE
[Testing 17] test(backend): document-integrity unit tests + ratchet raise

### DIFF
--- a/backend/src/lib/__tests__/chatPrompts.test.ts
+++ b/backend/src/lib/__tests__/chatPrompts.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { SYSTEM_PROMPT, buildSystemPrompt } from "../chat/prompts";
+import { COURTLISTENER_SYSTEM_PROMPT } from "../chat/tools/courtlistenerTools";
+
+describe("buildSystemPrompt", () => {
+    it("always contains the core identity and rules", () => {
+        for (const prompt of [buildSystemPrompt(true), buildSystemPrompt(false)]) {
+            expect(prompt).toContain(
+                "You are Mike, an AI legal assistant for lawyers and legal professionals.",
+            );
+            expect(prompt).toContain("Do not fabricate document content.");
+            expect(prompt).toContain("DOCX GENERATION:");
+            expect(prompt).toContain("DOCUMENT EDITING:");
+        }
+    });
+
+    it("always contains the citation contract the parser depends on", () => {
+        for (const prompt of [buildSystemPrompt(true), buildSystemPrompt(false)]) {
+            expect(prompt).toContain("<CITATIONS>");
+            expect(prompt).toContain("</CITATIONS>");
+            expect(prompt).toContain(
+                `Every [N] marker must have exactly one matching entry with "ref": N.`,
+            );
+            expect(prompt).toContain(
+                `"doc_id" must be the exact chat-local label you were given`,
+            );
+        }
+    });
+
+    it("always contains the doc-label hygiene and reasoning-trace safety rules", () => {
+        for (const prompt of [buildSystemPrompt(true), buildSystemPrompt(false)]) {
+            expect(prompt).toContain("REASONING TRACE SAFETY:");
+            expect(prompt).toContain(
+                `Never show "doc-N" labels to the user in prose`,
+            );
+        }
+    });
+
+    it("splices the CourtListener instructions between the two base sections when research is on", () => {
+        const prompt = buildSystemPrompt(true);
+        expect(prompt).toContain(COURTLISTENER_SYSTEM_PROMPT);
+        const researchIdx = prompt.indexOf("US CASE LAW RESEARCH:");
+        const editingIdx = prompt.indexOf("DOCUMENT EDITING:");
+        const afterIdx = prompt.indexOf("DOCUMENT NAMES IN PROSE:");
+        expect(editingIdx).toBeLessThan(researchIdx);
+        expect(researchIdx).toBeLessThan(afterIdx);
+    });
+
+    it("omits the CourtListener instructions entirely when research is off", () => {
+        const prompt = buildSystemPrompt(false);
+        expect(prompt).not.toContain("US CASE LAW RESEARCH");
+        expect(prompt).not.toContain("courtlistener");
+        // Both base sections are still present and in order.
+        const editingIdx = prompt.indexOf("DOCUMENT EDITING:");
+        const afterIdx = prompt.indexOf("DOCUMENT NAMES IN PROSE:");
+        expect(editingIdx).toBeGreaterThan(-1);
+        expect(editingIdx).toBeLessThan(afterIdx);
+    });
+
+    it("defaults to including research tools", () => {
+        expect(buildSystemPrompt()).toBe(buildSystemPrompt(true));
+    });
+});
+
+describe("SYSTEM_PROMPT", () => {
+    it("is the research-enabled prompt", () => {
+        expect(SYSTEM_PROMPT).toBe(buildSystemPrompt(true));
+    });
+});

--- a/backend/src/lib/__tests__/documentTypes.test.ts
+++ b/backend/src/lib/__tests__/documentTypes.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+    ALLOWED_DOCUMENT_TYPES,
+    ALLOWED_DOCUMENT_TYPES_LABEL,
+    contentTypeForDocumentType,
+    isPresentationDocumentType,
+    isSpreadsheetDocumentType,
+    isWordDocumentType,
+    shouldConvertToPdf,
+} from "../documentTypes";
+
+describe("ALLOWED_DOCUMENT_TYPES", () => {
+    it("matches the human-readable label exactly", () => {
+        expect([...ALLOWED_DOCUMENT_TYPES].sort()).toEqual(
+            ALLOWED_DOCUMENT_TYPES_LABEL.split(", ").sort(),
+        );
+    });
+});
+
+describe("isWordDocumentType", () => {
+    it("recognizes docx and doc, case-insensitively", () => {
+        expect(isWordDocumentType("docx")).toBe(true);
+        expect(isWordDocumentType("doc")).toBe(true);
+        expect(isWordDocumentType("DOCX")).toBe(true);
+    });
+
+    it("rejects other types and missing input", () => {
+        expect(isWordDocumentType("pdf")).toBe(false);
+        expect(isWordDocumentType("")).toBe(false);
+        expect(isWordDocumentType(null)).toBe(false);
+        expect(isWordDocumentType(undefined)).toBe(false);
+    });
+});
+
+describe("isSpreadsheetDocumentType", () => {
+    it("recognizes xlsx, xlsm, and xls, case-insensitively", () => {
+        expect(isSpreadsheetDocumentType("xlsx")).toBe(true);
+        expect(isSpreadsheetDocumentType("xlsm")).toBe(true);
+        expect(isSpreadsheetDocumentType("XLS")).toBe(true);
+    });
+
+    it("rejects other types and missing input", () => {
+        expect(isSpreadsheetDocumentType("docx")).toBe(false);
+        expect(isSpreadsheetDocumentType(null)).toBe(false);
+        expect(isSpreadsheetDocumentType(undefined)).toBe(false);
+    });
+});
+
+describe("isPresentationDocumentType", () => {
+    it("recognizes pptx and ppt, case-insensitively", () => {
+        expect(isPresentationDocumentType("pptx")).toBe(true);
+        expect(isPresentationDocumentType("PPT")).toBe(true);
+    });
+
+    it("rejects other types and missing input", () => {
+        expect(isPresentationDocumentType("pdf")).toBe(false);
+        expect(isPresentationDocumentType(null)).toBe(false);
+        expect(isPresentationDocumentType(undefined)).toBe(false);
+    });
+});
+
+describe("shouldConvertToPdf", () => {
+    it("converts Word and presentation documents", () => {
+        expect(shouldConvertToPdf("docx")).toBe(true);
+        expect(shouldConvertToPdf("doc")).toBe(true);
+        expect(shouldConvertToPdf("pptx")).toBe(true);
+        expect(shouldConvertToPdf("PPT")).toBe(true);
+    });
+
+    it("deliberately skips spreadsheets (rendered natively as a grid)", () => {
+        expect(shouldConvertToPdf("xlsx")).toBe(false);
+        expect(shouldConvertToPdf("xlsm")).toBe(false);
+        expect(shouldConvertToPdf("xls")).toBe(false);
+    });
+
+    it("skips pdf itself and missing input", () => {
+        expect(shouldConvertToPdf("pdf")).toBe(false);
+        expect(shouldConvertToPdf(null)).toBe(false);
+        expect(shouldConvertToPdf(undefined)).toBe(false);
+    });
+});
+
+describe("contentTypeForDocumentType", () => {
+    it("maps every allowed type to its MIME type", () => {
+        const expected: Record<string, string> = {
+            pdf: "application/pdf",
+            docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            doc: "application/octet-stream", // legacy .doc has no dedicated mapping
+            xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            xlsm: "application/vnd.ms-excel.sheet.macroEnabled.12",
+            xls: "application/vnd.ms-excel",
+            pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            ppt: "application/vnd.ms-powerpoint",
+        };
+        for (const type of ALLOWED_DOCUMENT_TYPES) {
+            expect(contentTypeForDocumentType(type)).toBe(expected[type]);
+        }
+    });
+
+    it("is case-insensitive", () => {
+        expect(contentTypeForDocumentType("PDF")).toBe("application/pdf");
+    });
+
+    it("falls back to application/octet-stream for unknown or missing input", () => {
+        expect(contentTypeForDocumentType("exe")).toBe("application/octet-stream");
+        expect(contentTypeForDocumentType("")).toBe("application/octet-stream");
+        expect(contentTypeForDocumentType(null)).toBe("application/octet-stream");
+        expect(contentTypeForDocumentType(undefined)).toBe(
+            "application/octet-stream",
+        );
+    });
+});

--- a/backend/src/lib/__tests__/docxTrackedChanges.test.ts
+++ b/backend/src/lib/__tests__/docxTrackedChanges.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+import JSZip from "jszip";
+import {
+    applyTrackedEdits,
+    extractDocxBodyText,
+    extractTrackedChangeIds,
+    resolveTrackedChange,
+} from "../docxTrackedChanges";
+
+const W_NS =
+    'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+/**
+ * Build a minimal in-memory .docx: a zip whose word/document.xml wraps the
+ * given body XML. No [Content_Types].xml etc. — the module only reads
+ * word/document.xml, so this is the smallest fixture that exercises it.
+ */
+async function makeDocx(bodyXml: string): Promise<Buffer> {
+    const zip = new JSZip();
+    zip.file(
+        "word/document.xml",
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+            `<w:document ${W_NS}><w:body>${bodyXml}</w:body></w:document>`,
+    );
+    return zip.generateAsync({ type: "nodebuffer" });
+}
+
+function para(text: string): string {
+    return `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+}
+
+async function readDocumentXml(bytes: Buffer): Promise<string> {
+    const zip = await JSZip.loadAsync(bytes);
+    return zip.file("word/document.xml")!.async("string");
+}
+
+describe("extractDocxBodyText", () => {
+    it("joins paragraph texts with newlines", async () => {
+        const bytes = await makeDocx(para("First paragraph.") + para("Second."));
+        await expect(extractDocxBodyText(bytes)).resolves.toBe(
+            "First paragraph.\nSecond.",
+        );
+    });
+
+    it("uses the accepted view: w:ins text included, w:del text excluded", async () => {
+        const bytes = await makeDocx(
+            `<w:p>` +
+                `<w:r><w:t xml:space="preserve">Keep </w:t></w:r>` +
+                `<w:ins w:id="1"><w:r><w:t>added</w:t></w:r></w:ins>` +
+                `<w:del w:id="2"><w:r><w:delText>removed</w:delText></w:r></w:del>` +
+                `</w:p>`,
+        );
+        await expect(extractDocxBodyText(bytes)).resolves.toBe("Keep added");
+    });
+
+    it("returns an empty string when word/document.xml is missing", async () => {
+        const zip = new JSZip();
+        zip.file("other.txt", "not a docx");
+        const bytes = await zip.generateAsync({ type: "nodebuffer" });
+        await expect(extractDocxBodyText(bytes)).resolves.toBe("");
+    });
+});
+
+describe("applyTrackedEdits", () => {
+    it("emits a w:del/w:ins pair for a replacement and reports the change", async () => {
+        const bytes = await makeDocx(para("The fee is ten dollars."));
+        const result = await applyTrackedEdits(bytes, [
+            {
+                find: "ten dollars",
+                replace: "five dollars",
+                context_before: "The fee is ",
+                context_after: ".",
+            },
+        ]);
+
+        expect(result.errors).toEqual([]);
+        expect(result.changes).toHaveLength(1);
+        const change = result.changes[0];
+        expect(change.deletedText).toBe("ten");
+        expect(change.insertedText).toBe("five");
+        expect(change.delId).toBeDefined();
+        expect(change.insId).toBeDefined();
+
+        const xml = await readDocumentXml(result.bytes);
+        expect(xml).toContain("<w:del");
+        expect(xml).toContain("<w:ins");
+        expect(xml).toContain(`w:author="Mike"`);
+        expect(xml).toContain("<w:delText");
+
+        // Accepted view of the output shows the replacement applied.
+        await expect(extractDocxBodyText(result.bytes)).resolves.toBe(
+            "The fee is five dollars.",
+        );
+    });
+
+    it("trims common prefix/suffix so only the changed span is tracked", async () => {
+        const bytes = await makeDocx(para("Payment due in 30 days."));
+        const result = await applyTrackedEdits(bytes, [
+            {
+                find: "Payment due in 30 days",
+                replace: "Payment due in 45 days",
+                context_before: "",
+                context_after: "",
+            },
+        ]);
+        expect(result.errors).toEqual([]);
+        expect(result.changes[0].deletedText).toBe("30");
+        expect(result.changes[0].insertedText).toBe("45");
+    });
+
+    it("honours a custom author", async () => {
+        const bytes = await makeDocx(para("Hello world."));
+        const result = await applyTrackedEdits(
+            bytes,
+            [{ find: "world", replace: "there", context_before: "", context_after: "" }],
+            { author: "Reviewer" },
+        );
+        const xml = await readDocumentXml(result.bytes);
+        expect(xml).toContain(`w:author="Reviewer"`);
+    });
+
+    it("supports a pure insertion anchored on context_before", async () => {
+        const bytes = await makeDocx(para("Hello world."));
+        const result = await applyTrackedEdits(bytes, [
+            {
+                find: "",
+                replace: "brave ",
+                context_before: "Hello ",
+                context_after: "",
+            },
+        ]);
+        expect(result.errors).toEqual([]);
+        expect(result.changes[0].delId).toBeUndefined();
+        expect(result.changes[0].insId).toBeDefined();
+        await expect(extractDocxBodyText(result.bytes)).resolves.toBe(
+            "Hello brave world.",
+        );
+    });
+
+    it("supports a pure deletion (empty replace)", async () => {
+        const bytes = await makeDocx(para("Hello cruel world."));
+        const result = await applyTrackedEdits(bytes, [
+            {
+                find: "cruel ",
+                replace: "",
+                context_before: "Hello ",
+                context_after: "world",
+            },
+        ]);
+        expect(result.errors).toEqual([]);
+        expect(result.changes[0].delId).toBeDefined();
+        expect(result.changes[0].insId).toBeUndefined();
+        await expect(extractDocxBodyText(result.bytes)).resolves.toBe(
+            "Hello world.",
+        );
+    });
+
+    it("numbers new tracked changes above the existing max w:id", async () => {
+        const bytes = await makeDocx(
+            `<w:p><w:ins w:id="7"><w:r><w:t>Existing insertion. </w:t></w:r></w:ins>` +
+                `<w:r><w:t xml:space="preserve">Plain text.</w:t></w:r></w:p>`,
+        );
+        const result = await applyTrackedEdits(bytes, [
+            {
+                find: "Plain",
+                replace: "Simple",
+                context_before: "",
+                context_after: " text.",
+            },
+        ]);
+        expect(result.errors).toEqual([]);
+        expect(result.changes[0].delId).toBe("8");
+        expect(result.changes[0].insId).toBe("9");
+    });
+
+    it("reports an error for a find that is not in the document", async () => {
+        const bytes = await makeDocx(para("Hello world."));
+        const result = await applyTrackedEdits(bytes, [
+            {
+                find: "goodbye",
+                replace: "farewell",
+                context_before: "",
+                context_after: "",
+            },
+        ]);
+        expect(result.changes).toEqual([]);
+        expect(result.errors).toEqual([
+            { index: 0, reason: expect.stringContaining("Could not locate") },
+        ]);
+        // The document itself is returned intact.
+        await expect(extractDocxBodyText(result.bytes)).resolves.toBe(
+            "Hello world.",
+        );
+    });
+
+    it("reports an ambiguous match instead of guessing", async () => {
+        const bytes = await makeDocx(para("alpha beta alpha"));
+        const result = await applyTrackedEdits(bytes, [
+            { find: "alpha", replace: "gamma", context_before: "", context_after: "" },
+        ]);
+        expect(result.changes).toEqual([]);
+        expect(result.errors).toEqual([
+            { index: 0, reason: expect.stringContaining("Ambiguous match") },
+        ]);
+    });
+
+    it("rejects empty edits and uncontexted pure insertions", async () => {
+        const bytes = await makeDocx(para("Hello world."));
+        const result = await applyTrackedEdits(bytes, [
+            { find: "", replace: "", context_before: "", context_after: "" },
+            { find: "", replace: "orphan", context_before: "", context_after: "" },
+        ]);
+        expect(result.changes).toEqual([]);
+        expect(result.errors).toEqual([
+            { index: 0, reason: "Empty edit." },
+            {
+                index: 1,
+                reason: "Pure insertion requires context_before or context_after.",
+            },
+        ]);
+    });
+
+    it("throws when word/document.xml is missing from the archive", async () => {
+        const zip = new JSZip();
+        zip.file("other.txt", "not a docx");
+        const bytes = await zip.generateAsync({ type: "nodebuffer" });
+        await expect(applyTrackedEdits(bytes, [])).rejects.toThrow(
+            "document.xml missing from docx",
+        );
+    });
+
+    it("rejects bytes that are not a zip archive at all", async () => {
+        await expect(
+            applyTrackedEdits(Buffer.from("plainly not a zip"), []),
+        ).rejects.toThrow();
+    });
+});
+
+describe("resolveTrackedChange", () => {
+    /** Apply one replace edit and return the output bytes + w:ids. */
+    async function trackedFixture() {
+        const bytes = await makeDocx(para("The fee is ten dollars."));
+        const applied = await applyTrackedEdits(bytes, [
+            {
+                find: "ten",
+                replace: "twenty",
+                context_before: "The fee is ",
+                context_after: " dollars",
+            },
+        ]);
+        expect(applied.errors).toEqual([]);
+        const { delId, insId } = applied.changes[0];
+        return { bytes: applied.bytes, delId: delId!, insId: insId! };
+    }
+
+    it("accept collapses the change to the new text", async () => {
+        const { bytes, delId, insId } = await trackedFixture();
+        const resolved = await resolveTrackedChange(bytes, [delId, insId], "accept");
+        expect(resolved.found).toBe(true);
+        await expect(extractDocxBodyText(resolved.bytes)).resolves.toBe(
+            "The fee is twenty dollars.",
+        );
+        await expect(extractTrackedChangeIds(resolved.bytes)).resolves.toEqual([]);
+    });
+
+    it("reject restores the original text, converting w:delText back to w:t", async () => {
+        const { bytes, delId, insId } = await trackedFixture();
+        const resolved = await resolveTrackedChange(bytes, [delId, insId], "reject");
+        expect(resolved.found).toBe(true);
+        await expect(extractDocxBodyText(resolved.bytes)).resolves.toBe(
+            "The fee is ten dollars.",
+        );
+        await expect(extractTrackedChangeIds(resolved.bytes)).resolves.toEqual([]);
+        const xml = await readDocumentXml(resolved.bytes);
+        expect(xml).not.toContain("w:delText");
+    });
+
+    it("returns found=false and leaves the document alone for unknown ids", async () => {
+        const { bytes } = await trackedFixture();
+        const resolved = await resolveTrackedChange(bytes, ["999"], "accept");
+        expect(resolved.found).toBe(false);
+        await expect(extractTrackedChangeIds(resolved.bytes)).resolves.toHaveLength(2);
+    });
+});
+
+describe("extractTrackedChangeIds", () => {
+    it("lists w:ins/w:del wrappers in document order", async () => {
+        const bytes = await makeDocx(
+            `<w:p>` +
+                `<w:ins w:id="3"><w:r><w:t>a</w:t></w:r></w:ins>` +
+                `<w:del w:id="5"><w:r><w:delText>b</w:delText></w:r></w:del>` +
+                `<w:ins w:id="9"><w:r><w:t>c</w:t></w:r></w:ins>` +
+                `</w:p>`,
+        );
+        await expect(extractTrackedChangeIds(bytes)).resolves.toEqual([
+            { kind: "ins", w_id: "3" },
+            { kind: "del", w_id: "5" },
+            { kind: "ins", w_id: "9" },
+        ]);
+    });
+
+    it("returns [] when word/document.xml is missing", async () => {
+        const zip = new JSZip();
+        zip.file("other.txt", "not a docx");
+        const bytes = await zip.generateAsync({ type: "nodebuffer" });
+        await expect(extractTrackedChangeIds(bytes)).resolves.toEqual([]);
+    });
+});

--- a/backend/src/lib/__tests__/systemWorkflows.test.ts
+++ b/backend/src/lib/__tests__/systemWorkflows.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+    SYSTEM_ASSISTANT_WORKFLOWS,
+    SYSTEM_WORKFLOWS,
+    SYSTEM_WORKFLOW_IDS,
+} from "../systemWorkflows";
+
+describe("SYSTEM_WORKFLOWS", () => {
+    it("has unique, builtin-prefixed ids", () => {
+        const ids = SYSTEM_WORKFLOWS.map((wf) => wf.id);
+        expect(new Set(ids).size).toBe(ids.length);
+        for (const id of ids) {
+            expect(id).toMatch(/^builtin-[a-z0-9-]+$/);
+        }
+    });
+
+    it("marks every workflow as a system workflow with complete metadata", () => {
+        for (const wf of SYSTEM_WORKFLOWS) {
+            expect(wf.is_system).toBe(true);
+            expect(wf.user_id).toBeNull();
+            expect(wf.metadata.title.trim()).not.toBe("");
+            expect(wf.metadata.description.trim()).not.toBe("");
+            expect(["assistant", "tabular"]).toContain(wf.metadata.type);
+            expect(wf.metadata.contributors.length).toBeGreaterThan(0);
+            expect(wf.metadata.version.trim()).not.toBe("");
+        }
+    });
+
+    it("gives every workflow non-empty skill markdown with a heading", () => {
+        for (const wf of SYSTEM_WORKFLOWS) {
+            expect(wf.skill_md, wf.id).toBeTruthy();
+            expect(wf.skill_md!.startsWith("# "), wf.id).toBe(true);
+        }
+    });
+
+    it("gives tabular workflows a well-formed columns_config", () => {
+        for (const wf of SYSTEM_WORKFLOWS) {
+            if (wf.metadata.type !== "tabular") continue;
+            expect(wf.columns_config, wf.id).toBeTruthy();
+            const columns = wf.columns_config!;
+            expect(columns.length).toBeGreaterThan(0);
+            columns.forEach((column, i) => {
+                // Indexes are contiguous from 0 so the frontend can lay the
+                // table out positionally.
+                expect(column.index, `${wf.id} column ${i}`).toBe(i);
+                expect(column.name.trim(), `${wf.id} column ${i}`).not.toBe("");
+                expect(column.prompt.trim(), `${wf.id} column ${i}`).not.toBe("");
+            });
+        }
+    });
+});
+
+describe("SYSTEM_WORKFLOW_IDS", () => {
+    it("is exactly the set of workflow ids", () => {
+        expect([...SYSTEM_WORKFLOW_IDS].sort()).toEqual(
+            SYSTEM_WORKFLOWS.map((wf) => wf.id).sort(),
+        );
+    });
+});
+
+describe("SYSTEM_ASSISTANT_WORKFLOWS", () => {
+    it("mirrors exactly the assistant-typed workflows", () => {
+        const assistantIds = SYSTEM_WORKFLOWS.filter(
+            (wf) => wf.metadata.type === "assistant",
+        )
+            .map((wf) => wf.id)
+            .sort();
+        expect(SYSTEM_ASSISTANT_WORKFLOWS.map((wf) => wf.id).sort()).toEqual(
+            assistantIds,
+        );
+    });
+
+    it("keeps title and skill markdown in sync with the full definitions", () => {
+        const byId = new Map(SYSTEM_WORKFLOWS.map((wf) => [wf.id, wf]));
+        for (const wf of SYSTEM_ASSISTANT_WORKFLOWS) {
+            const full = byId.get(wf.id);
+            expect(full, wf.id).toBeTruthy();
+            expect(wf.title, wf.id).toBe(full!.metadata.title);
+            expect(wf.skill_md, wf.id).toBe(full!.skill_md);
+            expect(wf.skill_md.trim(), wf.id).not.toBe("");
+        }
+    });
+});

--- a/backend/vitest.config.mts
+++ b/backend/vitest.config.mts
@@ -19,19 +19,21 @@ export default defineConfig({
             // tested libs (access, storage keys/dispositions, downloadTokens,
             // userApiKeys provider/env checks, chat doc resolution, safeError,
             // llm model resolution, chat citations, userLookup,
-            // documentVersions, userDataCleanup) AND the large, still-untested
-            // feature libs (courtlistener, mcp, chat tool dispatch, llm
-            // providers, spreadsheet/docx handling), so the global number is
-            // still low. Measured on this tree: 11.18% statements, 10.98%
-            // branches, 14.43% functions, 10.91% lines. These floors sit just
-            // below that (rounded down to whole percents) so CI fails on a
-            // *drop*. Floors only go up: when you add tests, raise them in the
-            // same PR. Backlog + per-area status: docs/testing-coverage.md.
+            // documentVersions, userDataCleanup, docxTrackedChanges,
+            // documentTypes, chat prompts, systemWorkflows) AND the large,
+            // still-untested feature libs (courtlistener, mcp, chat tool
+            // dispatch, llm providers, spreadsheet handling), so the global
+            // number is still low. Measured on this tree: 23.88% statements,
+            // 17.98% branches, 23.06% functions, 23.79% lines. These floors
+            // sit just below that (rounded down to whole percents) so CI
+            // fails on a *drop*. Floors only go up: when you add tests, raise
+            // them in the same PR. Backlog + per-area status:
+            // docs/testing-coverage.md.
             thresholds: {
-                statements: 11,
-                branches: 10,
-                functions: 14,
-                lines: 10,
+                statements: 23,
+                branches: 17,
+                functions: 23,
+                lines: 23,
             },
         },
     },

--- a/docs/testing-coverage.md
+++ b/docs/testing-coverage.md
@@ -28,27 +28,31 @@ Per-area statement coverage from `npm run test:coverage`:
 | `lib/safeError.ts` | 100 | ✓ |
 | `lib/userDataCleanup.ts` | 100 | ✓ |
 | `lib/llm/models.ts` | 100 | ✓ |
+| `lib/documentTypes.ts` | 100 | ✓ |
+| `lib/chat/prompts.ts` | 100 | ✓ |
+| `lib/systemWorkflows.ts` | 100 | ✓ |
 | `lib/documentVersions.ts` | 98 | ✓ |
 | `lib/chat/citations.ts` | 98 | ✓ |
 | `lib/userLookup.ts` | 91 | ✓ |
+| `lib/docxTrackedChanges.ts` | 89 | ✓ |
 | `lib/downloadTokens.ts` | 87 | ✓ |
 | `lib/chat/types.ts` | 85 | ✓ |
 | `lib/access.ts` | 76 | ✓ |
 | `lib/storage.ts` | 33 | partial — key/disposition helpers only |
 | `lib/userApiKeys.ts` | 13 | partial — provider/env helpers only |
-| `lib/documentTypes.ts`, `lib/userSettings.ts`, `lib/upload.ts`, `lib/officeText.ts` | 0 | ✗ |
-| `lib/convert.ts`, `lib/spreadsheet.ts`, `lib/docxTrackedChanges.ts` | 0 | ✗ |
+| `lib/userSettings.ts`, `lib/upload.ts`, `lib/officeText.ts` | 0 | ✗ |
+| `lib/convert.ts`, `lib/spreadsheet.ts` | 0 | ✗ |
 | `lib/userDataExport.ts` | 0 | ✗ |
-| `lib/courtlistener.ts`, `lib/systemWorkflows.ts` | 0 | ✗ |
-| `lib/chat/prompts.ts`, `lib/chat/contextBuilders.ts`, `lib/chat/streaming.ts` | 0 | ✗ |
+| `lib/courtlistener.ts` | 0 | ✗ |
+| `lib/chat/contextBuilders.ts`, `lib/chat/streaming.ts` | 0 | ✗ |
 | `lib/chat/tools/**` (schemas, documentOps, toolDispatcher) | 0 | ✗ |
 | `lib/llm/**` (providers, tools, index, rawStreamLog) | ~4 | ✗ (only models.ts) |
 | `lib/mcp/**` (client, servers, oauth, types) | 0 | ✗ |
 
-Global: **11.18% statements / 10.98% branches / 14.43% functions / 10.91%
+Global: **23.88% statements / 17.98% branches / 23.06% functions / 23.79%
 lines**. The global number is low because `src/lib/**` includes several very
-large feature libs (toolDispatcher, documentOps, systemWorkflows,
-courtlistener, docxTrackedChanges) that dominate the line count.
+large feature libs (toolDispatcher, documentOps, courtlistener) that dominate
+the line count.
 
 ## TODO — untested libs, in priority order
 
@@ -56,9 +60,9 @@ Each item is meant to be one self-contained PR: add the suite, then raise the
 floors in `backend/vitest.config.mts` to just below the new measured numbers.
 Size is a rough guess: S ≈ an hour, M ≈ an afternoon.
 
-- [ ] `lib/documentTypes.ts` — pure catalog/lookup of document types; assert
+- [x] `lib/documentTypes.ts` — pure catalog/lookup of document types; assert
       known types resolve and unknown inputs fall back sanely. (S)
-- [ ] `lib/chat/prompts.ts` — pure prompt builders; assert key instructions and
+- [x] `lib/chat/prompts.ts` — pure prompt builders; assert key instructions and
       interpolated values appear in the output strings. (S)
 - [ ] `lib/userSettings.ts` — title/tabular model resolution from which API
       keys a user has; reuse the Supabase mock pattern from
@@ -79,12 +83,12 @@ Size is a rough guess: S ≈ an hour, M ≈ an afternoon.
       and cell extraction, including empty/edge cells. (M)
 - [ ] `lib/chat/contextBuilders.ts` — context assembly from doc stores; assert
       doc labels, truncation, and ordering. (M)
-- [ ] `lib/docxTrackedChanges.ts` — tracked-changes XML round-trip on a minimal
+- [x] `lib/docxTrackedChanges.ts` — tracked-changes XML round-trip on a minimal
       docx fixture: insert/delete runs, accept/reject. High value: document
       integrity. (M)
 - [ ] `lib/courtlistener.ts` — API client with mocked fetch: query building,
       pagination, and error paths. Legal-research correctness. (M)
-- [ ] `lib/systemWorkflows.ts` — mostly data: assert workflow definitions are
+- [x] `lib/systemWorkflows.ts` — mostly data: assert workflow definitions are
       well-formed (unique ids, non-empty skill markdown). (S)
 - [ ] `lib/llm/tools.ts` + `lib/llm/index.ts` — provider-neutral tool plumbing
       and provider selection with mocked provider modules. (M)
@@ -109,7 +113,7 @@ better exercised by the e2e suite.
 ## Ratchet policy
 
 `backend/vitest.config.mts` enforces global coverage **floors** (currently
-statements 11 / branches 10 / functions 14 / lines 10). They are a
+statements 23 / branches 17 / functions 23 / lines 23). They are a
 no-regression ratchet, not a target:
 
 - **Floors only go up.** Never lower them to get a PR green — that means your


### PR DESCRIPTION
This lands the "document integrity" tier of the backlog in `docs/testing-coverage.md`: four new unit suites, 46 tests, no new dependencies, no production code changes.

**Why these four:** `docxTrackedChanges.ts` is the code that rewrites a client's .docx to show edits as tracked changes — if it corrupts a document or drops the wrong run, that's a real problem for a legal product. `chat/prompts.ts` carries the citation contract the response parser depends on. `documentTypes.ts` decides how uploads are handled and served. `systemWorkflows.ts` is the built-in workflow catalog the UI trusts to be well-formed.

**What the tests do:**
- **docxTrackedChanges (19):** builds tiny real .docx files in memory with JSZip (already a dependency) and checks the whole life cycle — a replacement comes out as a proper `w:del`/`w:ins` pair, only the changed span is tracked, accepting a change yields exactly the edited text and rejecting it restores the original. Also locks in the safe failure modes: unmatched or ambiguous edits are reported as errors (never guessed), and garbage input throws instead of producing a broken file.
- **chat/prompts (8):** the citation rules, doc-label hygiene, and safety instructions are present in every prompt variant, and the CourtListener research block appears only when research tools are actually available.
- **documentTypes (12):** known types resolve (case-insensitively), unknown/missing input falls back sanely, and spreadsheets are deliberately excluded from PDF conversion.
- **systemWorkflows (7):** unique ids, complete metadata, non-empty skill markdown, well-formed tabular columns, and the assistant shortlist stays in sync with the full definitions.

**Ratchet:** global coverage moves from 11.18/10.98/14.43/10.91 to 23.88/17.98/23.06/23.79 (stmts/branches/funcs/lines), so the floors in `backend/vitest.config.mts` go up from 11/10/14/10 to 23/17/23/23. Backlog doc updated to match.

Verified: `npm ci && npm run test:coverage` green with the new floors; `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
