### PR TITLE
Discover workflow packs from YAML manifests

### DIFF
--- a/scripts/build-workflows.js
+++ b/scripts/build-workflows.js
@@ -438,7 +438,7 @@ function loadWorkflows() {
       .flatMap((entry) => {
         const entryDir = path.join(collectionDir, entry.name);
         if (fs.existsSync(path.join(entryDir, "SKILL.md"))) return [entryDir];
-        if (!fs.existsSync(path.join(entryDir, "pack.json"))) return [];
+        if (!fs.existsSync(path.join(entryDir, "pack.yaml"))) return [];
         return fs
           .readdirSync(entryDir, { withFileTypes: true })
           .filter(


### PR DESCRIPTION
## Summary

Update workflow pack discovery to follow the YAML manifest migration.

## Changes

- detect pack directories using `pack.yaml` instead of `pack.json`

## Dependency

Depends on [Open-Legal-Products/mike-workflows#2](https://github.com/Open-Legal-Products/mike-workflows/pull/2).

## Testing

- `node scripts/build-workflows.js`
- confirmed 24 system workflows are generated successfully