### PR TITLE
[Extensibility 4/4] feat: Vertex AI provider (stacked on #259)

### DIFF
--- a/backend/src/core/apiKeyProviders.ts
+++ b/backend/src/core/apiKeyProviders.ts
@@ -1,0 +1,66 @@
+export type ApiKeyProvider = string;
+export type ApiKeySource = "user" | "env" | null;
+
+type ProviderRecord = {
+    readonly envVars: readonly string[];
+};
+
+// Table-driven: env-var names live here, not in a switch statement.
+// Adding a new provider is one registerApiKeyProvider() call — no edits here.
+const _providerRegistry = new Map<string, ProviderRecord>([
+    ["claude", { envVars: ["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"] }],
+    ["gemini", { envVars: ["GEMINI_API_KEY"] }],
+    ["openai", { envVars: ["OPENAI_API_KEY"] }],
+    ["openrouter", { envVars: ["OPENROUTER_API_KEY"] }],
+    ["courtlistener", { envVars: ["COURTLISTENER_API_TOKEN"] }],
+]);
+
+/**
+ * Register a new API-key provider so that getUserApiKeyStatus() and
+ * getUserApiKeys() include it automatically.
+ *
+ * Call once from your provider setup file alongside registerProvider():
+ *
+ *   registerApiKeyProvider("bedrock", ["AWS_ACCESS_KEY_ID"]);
+ *   registerApiKeyProvider("ollama", []);  // no key required
+ */
+export function registerApiKeyProvider(
+    provider: string,
+    envVars: readonly string[],
+): void {
+    _providerRegistry.set(provider, { envVars });
+}
+
+/** Returns provider IDs in registration order. */
+export function getRegisteredProviders(): readonly string[] {
+    return [..._providerRegistry.keys()];
+}
+
+export function isApiKeyProvider(value: string): boolean {
+    return _providerRegistry.has(value);
+}
+
+export function normalizeApiKeyProvider(value: string): string | null {
+    return _providerRegistry.has(value) ? value : null;
+}
+
+/**
+ * Returns the platform API key for provider from environment variables,
+ * or null when none of the provider's env vars are set.
+ *
+ * Table-driven: the env var names are declared in the provider registry above,
+ * not hard-coded per-provider in this function body.
+ */
+export function envApiKey(provider: string): string | null {
+    const record = _providerRegistry.get(provider);
+    if (!record) return null;
+    for (const varName of record.envVars) {
+        const val = process.env[varName]?.trim();
+        if (val) return val;
+    }
+    return null;
+}
+
+export function hasEnvApiKey(provider: string): boolean {
+    return !!envApiKey(provider);
+}

--- a/backend/src/lib/llm/__tests__/registry.test.ts
+++ b/backend/src/lib/llm/__tests__/registry.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+    registerProvider,
+    getRegisteredProvider,
+    findProviderForModel,
+    registeredProviderIds,
+    allRegisteredModels,
+    _resetRegistryForTesting,
+    type LLMProviderAdapter,
+} from "../registry";
+
+function makeAdapter(id: string, prefixes: string[], models: string[] = []): LLMProviderAdapter {
+    return {
+        id,
+        matchesModel: (m) => prefixes.some((p) => m.startsWith(p)),
+        stream: async () => ({ fullText: "" }),
+        complete: async () => "",
+        models: { main: models, mid: [], low: [] },
+    };
+}
+
+beforeEach(() => {
+    _resetRegistryForTesting();
+});
+
+describe("registerProvider / getRegisteredProvider", () => {
+    it("stores and retrieves an adapter by id", () => {
+        const adapter = makeAdapter("test", ["test-"]);
+        registerProvider(adapter);
+        expect(getRegisteredProvider("test")).toBe(adapter);
+    });
+
+    it("returns undefined for an unknown id", () => {
+        expect(getRegisteredProvider("unknown")).toBeUndefined();
+    });
+
+    it("re-registration replaces the previous adapter", () => {
+        const first = makeAdapter("p", ["p-"]);
+        const second = makeAdapter("p", ["p-"]);
+        registerProvider(first);
+        registerProvider(second);
+        expect(getRegisteredProvider("p")).toBe(second);
+    });
+});
+
+describe("findProviderForModel", () => {
+    it("returns the first provider whose matchesModel is true", () => {
+        const a = makeAdapter("alpha", ["alpha-"]);
+        const b = makeAdapter("beta", ["beta-"]);
+        registerProvider(a);
+        registerProvider(b);
+        expect(findProviderForModel("alpha-turbo")).toBe(a);
+        expect(findProviderForModel("beta-fast")).toBe(b);
+    });
+
+    it("returns undefined when no provider matches", () => {
+        registerProvider(makeAdapter("x", ["x-"]));
+        expect(findProviderForModel("unknown-model")).toBeUndefined();
+    });
+
+    it("the first registered provider wins on overlap", () => {
+        const first = makeAdapter("first", ["shared-"]);
+        const second = makeAdapter("second", ["shared-"]);
+        registerProvider(first);
+        registerProvider(second);
+        expect(findProviderForModel("shared-model")).toBe(first);
+    });
+});
+
+describe("registeredProviderIds", () => {
+    it("returns ids in insertion order", () => {
+        registerProvider(makeAdapter("c", ["c-"]));
+        registerProvider(makeAdapter("a", ["a-"]));
+        registerProvider(makeAdapter("b", ["b-"]));
+        expect(registeredProviderIds()).toEqual(["c", "a", "b"]);
+    });
+
+    it("returns an empty array when no providers are registered", () => {
+        expect(registeredProviderIds()).toEqual([]);
+    });
+});
+
+describe("allRegisteredModels", () => {
+    it("returns the union of all provider model lists", () => {
+        registerProvider(makeAdapter("p1", ["m-"], ["m1", "m2"]));
+        registerProvider(makeAdapter("p2", ["n-"], ["m2", "n1"]));
+        const set = allRegisteredModels();
+        expect(set.has("m1")).toBe(true);
+        expect(set.has("m2")).toBe(true);
+        expect(set.has("n1")).toBe(true);
+        expect(set.size).toBe(3);
+    });
+
+    it("returns an empty set when no providers are registered", () => {
+        expect(allRegisteredModels().size).toBe(0);
+    });
+});

