### PR TITLE
[Extensibility 3/4] feat: local LLMs via Ollama, behind ENABLE_OLLAMA (stacked on #259)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,6 +16,18 @@ R2_BUCKET_NAME=mike
 GEMINI_API_KEY=your-gemini-key
 ANTHROPIC_API_KEY=your-anthropic-key
 OPENAI_API_KEY=your-openai-key
+# Optional: OpenAI-compatible gateway endpoint, e.g. OpenRouter/Azure proxy/Ollama-compatible bridge.
+# Must be https in production unless OPENAI_ALLOW_LOCAL_BASE_URL=true.
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_ALLOW_LOCAL_BASE_URL=false
+# Local models via Ollama (opt-in, off by default). To enable: set ENABLE_OLLAMA=true
+# and point the OpenAI-compatible client at your local Ollama server:
+#   ENABLE_OLLAMA=true
+#   OPENAI_BASE_URL=http://localhost:11434/v1
+#   OPENAI_ALLOW_LOCAL_BASE_URL=true
+#   OPENAI_API_KEY=ollama          # Ollama accepts any non-empty string
+#   OLLAMA_MODELS=my-custom-model  # optional; extra models beyond the defaults
+ENABLE_OLLAMA=false
 RESEND_API_KEY=your-resend-key
 USER_API_KEYS_ENCRYPTION_SECRET=your-long-random-secret
 

--- a/backend/src/core/apiKeyProviders.ts
+++ b/backend/src/core/apiKeyProviders.ts
@@ -1,0 +1,66 @@
+export type ApiKeyProvider = string;
+export type ApiKeySource = "user" | "env" | null;
+
+type ProviderRecord = {
+    readonly envVars: readonly string[];
+};
+
+// Table-driven: env-var names live here, not in a switch statement.
+// Adding a new provider is one registerApiKeyProvider() call — no edits here.
+const _providerRegistry = new Map<string, ProviderRecord>([
+    ["claude", { envVars: ["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"] }],
+    ["gemini", { envVars: ["GEMINI_API_KEY"] }],
+    ["openai", { envVars: ["OPENAI_API_KEY"] }],
+    ["openrouter", { envVars: ["OPENROUTER_API_KEY"] }],
+    ["courtlistener", { envVars: ["COURTLISTENER_API_TOKEN"] }],
+]);
+
+/**
+ * Register a new API-key provider so that getUserApiKeyStatus() and
+ * getUserApiKeys() include it automatically.
+ *
+ * Call once from your provider setup file alongside registerProvider():
+ *
+ *   registerApiKeyProvider("bedrock", ["AWS_ACCESS_KEY_ID"]);
+ *   registerApiKeyProvider("ollama", []);  // no key required
+ */
+export function registerApiKeyProvider(
+    provider: string,
+    envVars: readonly string[],
+): void {
+    _providerRegistry.set(provider, { envVars });
+}
+
+/** Returns provider IDs in registration order. */
+export function getRegisteredProviders(): readonly string[] {
+    return [..._providerRegistry.keys()];
+}
+
+export function isApiKeyProvider(value: string): boolean {
+    return _providerRegistry.has(value);
+}
+
+export function normalizeApiKeyProvider(value: string): string | null {
+    return _providerRegistry.has(value) ? value : null;
+}
+
+/**
+ * Returns the platform API key for provider from environment variables,
+ * or null when none of the provider's env vars are set.
+ *
+ * Table-driven: the env var names are declared in the provider registry above,
+ * not hard-coded per-provider in this function body.
+ */
+export function envApiKey(provider: string): string | null {
+    const record = _providerRegistry.get(provider);
+    if (!record) return null;
+    for (const varName of record.envVars) {
+        const val = process.env[varName]?.trim();
+        if (val) return val;
+    }
+    return null;
+}
+
+export function hasEnvApiKey(provider: string): boolean {
+    return !!envApiKey(provider);
+}

--- a/backend/src/lib/llm/__tests__/baseUrl.test.ts
+++ b/backend/src/lib/llm/__tests__/baseUrl.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { openAIResponsesUrl, resolveOpenAIBaseUrl } from "../baseUrl";
+
+describe("resolveOpenAIBaseUrl", () => {
+    it("defaults to the official OpenAI v1 endpoint", () => {
+        expect(resolveOpenAIBaseUrl()).toBe("https://api.openai.com/v1");
+        expect(openAIResponsesUrl()).toBe("https://api.openai.com/v1/responses");
+    });
+
+    it("normalizes trailing slashes", () => {
+        expect(resolveOpenAIBaseUrl("https://gateway.example.com/v1///")).toBe(
+            "https://gateway.example.com/v1",
+        );
+    });
+
+    it("allows local http endpoints outside production", () => {
+        expect(resolveOpenAIBaseUrl("http://localhost:11434/v1", "development")).toBe(
+            "http://localhost:11434/v1",
+        );
+    });
+
+    it("rejects http endpoints in production", () => {
+        expect(() =>
+            resolveOpenAIBaseUrl("http://gateway.example.com/v1", "production"),
+        ).toThrow(/https in production/);
+    });
+
+    it("rejects unsupported protocols", () => {
+        expect(() => resolveOpenAIBaseUrl("file:///tmp/openai")).toThrow(
+            /http or https/,
+        );
+    });
+
+    it("rejects private/reserved IP literals in production (SSRF)", () => {
+        for (const host of [
+            "https://10.0.1.50/v1",
+            "https://172.16.5.4/v1",
+            "https://192.168.1.10/v1",
+            "https://169.254.169.254/v1", // cloud metadata
+            "https://127.0.0.1/v1",
+            "https://[::1]/v1",
+        ]) {
+            expect(() => resolveOpenAIBaseUrl(host, "production")).toThrow(
+                /private or reserved IP|localhost/,
+            );
+        }
+    });
+
+    it("allows a public IP / hostname in production", () => {
+        expect(resolveOpenAIBaseUrl("https://8.8.8.8/v1", "production")).toBe(
+            "https://8.8.8.8/v1",
+        );
+        expect(
+            resolveOpenAIBaseUrl("https://gateway.example.com/v1", "production"),
+        ).toBe("https://gateway.example.com/v1");
+    });
+});

--- a/backend/src/lib/llm/__tests__/registry.test.ts
+++ b/backend/src/lib/llm/__tests__/registry.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+    registerProvider,
+    getRegisteredProvider,
+    findProviderForModel,
+    registeredProviderIds,
+    allRegisteredModels,
+    _resetRegistryForTesting,
+    type LLMProviderAdapter,
+} from "../registry";
+
+function makeAdapter(id: string, prefixes: string[], models: string[] = []): LLMProviderAdapter {
+    return {
+        id,
+        matchesModel: (m) => prefixes.some((p) => m.startsWith(p)),
+        stream: async () => ({ fullText: "" }),
+        complete: async () => "",
+        models: { main: models, mid: [], low: [] },
+    };
+}
+
+beforeEach(() => {
+    _resetRegistryForTesting();
+});
+
+describe("registerProvider / getRegisteredProvider", () => {
+    it("stores and retrieves an adapter by id", () => {
+        const adapter = makeAdapter("test", ["test-"]);
+        registerProvider(adapter);
+        expect(getRegisteredProvider("test")).toBe(adapter);
+    });
+
+    it("returns undefined for an unknown id", () => {
+        expect(getRegisteredProvider("unknown")).toBeUndefined();
+    });
+
+    it("re-registration replaces the previous adapter", () => {
+        const first = makeAdapter("p", ["p-"]);
+        const second = makeAdapter("p", ["p-"]);
+        registerProvider(first);
+        registerProvider(second);
+        expect(getRegisteredProvider("p")).toBe(second);
+    });
+});
+
+describe("findProviderForModel", () => {
+    it("returns the first provider whose matchesModel is true", () => {
+        const a = makeAdapter("alpha", ["alpha-"]);
+        const b = makeAdapter("beta", ["beta-"]);
+        registerProvider(a);
+        registerProvider(b);
+        expect(findProviderForModel("alpha-turbo")).toBe(a);
+        expect(findProviderForModel("beta-fast")).toBe(b);
+    });
+
+    it("returns undefined when no provider matches", () => {
+        registerProvider(makeAdapter("x", ["x-"]));
+        expect(findProviderForModel("unknown-model")).toBeUndefined();
+    });
+
+    it("the first registered provider wins on overlap", () => {
+        const first = makeAdapter("first", ["shared-"]);
+        const second = makeAdapter("second", ["shared-"]);
+        registerProvider(first);
+        registerProvider(second);
+        expect(findProviderForModel("shared-model")).toBe(first);
+    });
+});
+
+describe("registeredProviderIds", () => {
+    it("returns ids in insertion order", () => {
+        registerProvider(makeAdapter("c", ["c-"]));
+        registerProvider(makeAdapter("a", ["a-"]));
+        registerProvider(makeAdapter("b", ["b-"]));
+        expect(registeredProviderIds()).toEqual(["c", "a", "b"]);
+    });
+
+    it("returns an empty array when no providers are registered", () => {
+        expect(registeredProviderIds()).toEqual([]);
+    });
+});
+
+describe("allRegisteredModels", () => {
+    it("returns the union of all provider model lists", () => {
+        registerProvider(makeAdapter("p1", ["m-"], ["m1", "m2"]));
+        registerProvider(makeAdapter("p2", ["n-"], ["m2", "n1"]));
+        const set = allRegisteredModels();
+        expect(set.has("m1")).toBe(true);
+        expect(set.has("m2")).toBe(true);
+        expect(set.has("n1")).toBe(true);
+        expect(set.size).toBe(3);
+    });
+
+    it("returns an empty set when no providers are registered", () => {
+        expect(allRegisteredModels().size).toBe(0);
+    });
+});

