### PR TITLE
fix(frontend): require public env vars at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-supabase-anon-key
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3001
 ```
 
+These three `NEXT_PUBLIC_*` variables are required when running
+`npm run build --prefix frontend`. Next.js embeds public environment values in
+the browser bundle at build time, so setting them only when starting or
+deploying an already-built application is too late. Production builds fail
+with a list of missing variables instead of producing a bundle that cannot
+connect to Supabase or the backend API.
+
 Supabase values come from the project dashboard. Use the project URL for `SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_URL`, the service role key for the backend `SUPABASE_SECRET_KEY`, and the anon/public key for `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`. If your Supabase project shows multiple key formats, use the legacy JWT-style anon and service role keys expected by the Supabase client libraries.
 
 Provider keys are only needed for the models, legal research, and email features you plan to use. Model provider keys and the CourtListener token can be configured in `backend/.env` for the whole instance, or per user in **Account > Models & API Keys**. If a provider key is present in `backend/.env`, that provider is available by default and the matching browser API key field is read-only.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,22 @@
 import type { NextConfig } from "next";
 
+const REQUIRED_PUBLIC_BUILD_ENV = [
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY",
+    "NEXT_PUBLIC_API_BASE_URL",
+] as const;
+
+if (process.env.NODE_ENV === "production") {
+    const missing = REQUIRED_PUBLIC_BUILD_ENV.filter(
+        (key) => !process.env[key]?.trim(),
+    );
+    if (missing.length > 0) {
+        throw new Error(
+            `Missing required frontend build-time environment variables: ${missing.join(", ")}`,
+        );
+    }
+}
+
 const nextConfig: NextConfig = {
     /* config options here */
     reactCompiler: true,


### PR DESCRIPTION
## Summary

- fail production frontend builds when required public connection variables are missing or blank
- validate the Supabase URL, Supabase publishable key, and backend API URL together
- document that `NEXT_PUBLIC_*` values must be present during `next build`, not only at runtime

This prevents deploying a browser bundle that cannot connect to Supabase or the backend API.

Closes #92.
Addresses the frontend build-time configuration portion of #265.

## Verification

- missing-value production build fails with the expected list of all three variables
- configured `npm run build --prefix frontend` passes
- `npm test --prefix frontend` — 47 passed
- `npm run lint --prefix frontend` — 0 errors (existing warnings remain)