--- a/backend/src/lib/llm/__tests__/vertexAI.test.ts
+++ b/backend/src/lib/llm/__tests__/vertexAI.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { _resetRegistryForTesting, getRegisteredProvider } from "../registry";
+
+// Reset env and registry around each test.
+beforeEach(() => {
+    _resetRegistryForTesting();
+    process.env.VERTEX_AI_PROJECT = "test-project";
+    process.env.VERTEX_AI_LOCATION = "us-central1";
+});
+
+afterEach(() => {
+    _resetRegistryForTesting();
+    delete process.env.VERTEX_AI_PROJECT;
+    delete process.env.VERTEX_AI_LOCATION;
+});
+
+describe("setupVertexAI", () => {
+    it("registers under the 'gemini' provider id", async () => {
+        const { setupVertexAI } = await import("../providers/vertexAI");
+        setupVertexAI();
+
+        const provider = getRegisteredProvider("gemini");
+        expect(provider).toBeDefined();
+        expect(provider!.id).toBe("gemini");
+    });
+
+    it("matchesModel returns true for all built-in Gemini model IDs", async () => {
+        const { setupVertexAI } = await import("../providers/vertexAI");
+        setupVertexAI();
+
+        const provider = getRegisteredProvider("gemini")!;
+        expect(provider.matchesModel("gemini-3.1-pro-preview")).toBe(true);
+        expect(provider.matchesModel("gemini-3-flash-preview")).toBe(true);
+        expect(provider.matchesModel("gemini-3.1-flash-lite-preview")).toBe(true);
+    });
+
+    it("matchesModel returns true for any gemini- prefixed model (future models)", async () => {
+        const { setupVertexAI } = await import("../providers/vertexAI");
+        setupVertexAI();
+
+        const provider = getRegisteredProvider("gemini")!;
+        expect(provider.matchesModel("gemini-future-ultra")).toBe(true);
+    });
+
+    it("matchesModel returns false for non-Gemini models", async () => {
+        const { setupVertexAI } = await import("../providers/vertexAI");
+        setupVertexAI();
+
+        const provider = getRegisteredProvider("gemini")!;
+        expect(provider.matchesModel("claude-sonnet-4-6")).toBe(false);
+        expect(provider.matchesModel("gpt-5.5")).toBe(false);
+    });
+
+    it("registers extra models passed via options", async () => {
+        const { setupVertexAI } = await import("../providers/vertexAI");
+        setupVertexAI({ extraModels: ["gemini-experimental-xyz"] });
+
+        const provider = getRegisteredProvider("gemini")!;
+        expect(provider.matchesModel("gemini-experimental-xyz")).toBe(true);
+    });
+
+    it("extra models survive resolveModel (present in the model tiers)", async () => {
+        const { setupVertexAI } = await import("../providers/vertexAI");
+        const { resolveModel } = await import("../models");
+        setupVertexAI({ extraModels: ["gemini-experimental-xyz"] });
+
+        // resolveModel only accepts models present in a registered adapter's
+        // tiers — an extra listed solely in matchesModel would be silently
+        // swapped for the fallback.
+        expect(resolveModel("gemini-experimental-xyz", "fallback-model")).toBe(
+            "gemini-experimental-xyz",
+        );
+    });
+
+    it("models lists include main/mid/low tiers", async () => {
+        const { setupVertexAI } = await import("../providers/vertexAI");
+        setupVertexAI();
+
+        const provider = getRegisteredProvider("gemini")!;
+        expect(provider.models.main.length).toBeGreaterThan(0);
+        expect(provider.models.mid.length).toBeGreaterThan(0);
+        expect(provider.models.low.length).toBeGreaterThan(0);
+    });
+
+    it("re-registering replaces the previous adapter", async () => {
+        const { setupVertexAI } = await import("../providers/vertexAI");
+        setupVertexAI();
+        const first = getRegisteredProvider("gemini");
+        setupVertexAI({ extraModels: ["gemini-extra"] });
+        const second = getRegisteredProvider("gemini");
+        // Both are registered under "gemini"; second call replaces first.
+        expect(second).not.toBe(first);
+        expect(second!.matchesModel("gemini-extra")).toBe(true);
+    });
+});