--- a/backend/src/lib/llm/baseUrl.ts
+++ b/backend/src/lib/llm/baseUrl.ts
@@ -1,0 +1,50 @@
+import net from "net";
+import { isBlockedIp } from "../privateIp";
+
+const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
+
+function isLocalHostname(hostname: string): boolean {
+    return (
+        hostname === "localhost" ||
+        hostname === "127.0.0.1" ||
+        hostname === "::1" ||
+        hostname.endsWith(".local")
+    );
+}
+
+export function resolveOpenAIBaseUrl(
+    raw = process.env.OPENAI_BASE_URL ?? DEFAULT_OPENAI_BASE_URL,
+    nodeEnv = process.env.NODE_ENV,
+): string {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+        throw new Error("OPENAI_BASE_URL must use http or https");
+    }
+    if (nodeEnv === "production" && parsed.protocol !== "https:") {
+        throw new Error("OPENAI_BASE_URL must use https in production");
+    }
+    if (nodeEnv === "production" && process.env.OPENAI_ALLOW_LOCAL_BASE_URL !== "true") {
+        // URL hostnames wrap IPv6 in brackets ([::1]); strip them for net.isIP.
+        const host = parsed.hostname.replace(/^\[|\]$/g, "");
+        if (isLocalHostname(parsed.hostname)) {
+            throw new Error(
+                "OPENAI_BASE_URL cannot point at localhost in production unless OPENAI_ALLOW_LOCAL_BASE_URL=true",
+            );
+        }
+        // Reject IP literals in private/reserved ranges (SSRF) — parity with the
+        // MCP egress guard. DNS hostnames are operator config, not resolved here.
+        if (net.isIP(host) !== 0 && isBlockedIp(host)) {
+            throw new Error(
+                "OPENAI_BASE_URL cannot point at a private or reserved IP in production unless OPENAI_ALLOW_LOCAL_BASE_URL=true",
+            );
+        }
+    }
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString().replace(/\/$/, "");
+}
+
+export function openAIResponsesUrl(baseUrl = resolveOpenAIBaseUrl()): string {
+    return `${baseUrl}/responses`;
+}

--- a/backend/src/lib/llm/index.ts
+++ b/backend/src/lib/llm/index.ts
@@ -23,10 +23,12 @@ export * from "./models";
  * Register a third-party LLM provider so it is available via
  * streamChatWithTools() and completeText().
  *
- * OpenAI-compatible providers can be added the same way — call
- * registerProvider()/registerApiKeyProvider(), no core edits.
+ * Local models via Ollama are built in but opt-in: set ENABLE_OLLAMA=true (see
+ * setupOllamaFromEnv below). Other OpenAI-compatible providers can be added the
+ * same way — call registerProvider()/registerApiKeyProvider(), no core edits.
  */
 export { registerProvider } from "./registry";
+import { setupOllamaFromEnv } from "./providers/ollama";
 
 // ---------------------------------------------------------------------------
 // Register built-in providers
@@ -35,8 +37,16 @@ export { registerProvider } from "./registry";
 // test files mock e.g. "../claude" before this module loads, so the mocked
 // function is captured here and ends up in the registry.
 
-/** Register the built-in LLM providers (claude/gemini/openai). */
-export function registerBuiltinProviders(): void {
+/**
+ * Register the built-in LLM providers (claude/gemini/openai), plus local
+ * (Ollama) models when opted in via ENABLE_OLLAMA.
+ *
+ * Reads process.env by default and is exported so it can be exercised against
+ * a controlled env.
+ */
+export function registerBuiltinProviders(
+    env: NodeJS.ProcessEnv = process.env,
+): void {
     registerProvider({
         id: "claude",
         matchesModel: (m) => m.startsWith("claude"),
@@ -58,6 +68,11 @@ export function registerBuiltinProviders(): void {
         complete: completeOpenAIText,
         models: { main: OPENAI_MAIN_MODELS, mid: OPENAI_MID_MODELS, low: OPENAI_LOW_MODELS },
     });
+
+    // Local models — opt-in via ENABLE_OLLAMA.
+    if (setupOllamaFromEnv(env)) {
+        console.log("[llm] Ollama provider enabled (ENABLE_OLLAMA=true)");
+    }
 }
 
 registerBuiltinProviders();

--- a/backend/src/lib/llm/index.ts
+++ b/backend/src/lib/llm/index.ts
@@ -1,30 +1,93 @@
 import { streamClaude, completeClaudeText } from "./claude";
 import { streamGemini, completeGeminiText } from "./gemini";
 import { streamOpenAI, completeOpenAIText } from "./openai";
-import { providerForModel } from "./models";
-import type { StreamChatParams, StreamChatResult, UserApiKeys } from "./types";
+import { registerProvider, getRegisteredProvider } from "./registry";
+import {
+    providerForModel,
+    CLAUDE_MAIN_MODELS,
+    CLAUDE_MID_MODELS,
+    CLAUDE_LOW_MODELS,
+    GEMINI_MAIN_MODELS,
+    GEMINI_MID_MODELS,
+    GEMINI_LOW_MODELS,
+    OPENAI_MAIN_MODELS,
+    OPENAI_MID_MODELS,
+    OPENAI_LOW_MODELS,
+} from "./models";
+import type { StreamChatParams, StreamChatResult, CompleteTextParams } from "./types";
 
 export * from "./types";
 export * from "./models";
 
+/**
+ * Register a third-party LLM provider so it is available via
+ * streamChatWithTools() and completeText().
+ *
+ * OpenAI-compatible providers can be added the same way — call
+ * registerProvider()/registerApiKeyProvider(), no core edits.
+ */
+export { registerProvider } from "./registry";
+
+// ---------------------------------------------------------------------------
+// Register built-in providers
+// ---------------------------------------------------------------------------
+// Providers are imported above so that Vitest's vi.mock() hoisting works:
+// test files mock e.g. "../claude" before this module loads, so the mocked
+// function is captured here and ends up in the registry.
+
+/** Register the built-in LLM providers (claude/gemini/openai). */
+export function registerBuiltinProviders(): void {
+    registerProvider({
+        id: "claude",
+        matchesModel: (m) => m.startsWith("claude"),
+        stream: streamClaude,
+        complete: completeClaudeText,
+        models: { main: CLAUDE_MAIN_MODELS, mid: CLAUDE_MID_MODELS, low: CLAUDE_LOW_MODELS },
+    });
+    registerProvider({
+        id: "gemini",
+        matchesModel: (m) => m.startsWith("gemini"),
+        stream: streamGemini,
+        complete: completeGeminiText,
+        models: { main: GEMINI_MAIN_MODELS, mid: GEMINI_MID_MODELS, low: GEMINI_LOW_MODELS },
+    });
+    registerProvider({
+        id: "openai",
+        matchesModel: (m) => m.startsWith("gpt-"),
+        stream: streamOpenAI,
+        complete: completeOpenAIText,
+        models: { main: OPENAI_MAIN_MODELS, mid: OPENAI_MID_MODELS, low: OPENAI_LOW_MODELS },
+    });
+}
+
+registerBuiltinProviders();
+
+// ---------------------------------------------------------------------------
+// Public dispatch
+// ---------------------------------------------------------------------------
+
+function requireAdapter(providerId: string, model: string) {
+    const adapter = getRegisteredProvider(providerId);
+    if (!adapter) {
+        throw new Error(
+            `LLM provider "${providerId}" matched model "${model}" but is not registered. ` +
+            `Import "lib/llm" to initialize built-in providers, ` +
+            `or call registerProvider() for third-party providers.`,
+        );
+    }
+    return adapter;
+}
+
 export async function streamChatWithTools(
     params: StreamChatParams,
 ): Promise<StreamChatResult> {
-    const provider = providerForModel(params.model);
-    if (provider === "claude") return streamClaude(params);
-    if (provider === "openai") return streamOpenAI(params);
-    return streamGemini(params);
+    const providerId = providerForModel(params.model);
+    const adapter = requireAdapter(providerId, params.model);
+    return adapter.stream(params);
 }
 
-export async function completeText(params: {
-    model: string;
-    systemPrompt?: string;
-    user: string;
-    maxTokens?: number;
-    apiKeys?: UserApiKeys;
-}): Promise<string> {
-    const provider = providerForModel(params.model);
-    if (provider === "claude") return completeClaudeText(params);
-    if (provider === "openai") return completeOpenAIText(params);
-    return completeGeminiText(params);
+export async function completeText(params: CompleteTextParams): Promise<string> {
+    const providerId = providerForModel(params.model);
+    const adapter = requireAdapter(providerId, params.model);
+    return adapter.complete(params);
 }

--- a/backend/src/lib/llm/models.ts
+++ b/backend/src/lib/llm/models.ts
@@ -1,7 +1,7 @@
-import type { Provider } from "./types";
+import { findProviderForModel, allRegisteredModels } from "./registry";
 
 // ---------------------------------------------------------------------------
-// Canonical model IDs
+// Canonical model IDs (built-in providers)
 // ---------------------------------------------------------------------------
 // Main-chat tier (top-end) — user picks one of these per message.
 export const CLAUDE_MAIN_MODELS = [
@@ -32,6 +32,18 @@ export const DEFAULT_MAIN_MODEL = "gemini-3-flash-preview";
 export const DEFAULT_TITLE_MODEL = "gemini-3.1-flash-lite-preview";
 export const DEFAULT_TABULAR_MODEL = "gemini-3-flash-preview";
 
+// Derived (not hand-maintained) fallback set for resolveModel().
+// Built by spreading the *_MODELS arrays above, so adding a model to any
+// of those arrays automatically includes it here — no second edit site.
+//
+// Why keep this alongside allRegisteredModels()?  Two reasons:
+//   1. Test isolation: models.test.ts imports models.ts directly without
+//      importing index.ts, so no providers are registered and the registry
+//      is empty.  ALL_MODELS provides the fallback in that case.
+//   2. External providers registered via registerProvider() appear in
+//      allRegisteredModels() but NOT here — that's intentional.
+//      resolveModel() checks both, so external models are always accepted
+//      once their provider is registered.
 const ALL_MODELS = new Set<string>([
     ...CLAUDE_MAIN_MODELS,
     ...GEMINI_MAIN_MODELS,
@@ -48,14 +60,33 @@ const ALL_MODELS = new Set<string>([
 // Provider inference
 // ---------------------------------------------------------------------------
 
-export function providerForModel(model: string): Provider {
+/**
+ * Maps a model ID to its provider string.
+ *
+ * Registered providers are checked first so that externally registered
+ * adapters (Ollama, Bedrock, Azure) override the built-in prefix matching
+ * below — no edits to this file required to support a new provider.
+ *
+ * The prefix fallback keeps this function usable in test contexts that don't
+ * import index.ts and therefore don't trigger provider registration.
+ */
+export function providerForModel(model: string): string {
+    const registered = findProviderForModel(model);
+    if (registered) return registered.id;
     if (model.startsWith("claude")) return "claude";
     if (model.startsWith("gemini")) return "gemini";
     if (model.startsWith("gpt-")) return "openai";
     throw new Error(`Unknown model id: ${model}`);
 }
 
+/**
+ * Returns id if it is a recognised model, otherwise returns fallback.
+ *
+ * Checks the live registry first (includes externally registered models) then
+ * falls back to the static ALL_MODELS set so the function works in test
+ * contexts where no providers have been registered.
+ */
 export function resolveModel(id: string | null | undefined, fallback: string): string {
-    if (id && ALL_MODELS.has(id)) return id;
+    if (id && (allRegisteredModels().has(id) || ALL_MODELS.has(id))) return id;
     return fallback;
 }

--- a/backend/src/lib/llm/openai.ts
+++ b/backend/src/lib/llm/openai.ts
@@ -6,9 +6,9 @@ import type {
   StreamChatParams,
   StreamChatResult,
 } from "./types";
+import { openAIResponsesUrl } from "./baseUrl";
 import { createRawLlmStreamRecorder, logRawLlmStream } from "./rawStreamLog";
 
-const OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";
 const MAX_OUTPUT_TOKENS = 16384;
 const COURTLISTENER_CITATION_REMINDER_TOOL_NAMES = new Set([
   "courtlistener_find_in_case",
@@ -173,7 +173,7 @@ async function createResponse(params: {
   apiKey: string;
   signal?: AbortSignal;
 }): Promise<Response> {
-  const response = await fetch(OPENAI_RESPONSES_URL, {
+  const response = await fetch(openAIResponsesUrl(), {
     method: "POST",
     headers: {
       Authorization: `Bearer ${params.apiKey}`,

--- a/backend/src/lib/llm/providers/__tests__/ollama.test.ts
+++ b/backend/src/lib/llm/providers/__tests__/ollama.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { setupOllamaFromEnv } from "../ollama";
+import { getRegisteredProvider } from "../../registry";
+
+describe("setupOllamaFromEnv (ENABLE_OLLAMA gate)", () => {
+    it("does nothing when the flag is unset or not 'true'", () => {
+        expect(setupOllamaFromEnv({})).toBe(false);
+        expect(setupOllamaFromEnv({ ENABLE_OLLAMA: "false" })).toBe(false);
+        expect(setupOllamaFromEnv({ ENABLE_OLLAMA: "1" })).toBe(false);
+    });
+
+    it("registers the Ollama provider when ENABLE_OLLAMA=true", () => {
+        expect(setupOllamaFromEnv({ ENABLE_OLLAMA: "true" })).toBe(true);
+        const provider = getRegisteredProvider("ollama");
+        expect(provider).toBeDefined();
+        // A default local model routes to this provider.
+        expect(provider?.matchesModel("llama3.3")).toBe(true);
+        // A cloud model does not.
+        expect(provider?.matchesModel("gpt-4o")).toBe(false);
+    });
+
+    it("registers extra models from OLLAMA_MODELS", () => {
+        setupOllamaFromEnv({
+            ENABLE_OLLAMA: "true",
+            OLLAMA_MODELS: "my-custom-model, another-model",
+        });
+        const provider = getRegisteredProvider("ollama");
+        expect(provider?.matchesModel("my-custom-model")).toBe(true);
+        expect(provider?.matchesModel("another-model")).toBe(true);
+    });
+});

--- a/backend/src/lib/llm/providers/ollama.ts
+++ b/backend/src/lib/llm/providers/ollama.ts
@@ -1,0 +1,86 @@
+/**
+ * Ollama provider — routes Ollama model IDs through the OpenAI-compatible
+ * streaming backend pointed at a local Ollama server.
+ *
+ * Prerequisites:
+ *   OPENAI_BASE_URL=http://localhost:11434/v1
+ *   OPENAI_ALLOW_LOCAL_BASE_URL=true
+ *   OPENAI_API_KEY=ollama              # Ollama accepts any non-empty string
+ *
+ * Call setupOllama() once from your app bootstrap before any LLM calls:
+ *
+ *   import { setupOllama } from "lib/llm/providers/ollama";
+ *   setupOllama();
+ *   // or pass a custom list:
+ *   setupOllama({ models: ["llama3.3", "phi4", "my-custom-model"] });
+ *
+ * This pattern demonstrates how to add any OpenAI-compatible provider
+ * (OpenRouter, Mistral AI, Together AI, Anyscale, etc.) without modifying
+ * any core file — only a call to registerProvider() and registerApiKeyProvider().
+ */
+
+import { registerProvider } from "../registry";
+import { streamOpenAI, completeOpenAIText } from "../openai";
+import { registerApiKeyProvider } from "../../../core/apiKeyProviders";
+
+const DEFAULT_MODELS = [
+    // Meta Llama
+    "llama3.3", "llama3.2", "llama3.1", "llama3",
+    // Mistral
+    "mistral", "mistral-nemo", "mistral-small",
+    // Microsoft Phi
+    "phi4", "phi4-mini",
+    // Alibaba Qwen
+    "qwen2.5", "qwen2.5-coder",
+    // Google Gemma
+    "gemma3", "gemma2",
+    // DeepSeek
+    "deepseek-r1", "deepseek-coder-v2",
+];
+
+export interface OllamaSetupOptions {
+    /** Model IDs to register (merged with defaults). */
+    models?: string[];
+}
+
+/**
+ * Opt-in bootstrap: register the Ollama provider iff `ENABLE_OLLAMA=true`.
+ *
+ * Gated (not always-on) because registering ~20 local model IDs would pollute
+ * the model picker on cloud deployments that have no Ollama server, and because
+ * running Ollama also requires `OPENAI_ALLOW_LOCAL_BASE_URL=true` — a deliberate
+ * SSRF-guard relaxation we only want when a self-hoster asks for it. Optional
+ * `OLLAMA_MODELS` (comma-separated) adds custom models to the defaults.
+ *
+ * Returns true if it registered the provider. `env` is injectable for testing.
+ */
+export function setupOllamaFromEnv(
+    env: NodeJS.ProcessEnv = process.env,
+): boolean {
+    if (env.ENABLE_OLLAMA !== "true") return false;
+    const models = (env.OLLAMA_MODELS ?? "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    setupOllama({ models });
+    return true;
+}
+
+export function setupOllama(options: OllamaSetupOptions = {}): void {
+    const id = "ollama";
+    const allModels = [...new Set([...DEFAULT_MODELS, ...(options.models ?? [])])];
+    const modelSet = new Set(allModels);
+
+    // No dedicated API key — Ollama reuses OPENAI_API_KEY (set to any string).
+    registerApiKeyProvider(id, ["OPENAI_API_KEY"]);
+
+    registerProvider({
+        id,
+        matchesModel: (m) => modelSet.has(m),
+        // Ollama exposes an OpenAI Responses-compatible API on port 11434.
+        // The base URL is resolved from OPENAI_BASE_URL by the openai adapter.
+        stream: streamOpenAI,
+        complete: completeOpenAIText,
+        models: { main: allModels, mid: [], low: [] },
+    });
+}

--- a/backend/src/lib/llm/registry.ts
+++ b/backend/src/lib/llm/registry.ts
@@ -1,0 +1,92 @@
+import type { StreamChatParams, StreamChatResult, CompleteTextParams } from "./types";
+
+/**
+ * Contract every LLM provider adapter must satisfy.
+ *
+ * Built-in providers (Claude, Gemini, OpenAI) are registered in index.ts on
+ * module load.  Third-party providers (Ollama, Bedrock, Azure, Mistral) call
+ * registerProvider() from their own setup file before the first LLM call.
+ *
+ * Adding a new provider is a single-file operation — no edits to index.ts,
+ * models.ts, or userApiKeys.ts are required.
+ */
+export interface LLMProviderAdapter {
+    /** Stable identifier, e.g. "claude", "gemini", "openai", "ollama". */
+    readonly id: string;
+    /**
+     * Return true if this provider handles the given model string.
+     * Checked in registration order; the first match wins.
+     */
+    matchesModel(model: string): boolean;
+    /** Streaming chat with optional tool-call loop. */
+    stream(params: StreamChatParams): Promise<StreamChatResult>;
+    /** Single-shot non-streaming text completion. */
+    complete(params: CompleteTextParams): Promise<string>;
+    /**
+     * Model IDs grouped by usage tier.
+     * Drives the global valid-model set so resolveModel() recognises
+     * externally registered models without hard-coding them in models.ts.
+     */
+    readonly models: {
+        readonly main: readonly string[];
+        readonly mid: readonly string[];
+        readonly low: readonly string[];
+    };
+}
+
+const _registry = new Map<string, LLMProviderAdapter>();
+
+/**
+ * Register an LLM provider adapter.
+ *
+ * Call once per provider, typically at application startup or when the
+ * provider's setup module is first imported.  Re-registering an id replaces
+ * the previous entry.
+ */
+export function registerProvider(adapter: LLMProviderAdapter): void {
+    _registry.set(adapter.id, adapter);
+}
+
+/** Returns the adapter registered under id, or undefined if none. */
+export function getRegisteredProvider(id: string): LLMProviderAdapter | undefined {
+    return _registry.get(id);
+}
+
+/**
+ * Returns the first registered provider whose matchesModel() returns true,
+ * or undefined when none match.
+ *
+ * models.ts calls this before falling back to built-in prefix heuristics,
+ * so externally registered providers can override routing for any model ID.
+ */
+export function findProviderForModel(model: string): LLMProviderAdapter | undefined {
+    for (const p of _registry.values()) {
+        if (p.matchesModel(model)) return p;
+    }
+    return undefined;
+}
+
+/** IDs of all currently registered providers in insertion order. */
+export function registeredProviderIds(): string[] {
+    return [..._registry.keys()];
+}
+
+/**
+ * Union of every model ID declared across all registered providers.
+ * resolveModel() in models.ts calls this so that externally added models
+ * are validated without requiring changes to the static ALL_MODELS set.
+ */
+export function allRegisteredModels(): Set<string> {
+    const set = new Set<string>();
+    for (const p of _registry.values()) {
+        for (const m of [...p.models.main, ...p.models.mid, ...p.models.low]) {
+            set.add(m);
+        }
+    }
+    return set;
+}
+
+/** Exposed for test isolation only — do not call in production code. */
+export function _resetRegistryForTesting(): void {
+    _registry.clear();
+}

--- a/backend/src/lib/llm/types.ts
+++ b/backend/src/lib/llm/types.ts
@@ -2,7 +2,8 @@
 // Callers always speak OpenAI-style tools + { role, content } messages; each
 // provider translates internally.
 
-export type Provider = "claude" | "gemini" | "openai";
+/** Provider identifier string — extensible, not a closed union. */
+export type Provider = string;
 
 export type OpenAIToolSchema = {
     type: "function";
@@ -36,12 +37,31 @@ export type StreamCallbacks = {
     onToolCallStart?: (call: NormalizedToolCall) => void;
 };
 
+/**
+ * Per-request API keys keyed by provider id.
+ *
+ * The three named optional properties exist solely for IDE autocomplete on
+ * the built-in providers — they are NOT a closed list.  The index signature
+ * makes this map open: third-party providers (e.g. "ollama", "bedrock") carry
+ * their credentials here without any changes to this file.  Callers access
+ * keys via apiKeys[providerId], not via named property access.
+ */
 export type UserApiKeys = {
     claude?: string | null;
     gemini?: string | null;
     openai?: string | null;
     openrouter?: string | null;
     courtlistener?: string | null;
+    [provider: string]: string | null | undefined;
+};
+
+/** Parameters for the single-shot non-streaming completeText() call. */
+export type CompleteTextParams = {
+    model: string;
+    systemPrompt?: string;
+    user: string;
+    maxTokens?: number;
+    apiKeys?: UserApiKeys;
 };
 
 export type StreamChatParams = {

--- a/backend/src/lib/userApiKeys.ts
+++ b/backend/src/lib/userApiKeys.ts
@@ -1,17 +1,24 @@
 import crypto from "crypto";
 import { createServerSupabase } from "./supabase";
 import type { UserApiKeys } from "./llm";
+import {
+    envApiKey,
+    hasEnvApiKey,
+    normalizeApiKeyProvider,
+    getRegisteredProviders,
+    type ApiKeyProvider,
+    type ApiKeySource,
+} from "../core/apiKeyProviders";
 
 type Db = ReturnType<typeof createServerSupabase>;
-export type ApiKeyProvider =
-    | "claude"
-    | "gemini"
-    | "openai"
-    | "openrouter"
-    | "courtlistener";
-export type ApiKeySource = "user" | "env" | null;
-export type ApiKeyStatus = Record<ApiKeyProvider, boolean> & {
-    sources: Record<ApiKeyProvider, ApiKeySource>;
+
+/**
+ * Status record keyed by provider id.
+ * Derived dynamically from the registered provider list so new providers
+ * added via registerApiKeyProvider() appear here automatically.
+ */
+export type ApiKeyStatus = Record<string, boolean> & {
+    sources: Record<string, ApiKeySource>;
 };
 
 type EncryptedKeyRow = {
@@ -21,38 +28,7 @@ type EncryptedKeyRow = {
     auth_tag: string;
 };
 
-const PROVIDERS: ApiKeyProvider[] = [
-    "claude",
-    "gemini",
-    "openai",
-    "openrouter",
-    "courtlistener",
-];
-
-function envApiKey(provider: ApiKeyProvider): string | null {
-    switch (provider) {
-        case "claude":
-            return (
-                process.env.ANTHROPIC_API_KEY?.trim() ||
-                process.env.CLAUDE_API_KEY?.trim() ||
-                null
-            );
-        case "gemini":
-            return process.env.GEMINI_API_KEY?.trim() || null;
-        case "openai":
-            return process.env.OPENAI_API_KEY?.trim() || null;
-        case "openrouter":
-            return process.env.OPENROUTER_API_KEY?.trim() || null;
-        case "courtlistener":
-            return process.env.COURTLISTENER_API_TOKEN?.trim() || null;
-        default:
-            return null;
-    }
-}
-
-export function hasEnvApiKey(provider: ApiKeyProvider): boolean {
-    return !!envApiKey(provider);
-}
+export { hasEnvApiKey, normalizeApiKeyProvider };
 
 function encryptionKey(): Buffer {
     const secret = process.env.USER_API_KEYS_ENCRYPTION_SECRET;
@@ -98,34 +74,21 @@ function decrypt(row: EncryptedKeyRow): string | null {
     }
 }
 
-function isProvider(value: string): value is ApiKeyProvider {
-    return (PROVIDERS as string[]).includes(value);
-}
-
-export function normalizeApiKeyProvider(value: string): ApiKeyProvider | null {
-    return isProvider(value) ? value : null;
-}
-
 export async function getUserApiKeyStatus(
     userId: string,
     db: Db = createServerSupabase(),
 ): Promise<ApiKeyStatus> {
-    const status: ApiKeyStatus = {
-        claude: false,
-        gemini: false,
-        openai: false,
-        openrouter: false,
-        courtlistener: false,
-        sources: {
-            claude: null,
-            gemini: null,
-            openai: null,
-            openrouter: null,
-            courtlistener: null,
-        },
-    };
+    // Build status object dynamically from the registered provider list so new
+    // providers appear here without any manual addition to this function.
+    const providers = getRegisteredProviders();
+    const status: ApiKeyStatus = {} as ApiKeyStatus;
+    status.sources = {} as Record<string, ApiKeySource>;
+    for (const provider of providers) {
+        status[provider] = false;
+        status.sources[provider] = null;
+    }
 
-    for (const provider of PROVIDERS) {
+    for (const provider of providers) {
         if (hasEnvApiKey(provider)) {
             status[provider] = true;
             status.sources[provider] = "env";
@@ -153,13 +116,11 @@ export async function getUserApiKeys(
     userId: string,
     db: Db = createServerSupabase(),
 ): Promise<UserApiKeys> {
-    const apiKeys: UserApiKeys = {
-        claude: envApiKey("claude"),
-        gemini: envApiKey("gemini"),
-        openai: envApiKey("openai"),
-        openrouter: envApiKey("openrouter"),
-        courtlistener: envApiKey("courtlistener"),
-    };
+    // Seed from env vars for all registered providers.
+    const apiKeys: UserApiKeys = {};
+    for (const provider of getRegisteredProviders()) {
+        apiKeys[provider] = envApiKey(provider);
+    }
 
     const { data, error } = await db
         .from("user_api_keys")


### PR DESCRIPTION
> **Stacked on #259** — merge that first; until it merges, this diff shows its commit too. This PR's own change is the single Ollama commit.

Closes #23.

## Summary

Opt-in local LLM support via Ollama's OpenAI-compatible endpoint: a self-hosted deployment can run chat inference entirely on its own hardware — documents never leave the building, and with this flag neither does inference. Everything is behind `ENABLE_OLLAMA=true` (default **off**): with the flag unset, no new models appear and nothing changes.

## Changes

- `providers/ollama.ts` (new): registry entry that routes local model IDs (llama3.3, phi4, qwen2.5, + `OLLAMA_MODELS` extras) through the existing OpenAI adapter pointed at `http://localhost:11434/v1`. **No new dependencies, no new streaming code path.**
- `baseUrl.ts` (new) + `openai.ts`: `OPENAI_BASE_URL` resolution with an SSRF guard — http/localhost/private-IP endpoints rejected in production unless explicitly allowed. Defaults to `https://api.openai.com/v1` (unchanged when unset).
- `privateIp.ts` (new): shared private/reserved IP classifier (IPv4 + IPv6 incl. mapped/NAT64/6to4).
- `.env.example`: documents the opt-in config.
- Tests: ollama gate, baseUrl, privateIp (21 tests).

## Why

The most-requested self-hosting capability (#23), done as a registry entry instead of a bespoke client — the first external provider to use the registry, which is exactly what it was built for.

## Testing

On this branch: backend `npm test` — **300 passed, 5 skipped** (includes the 21 new tests). Flag gate verified: only the exact string `"true"` registers the provider.

## Provenance

Mechanical port of code running in amal66/mike (main); `privateIp.ts` and `providers/ollama.ts` byte-identical to the fork. Full provenance in [amal66#34](https://github.com/amal66/mike/pull/34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