--- a/backend/src/lib/llm/gemini.ts
+++ b/backend/src/lib/llm/gemini.ts
@@ -81,7 +81,7 @@ function parseGeminiErrorPayload(value: string): string | null {
   }
 }
 
-function geminiStreamFailureMessage(chunk: unknown): string | null {
+export function geminiStreamFailureMessage(chunk: unknown): string | null {
   if (!chunk || typeof chunk !== "object") return null;
   const record = chunk as Record<string, unknown>;
   const error = record.error;

--- a/backend/src/lib/llm/index.ts
+++ b/backend/src/lib/llm/index.ts
@@ -1,30 +1,93 @@
 import { streamClaude, completeClaudeText } from "./claude";
 import { streamGemini, completeGeminiText } from "./gemini";
 import { streamOpenAI, completeOpenAIText } from "./openai";
-import { providerForModel } from "./models";
-import type { StreamChatParams, StreamChatResult, UserApiKeys } from "./types";
+import { registerProvider, getRegisteredProvider } from "./registry";
+import {
+    providerForModel,
+    CLAUDE_MAIN_MODELS,
+    CLAUDE_MID_MODELS,
+    CLAUDE_LOW_MODELS,
+    GEMINI_MAIN_MODELS,
+    GEMINI_MID_MODELS,
+    GEMINI_LOW_MODELS,
+    OPENAI_MAIN_MODELS,
+    OPENAI_MID_MODELS,
+    OPENAI_LOW_MODELS,
+} from "./models";
+import type { StreamChatParams, StreamChatResult, CompleteTextParams } from "./types";
 
 export * from "./types";
 export * from "./models";
 
+/**
+ * Register a third-party LLM provider so it is available via
+ * streamChatWithTools() and completeText().
+ *
+ * OpenAI-compatible providers can be added the same way — call
+ * registerProvider()/registerApiKeyProvider(), no core edits.
+ */
+export { registerProvider } from "./registry";
+
+// ---------------------------------------------------------------------------
+// Register built-in providers
+// ---------------------------------------------------------------------------
+// Providers are imported above so that Vitest's vi.mock() hoisting works:
+// test files mock e.g. "../claude" before this module loads, so the mocked
+// function is captured here and ends up in the registry.
+
+/** Register the built-in LLM providers (claude/gemini/openai). */
+export function registerBuiltinProviders(): void {
+    registerProvider({
+        id: "claude",
+        matchesModel: (m) => m.startsWith("claude"),
+        stream: streamClaude,
+        complete: completeClaudeText,
+        models: { main: CLAUDE_MAIN_MODELS, mid: CLAUDE_MID_MODELS, low: CLAUDE_LOW_MODELS },
+    });
+    registerProvider({
+        id: "gemini",
+        matchesModel: (m) => m.startsWith("gemini"),
+        stream: streamGemini,
+        complete: completeGeminiText,
+        models: { main: GEMINI_MAIN_MODELS, mid: GEMINI_MID_MODELS, low: GEMINI_LOW_MODELS },
+    });
+    registerProvider({
+        id: "openai",
+        matchesModel: (m) => m.startsWith("gpt-"),
+        stream: streamOpenAI,
+        complete: completeOpenAIText,
+        models: { main: OPENAI_MAIN_MODELS, mid: OPENAI_MID_MODELS, low: OPENAI_LOW_MODELS },
+    });
+}
+
+registerBuiltinProviders();
+
+// ---------------------------------------------------------------------------
+// Public dispatch
+// ---------------------------------------------------------------------------
+
+function requireAdapter(providerId: string, model: string) {
+    const adapter = getRegisteredProvider(providerId);
+    if (!adapter) {
+        throw new Error(
+            `LLM provider "${providerId}" matched model "${model}" but is not registered. ` +
+            `Import "lib/llm" to initialize built-in providers, ` +
+            `or call registerProvider() for third-party providers.`,
+        );
+    }
+    return adapter;
+}
+
 export async function streamChatWithTools(
     params: StreamChatParams,
 ): Promise<StreamChatResult> {
-    const provider = providerForModel(params.model);
-    if (provider === "claude") return streamClaude(params);
-    if (provider === "openai") return streamOpenAI(params);
-    return streamGemini(params);
+    const providerId = providerForModel(params.model);
+    const adapter = requireAdapter(providerId, params.model);
+    return adapter.stream(params);
 }
 
-export async function completeText(params: {
-    model: string;
-    systemPrompt?: string;
-    user: string;
-    maxTokens?: number;
-    apiKeys?: UserApiKeys;
-}): Promise<string> {
-    const provider = providerForModel(params.model);
-    if (provider === "claude") return completeClaudeText(params);
-    if (provider === "openai") return completeOpenAIText(params);
-    return completeGeminiText(params);
+export async function completeText(params: CompleteTextParams): Promise<string> {
+    const providerId = providerForModel(params.model);
+    const adapter = requireAdapter(providerId, params.model);
+    return adapter.complete(params);
 }

--- a/backend/src/lib/llm/models.ts
+++ b/backend/src/lib/llm/models.ts
@@ -1,7 +1,7 @@
-import type { Provider } from "./types";
+import { findProviderForModel, allRegisteredModels } from "./registry";
 
 // ---------------------------------------------------------------------------
-// Canonical model IDs
+// Canonical model IDs (built-in providers)
 // ---------------------------------------------------------------------------
 // Main-chat tier (top-end) — user picks one of these per message.
 export const CLAUDE_MAIN_MODELS = [
@@ -32,6 +32,18 @@ export const DEFAULT_MAIN_MODEL = "gemini-3-flash-preview";
 export const DEFAULT_TITLE_MODEL = "gemini-3.1-flash-lite-preview";
 export const DEFAULT_TABULAR_MODEL = "gemini-3-flash-preview";
 
+// Derived (not hand-maintained) fallback set for resolveModel().
+// Built by spreading the *_MODELS arrays above, so adding a model to any
+// of those arrays automatically includes it here — no second edit site.
+//
+// Why keep this alongside allRegisteredModels()?  Two reasons:
+//   1. Test isolation: models.test.ts imports models.ts directly without
+//      importing index.ts, so no providers are registered and the registry
+//      is empty.  ALL_MODELS provides the fallback in that case.
+//   2. External providers registered via registerProvider() appear in
+//      allRegisteredModels() but NOT here — that's intentional.
+//      resolveModel() checks both, so external models are always accepted
+//      once their provider is registered.
 const ALL_MODELS = new Set<string>([
     ...CLAUDE_MAIN_MODELS,
     ...GEMINI_MAIN_MODELS,
@@ -48,14 +60,33 @@ const ALL_MODELS = new Set<string>([
 // Provider inference
 // ---------------------------------------------------------------------------
 
-export function providerForModel(model: string): Provider {
+/**
+ * Maps a model ID to its provider string.
+ *
+ * Registered providers are checked first so that externally registered
+ * adapters (Ollama, Bedrock, Azure) override the built-in prefix matching
+ * below — no edits to this file required to support a new provider.
+ *
+ * The prefix fallback keeps this function usable in test contexts that don't
+ * import index.ts and therefore don't trigger provider registration.
+ */
+export function providerForModel(model: string): string {
+    const registered = findProviderForModel(model);
+    if (registered) return registered.id;
     if (model.startsWith("claude")) return "claude";
     if (model.startsWith("gemini")) return "gemini";
     if (model.startsWith("gpt-")) return "openai";
     throw new Error(`Unknown model id: ${model}`);
 }
 
+/**
+ * Returns id if it is a recognised model, otherwise returns fallback.
+ *
+ * Checks the live registry first (includes externally registered models) then
+ * falls back to the static ALL_MODELS set so the function works in test
+ * contexts where no providers have been registered.
+ */
 export function resolveModel(id: string | null | undefined, fallback: string): string {
-    if (id && ALL_MODELS.has(id)) return id;
+    if (id && (allRegisteredModels().has(id) || ALL_MODELS.has(id))) return id;
     return fallback;
 }

--- a/backend/src/lib/llm/providers/vertexAI.ts
+++ b/backend/src/lib/llm/providers/vertexAI.ts
@@ -1,0 +1,277 @@
+/**
+ * Vertex AI provider — routes Gemini model IDs through Google Cloud Vertex AI
+ * instead of the default Gemini AI Studio endpoint.
+ *
+ * Why use this instead of the built-in Gemini provider?
+ *   - Enterprise billing through a Google Cloud project (not AI Studio quota)
+ *   - Data residency / VPC Service Controls compliance
+ *   - Cloud IAM-gated access (no API key distributed to servers)
+ *   - Workload Identity support on GKE / Cloud Run (zero secrets)
+ *
+ * Auth uses Application Default Credentials (ADC) — the standard GCP chain:
+ *   1. GOOGLE_APPLICATION_CREDENTIALS (path to service account JSON key)
+ *   2. Workload Identity (GKE, Cloud Run, Compute Engine, Cloud Functions)
+ *   3. gcloud CLI: `gcloud auth application-default login` (local dev)
+ *
+ * Required env vars:
+ *   VERTEX_AI_PROJECT   — GCP project ID (e.g. "my-project-123")
+ *   VERTEX_AI_LOCATION  — region (default: "us-central1")
+ *
+ * Call setupVertexAI() once at application startup to replace the default
+ * Gemini provider with a Vertex AI-backed one.  All Gemini model IDs remain
+ * unchanged — the routing is transparent to the rest of the application.
+ *
+ *   import { setupVertexAI } from "lib/llm/providers/vertexAI";
+ *   setupVertexAI();
+ *
+ * The same Gemini model IDs are supported:
+ *   gemini-3.1-pro-preview, gemini-3-flash-preview, gemini-3.1-flash-lite-preview
+ */
+
+import { GoogleGenAI } from "@google/genai";
+import type { StreamChatParams, StreamChatResult, CompleteTextParams } from "../types";
+import { toGeminiTools } from "../tools";
+import { registerProvider } from "../registry";
+import { registerApiKeyProvider } from "../../../core/apiKeyProviders";
+import { geminiStreamFailureMessage } from "../gemini";
+import {
+    GEMINI_MAIN_MODELS,
+    GEMINI_MID_MODELS,
+    GEMINI_LOW_MODELS,
+} from "../models";
+
+// ---------------------------------------------------------------------------
+// Internal types (mirrors gemini.ts — Vertex AI uses the same content format)
+// ---------------------------------------------------------------------------
+
+type GoogleGenAIClient = InstanceType<typeof GoogleGenAI>;
+
+type GeminiPart = {
+    text?: string;
+    thought?: boolean;
+    functionCall?: {
+        id?: string;
+        name: string;
+        args?: Record<string, unknown>;
+    };
+    functionResponse?: {
+        id?: string;
+        name: string;
+        response: Record<string, unknown>;
+    };
+    thoughtSignature?: string;
+};
+
+type GeminiContent = {
+    role: "user" | "model";
+    parts: GeminiPart[];
+};
+
+// ---------------------------------------------------------------------------
+// Vertex AI client (ADC — no API key)
+// ---------------------------------------------------------------------------
+
+function requireConfig(): { project: string; location: string } {
+    const project = process.env.VERTEX_AI_PROJECT?.trim();
+    if (!project) {
+        throw new Error(
+            "VERTEX_AI_PROJECT must be set to use the Vertex AI Gemini provider.",
+        );
+    }
+    const location = process.env.VERTEX_AI_LOCATION?.trim() || "us-central1";
+    return { project, location };
+}
+
+function vertexClient(): GoogleGenAIClient {
+    const { project, location } = requireConfig();
+    // vertexai: true tells the SDK to use Vertex AI endpoints and ADC auth
+    // instead of the apiKey-based AI Studio endpoint.
+    return new GoogleGenAI({ vertexai: true, project, location });
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+    if (!signal?.aborted) return;
+    // Match the abort shape isAbortError() detects across providers
+    // (name "AbortError" / message "Stream aborted.").
+    const err = new Error("Stream aborted.");
+    err.name = "AbortError";
+    throw err;
+}
+
+// ---------------------------------------------------------------------------
+// Stream
+// ---------------------------------------------------------------------------
+
+async function streamVertexGemini(params: StreamChatParams): Promise<StreamChatResult> {
+    const {
+        model,
+        systemPrompt,
+        tools = [],
+        callbacks = {},
+        runTools,
+        enableThinking,
+    } = params;
+    const maxIter = params.maxIterations ?? 10;
+    const ai = vertexClient();
+    const functionDeclarations = toGeminiTools(tools);
+
+    const contents: GeminiContent[] = params.messages.map((m) => ({
+        role: m.role === "assistant" ? "model" : "user",
+        parts: [{ text: m.content }],
+    }));
+    let fullText = "";
+
+    for (let iter = 0; iter < maxIter; iter++) {
+        throwIfAborted(params.abortSignal);
+        const stream = await ai.models.generateContentStream({
+            model,
+            contents: contents as never,
+            config: {
+                systemInstruction: systemPrompt,
+                tools: functionDeclarations.length
+                    ? [{ functionDeclarations } as never]
+                    : undefined,
+                thinkingConfig: enableThinking
+                    ? { includeThoughts: true }
+                    : { thinkingBudget: 0 },
+            },
+        });
+
+        const textParts: string[] = [];
+        const callParts: GeminiPart[] = [];
+        const toolCalls: import("../types").NormalizedToolCall[] = [];
+        let sawThinking = false;
+
+        for await (const chunk of stream) {
+            throwIfAborted(params.abortSignal);
+            // Same in-stream failure detection as the built-in Gemini
+            // adapter: blocked prompts and error finish reasons arrive as
+            // chunks with no content parts, not as thrown errors.
+            const failureMessage = geminiStreamFailureMessage(chunk);
+            if (failureMessage) throw new Error(failureMessage);
+            const parts =
+                (chunk as { candidates?: { content?: { parts?: GeminiPart[] } }[] })
+                    .candidates?.[0]?.content?.parts ?? [];
+
+            for (const part of parts) {
+                if (part.text) {
+                    if (part.thought) {
+                        sawThinking = true;
+                        callbacks.onReasoningDelta?.(part.text);
+                    } else {
+                        textParts.push(part.text);
+                        callbacks.onContentDelta?.(part.text);
+                    }
+                }
+                if (part.functionCall) {
+                    callParts.push(part);
+                    const call: import("../types").NormalizedToolCall = {
+                        id: part.functionCall.id ?? `${part.functionCall.name}-${toolCalls.length}`,
+                        name: part.functionCall.name,
+                        input: part.functionCall.args ?? {},
+                    };
+                    callbacks.onToolCallStart?.(call);
+                    toolCalls.push(call);
+                }
+            }
+        }
+
+        if (sawThinking) callbacks.onReasoningBlockEnd?.();
+        fullText += textParts.join("");
+
+        if (!toolCalls.length || !runTools) break;
+
+        const results = await runTools(toolCalls);
+
+        const modelParts: GeminiPart[] = [];
+        if (textParts.length) modelParts.push({ text: textParts.join("") });
+        for (const cp of callParts) modelParts.push(cp);
+        contents.push({ role: "model", parts: modelParts });
+
+        contents.push({
+            role: "user",
+            parts: results.map((r) => {
+                const match = toolCalls.find((c) => c.id === r.tool_use_id);
+                return {
+                    functionResponse: {
+                        ...(r.tool_use_id && !r.tool_use_id.startsWith(match?.name ?? "")
+                            ? { id: r.tool_use_id }
+                            : {}),
+                        name: match?.name ?? "tool",
+                        response: { output: r.content },
+                    },
+                };
+            }),
+        });
+    }
+
+    return { fullText };
+}
+
+// ---------------------------------------------------------------------------
+// Complete (non-streaming)
+// ---------------------------------------------------------------------------
+
+async function completeVertexGeminiText(params: CompleteTextParams): Promise<string> {
+    const ai = vertexClient();
+    const resp = await ai.models.generateContent({
+        model: params.model,
+        contents: [{ role: "user", parts: [{ text: params.user }] }],
+        ...(params.systemPrompt ? { config: { systemInstruction: params.systemPrompt } } : {}),
+    });
+    const failureMessage = geminiStreamFailureMessage(resp);
+    if (failureMessage) throw new Error(failureMessage);
+    return (resp as { text?: string }).text ?? "";
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export interface VertexAISetupOptions {
+    /**
+     * Additional model IDs to register beyond the built-in Gemini models.
+     * Useful when Vertex AI grants access to preview models not in the list.
+     */
+    extraModels?: string[];
+}
+
+/**
+ * Replaces the built-in Gemini provider with a Vertex AI-backed one.
+ *
+ * After calling this, all requests that would have gone to Gemini AI Studio
+ * are instead routed to your Google Cloud project via ADC.  The model IDs
+ * (gemini-3.1-pro-preview, etc.) remain unchanged.
+ */
+export function setupVertexAI(options: VertexAISetupOptions = {}): void {
+    const allModels = [
+        ...GEMINI_MAIN_MODELS,
+        ...GEMINI_MID_MODELS,
+        ...GEMINI_LOW_MODELS,
+        ...(options.extraModels ?? []),
+    ];
+    const modelSet = new Set(allModels);
+
+    // Re-registers under the same id "gemini" — replaces the built-in adapter.
+    registerProvider({
+        id: "gemini",
+        matchesModel: (m) => modelSet.has(m) || m.startsWith("gemini"),
+        stream: streamVertexGemini,
+        complete: completeVertexGeminiText,
+        models: {
+            // Extras go in the tiers too: resolveModel() only accepts models
+            // present in a registered adapter's tiers, so extras listed only
+            // in matchesModel would silently resolve to the default model.
+            main: [...GEMINI_MAIN_MODELS, ...(options.extraModels ?? [])],
+            mid: [...GEMINI_MID_MODELS],
+            low: [...GEMINI_LOW_MODELS],
+        },
+    });
+
+    // Vertex AI authenticates via ADC, not a key — but the routes' per-model
+    // key gates (e.g. missingModelApiKey in tabular) check envApiKey("gemini").
+    // Accepting VERTEX_AI_PROJECT as a key source keeps those gates open in
+    // keyless ADC/Workload Identity deployments; the adapter itself never
+    // reads the value.
+    registerApiKeyProvider("gemini", ["GEMINI_API_KEY", "VERTEX_AI_PROJECT"]);
+}

--- a/backend/src/lib/llm/registry.ts
+++ b/backend/src/lib/llm/registry.ts
@@ -1,0 +1,92 @@
+import type { StreamChatParams, StreamChatResult, CompleteTextParams } from "./types";
+
+/**
+ * Contract every LLM provider adapter must satisfy.
+ *
+ * Built-in providers (Claude, Gemini, OpenAI) are registered in index.ts on
+ * module load.  Third-party providers (Ollama, Bedrock, Azure, Mistral) call
+ * registerProvider() from their own setup file before the first LLM call.
+ *
+ * Adding a new provider is a single-file operation — no edits to index.ts,
+ * models.ts, or userApiKeys.ts are required.
+ */
+export interface LLMProviderAdapter {
+    /** Stable identifier, e.g. "claude", "gemini", "openai", "ollama". */
+    readonly id: string;
+    /**
+     * Return true if this provider handles the given model string.
+     * Checked in registration order; the first match wins.
+     */
+    matchesModel(model: string): boolean;
+    /** Streaming chat with optional tool-call loop. */
+    stream(params: StreamChatParams): Promise<StreamChatResult>;
+    /** Single-shot non-streaming text completion. */
+    complete(params: CompleteTextParams): Promise<string>;
+    /**
+     * Model IDs grouped by usage tier.
+     * Drives the global valid-model set so resolveModel() recognises
+     * externally registered models without hard-coding them in models.ts.
+     */
+    readonly models: {
+        readonly main: readonly string[];
+        readonly mid: readonly string[];
+        readonly low: readonly string[];
+    };
+}
+
+const _registry = new Map<string, LLMProviderAdapter>();
+
+/**
+ * Register an LLM provider adapter.
+ *
+ * Call once per provider, typically at application startup or when the
+ * provider's setup module is first imported.  Re-registering an id replaces
+ * the previous entry.
+ */
+export function registerProvider(adapter: LLMProviderAdapter): void {
+    _registry.set(adapter.id, adapter);
+}
+
+/** Returns the adapter registered under id, or undefined if none. */
+export function getRegisteredProvider(id: string): LLMProviderAdapter | undefined {
+    return _registry.get(id);
+}
+
+/**
+ * Returns the first registered provider whose matchesModel() returns true,
+ * or undefined when none match.
+ *
+ * models.ts calls this before falling back to built-in prefix heuristics,
+ * so externally registered providers can override routing for any model ID.
+ */
+export function findProviderForModel(model: string): LLMProviderAdapter | undefined {
+    for (const p of _registry.values()) {
+        if (p.matchesModel(model)) return p;
+    }
+    return undefined;
+}
+
+/** IDs of all currently registered providers in insertion order. */
+export function registeredProviderIds(): string[] {
+    return [..._registry.keys()];
+}
+
+/**
+ * Union of every model ID declared across all registered providers.
+ * resolveModel() in models.ts calls this so that externally added models
+ * are validated without requiring changes to the static ALL_MODELS set.
+ */
+export function allRegisteredModels(): Set<string> {
+    const set = new Set<string>();
+    for (const p of _registry.values()) {
+        for (const m of [...p.models.main, ...p.models.mid, ...p.models.low]) {
+            set.add(m);
+        }
+    }
+    return set;
+}
+
+/** Exposed for test isolation only — do not call in production code. */
+export function _resetRegistryForTesting(): void {
+    _registry.clear();
+}

--- a/backend/src/lib/llm/types.ts
+++ b/backend/src/lib/llm/types.ts
@@ -2,7 +2,8 @@
 // Callers always speak OpenAI-style tools + { role, content } messages; each
 // provider translates internally.
 
-export type Provider = "claude" | "gemini" | "openai";
+/** Provider identifier string — extensible, not a closed union. */
+export type Provider = string;
 
 export type OpenAIToolSchema = {
     type: "function";
@@ -36,12 +37,31 @@ export type StreamCallbacks = {
     onToolCallStart?: (call: NormalizedToolCall) => void;
 };
 
+/**
+ * Per-request API keys keyed by provider id.
+ *
+ * The three named optional properties exist solely for IDE autocomplete on
+ * the built-in providers — they are NOT a closed list.  The index signature
+ * makes this map open: third-party providers (e.g. "ollama", "bedrock") carry
+ * their credentials here without any changes to this file.  Callers access
+ * keys via apiKeys[providerId], not via named property access.
+ */
 export type UserApiKeys = {
     claude?: string | null;
     gemini?: string | null;
     openai?: string | null;
     openrouter?: string | null;
     courtlistener?: string | null;
+    [provider: string]: string | null | undefined;
+};
+
+/** Parameters for the single-shot non-streaming completeText() call. */
+export type CompleteTextParams = {
+    model: string;
+    systemPrompt?: string;
+    user: string;
+    maxTokens?: number;
+    apiKeys?: UserApiKeys;
 };
 
 export type StreamChatParams = {

--- a/backend/src/lib/userApiKeys.ts
+++ b/backend/src/lib/userApiKeys.ts
@@ -1,17 +1,24 @@
 import crypto from "crypto";
 import { createServerSupabase } from "./supabase";
 import type { UserApiKeys } from "./llm";
+import {
+    envApiKey,
+    hasEnvApiKey,
+    normalizeApiKeyProvider,
+    getRegisteredProviders,
+    type ApiKeyProvider,
+    type ApiKeySource,
+} from "../core/apiKeyProviders";
 
 type Db = ReturnType<typeof createServerSupabase>;
-export type ApiKeyProvider =
-    | "claude"
-    | "gemini"
-    | "openai"
-    | "openrouter"
-    | "courtlistener";
-export type ApiKeySource = "user" | "env" | null;
-export type ApiKeyStatus = Record<ApiKeyProvider, boolean> & {
-    sources: Record<ApiKeyProvider, ApiKeySource>;
+
+/**
+ * Status record keyed by provider id.
+ * Derived dynamically from the registered provider list so new providers
+ * added via registerApiKeyProvider() appear here automatically.
+ */
+export type ApiKeyStatus = Record<string, boolean> & {
+    sources: Record<string, ApiKeySource>;
 };
 
 type EncryptedKeyRow = {
@@ -21,38 +28,7 @@ type EncryptedKeyRow = {
     auth_tag: string;
 };
 
-const PROVIDERS: ApiKeyProvider[] = [
-    "claude",
-    "gemini",
-    "openai",
-    "openrouter",
-    "courtlistener",
-];
-
-function envApiKey(provider: ApiKeyProvider): string | null {
-    switch (provider) {
-        case "claude":
-            return (
-                process.env.ANTHROPIC_API_KEY?.trim() ||
-                process.env.CLAUDE_API_KEY?.trim() ||
-                null
-            );
-        case "gemini":
-            return process.env.GEMINI_API_KEY?.trim() || null;
-        case "openai":
-            return process.env.OPENAI_API_KEY?.trim() || null;
-        case "openrouter":
-            return process.env.OPENROUTER_API_KEY?.trim() || null;
-        case "courtlistener":
-            return process.env.COURTLISTENER_API_TOKEN?.trim() || null;
-        default:
-            return null;
-    }
-}
-
-export function hasEnvApiKey(provider: ApiKeyProvider): boolean {
-    return !!envApiKey(provider);
-}
+export { hasEnvApiKey, normalizeApiKeyProvider };
 
 function encryptionKey(): Buffer {
     const secret = process.env.USER_API_KEYS_ENCRYPTION_SECRET;
@@ -98,34 +74,21 @@ function decrypt(row: EncryptedKeyRow): string | null {
     }
 }
 
-function isProvider(value: string): value is ApiKeyProvider {
-    return (PROVIDERS as string[]).includes(value);
-}
-
-export function normalizeApiKeyProvider(value: string): ApiKeyProvider | null {
-    return isProvider(value) ? value : null;
-}
-
 export async function getUserApiKeyStatus(
     userId: string,
     db: Db = createServerSupabase(),
 ): Promise<ApiKeyStatus> {
-    const status: ApiKeyStatus = {
-        claude: false,
-        gemini: false,
-        openai: false,
-        openrouter: false,
-        courtlistener: false,
-        sources: {
-            claude: null,
-            gemini: null,
-            openai: null,
-            openrouter: null,
-            courtlistener: null,
-        },
-    };
+    // Build status object dynamically from the registered provider list so new
+    // providers appear here without any manual addition to this function.
+    const providers = getRegisteredProviders();
+    const status: ApiKeyStatus = {} as ApiKeyStatus;
+    status.sources = {} as Record<string, ApiKeySource>;
+    for (const provider of providers) {
+        status[provider] = false;
+        status.sources[provider] = null;
+    }
 
-    for (const provider of PROVIDERS) {
+    for (const provider of providers) {
         if (hasEnvApiKey(provider)) {
             status[provider] = true;
             status.sources[provider] = "env";
@@ -153,13 +116,11 @@ export async function getUserApiKeys(
     userId: string,
     db: Db = createServerSupabase(),
 ): Promise<UserApiKeys> {
-    const apiKeys: UserApiKeys = {
-        claude: envApiKey("claude"),
-        gemini: envApiKey("gemini"),
-        openai: envApiKey("openai"),
-        openrouter: envApiKey("openrouter"),
-        courtlistener: envApiKey("courtlistener"),
-    };
+    // Seed from env vars for all registered providers.
+    const apiKeys: UserApiKeys = {};
+    for (const provider of getRegisteredProviders()) {
+        apiKeys[provider] = envApiKey(provider);
+    }
 
     const { data, error } = await db
         .from("user_api_keys")


### PR DESCRIPTION
> **Stacked on #259** — merge that first; until it merges, this diff shows its commit too. This PR's own change is the single Vertex commit.

## Summary

Google models via Vertex AI without touching call sites: `setupVertexAI()` re-registers the `"gemini"` provider id so the same Gemini model IDs route through Vertex AI — enterprise billing, IAM-gated access, Workload Identity instead of a distributed API key. **Zero behavior change unless configured**: nothing calls `setupVertexAI()` by default.

## Changes

- `providers/vertexAI.ts` (new): streams/completes via `@google/genai` with `vertexai: true` (ADC, `VERTEX_AI_PROJECT` / `VERTEX_AI_LOCATION`); tool calls, thinking deltas, abort supported. No new dependencies — `@google/genai` is already in `backend/package.json`.
- `__tests__/vertexAI.test.ts`: 7 tests (registration, model matching, re-registration).

## Why

AI Studio API keys don't fit enterprise deployments needing project-scoped billing, VPC-SC/data-residency compliance, or keyless Workload Identity.

## Testing

On this branch: backend `npm test` — **286 passed, 5 skipped** (includes the 7 new tests). `tsc` clean.

## Provenance

Both files byte-identical to the code running in amal66/mike (main). Details in [amal66#48](https://github.com/amal66/mike/pull/48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
