### PR TITLE
feat: content hashes on document versions + signed project export manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ COURTLISTENER_API_TOKEN=your-courtlistener-token
 
 # Optional: use locally imported CourtListener bulk data for faster case reads.
 COURTLISTENER_BULK_DATA_ENABLED=false
+
+# Optional: Ed25519 seed (openssl rand -hex 32) used to sign project export
+# manifests. Unset means manifests export unsigned.
+MANIFEST_SIGNING_KEY=
 ```
 
 Create `frontend/.env.local`:
@@ -99,6 +103,35 @@ connect to Supabase or the backend API.
 Supabase values come from the project dashboard. Use the project URL for `SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_URL`, the service role key for the backend `SUPABASE_SECRET_KEY`, and the anon/public key for `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`. If your Supabase project shows multiple key formats, use the legacy JWT-style anon and service role keys expected by the Supabase client libraries.
 
 Provider keys are only needed for the models, legal research, and email features you plan to use. Model provider keys and the CourtListener token can be configured in `backend/.env` for the whole instance, or per user in **Account > Models & API Keys**. If a provider key is present in `backend/.env`, that provider is available by default and the matching browser API key field is read-only.
+
+## Tamper-Evident Export
+
+Mike hashes a document version's bytes (SHA-256) whenever it writes them.
+`GET /projects/:projectId/export` returns a manifest of those hashes plus the
+accept/reject trail. To check a file you were given, run
+`shasum -a 256 lease.docx` and compare it to the manifest. Versions written
+before this shipped carry a `null` hash, so they read as unverifiable rather
+than as falsely verified.
+
+The manifest also carries a SHA-256 `digest` over its own body, meaning
+everything except `digest` and `signature`. Serialise that body with object
+keys sorted, array order kept, and no whitespace, and you can recompute the
+digest from parsed JSON.
+
+Set `MANIFEST_SIGNING_KEY` to sign that digest. The signature is a raw Ed25519
+signature over the bytes `mike-project-manifest-v1`, a NUL byte, then the
+digest bytes, checkable with any Ed25519 library:
+
+```js
+crypto.verify(null,
+  Buffer.concat([Buffer.from("mike-project-manifest-v1\0"),
+                 Buffer.from(manifest.digest.value, "hex")]),
+  publicKey, Buffer.from(manifest.signature.value, "hex"));
+```
+
+Take `publicKey` from `GET /manifest-signing-key`, not from the manifest.
+Whoever edits a manifest can re-sign it with a key of their own, so the
+embedded copy shows consistency, never provenance.
 
 ## CourtListener Integration
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ accept/reject trail. To check a file you were given, run
 before this shipped carry a `null` hash, so they read as unverifiable rather
 than as falsely verified.
 
+Soft-deleted versions stay in the manifest, carrying their `deleted_at`. A
+trail that dropped them would be a weaker attestation, but it does mean the
+filename and timestamps of a deleted version are visible to anyone with access
+to the project.
+
 The manifest also carries a SHA-256 `digest` over its own body, meaning
 everything except `digest` and `signature`. Serialise that body with object
 keys sorted, array order kept, and no whitespace, and you can recompute the

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,3 +21,13 @@ USER_API_KEYS_ENCRYPTION_SECRET=your-long-random-secret
 
 # Optional: enables higher-rate CourtListener case law/citation lookup tools.
 COURTLISTENER_API_TOKEN=your-courtlistener-token
+
+# Optional: Ed25519 seed used to sign project export manifests, so a recipient
+# can tell an untouched manifest from an edited one. Leave it unset to export
+# unsigned manifests: the file hashes are still there, the manifest itself is
+# just unattested.
+# Generate with: openssl rand -hex 32
+# Use a dedicated secret. The matching public key is served at
+# GET /manifest-signing-key. Rotating the key does not invalidate past exports,
+# but whoever checks one needs the key that was current when it was made.
+MANIFEST_SIGNING_KEY=

--- a/backend/migrations/20260731_01_document_version_content_sha256.sql
+++ b/backend/migrations/20260731_01_document_version_content_sha256.sql
@@ -1,0 +1,15 @@
+-- Migration date: 2026-07-31
+
+-- Tamper-evidence: store a SHA-256 hex digest of each version's file bytes at
+-- write time so a project export can prove a file matches what the workspace
+-- actually held. Verification is then `shasum -a 256 <file>` against the value
+-- recorded in the export manifest.
+--
+-- Nullable on purpose: rows written before this migration stay unhashed until
+-- their bytes are next rewritten (in-place edit resolution, or version
+-- replace). Backfilling legacy rows would mean streaming every stored object
+-- out of R2, so it is deliberately left to a separate opt-in job rather than
+-- folded into a schema migration.
+
+alter table public.document_versions
+  add column if not exists content_sha256 text;

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -276,6 +276,7 @@ create table if not exists public.document_versions (
   file_type text,
   size_bytes integer,
   page_count integer,
+  content_sha256 text,
   deleted_at timestamptz,
   deleted_by uuid,
   created_at timestamptz not null default now(),

--- a/backend/src/__tests__/integration/health.test.ts
+++ b/backend/src/__tests__/integration/health.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import request from "supertest";
 
 // requireAuth reads SUPABASE_URL / SUPABASE_SECRET_KEY from process.env at
@@ -69,6 +69,45 @@ describe("requireAuth middleware", () => {
             .set("Authorization", "Bearer invalid-token");
         expect(res.status).toBe(401);
         expect(res.body.detail).toMatch(/invalid|expired/i);
+    });
+});
+
+describe("GET /manifest-signing-key", () => {
+    afterEach(() => {
+        delete process.env.MANIFEST_SIGNING_KEY;
+    });
+
+    it("returns null when the deployment does not sign manifests", async () => {
+        const res = await request(app).get("/manifest-signing-key");
+        expect(res.status).toBe(200);
+        expect(res.body).toBeNull();
+    });
+
+    it("serves the public key, never the seed, when signing is on", async () => {
+        const seed = "7c".repeat(32);
+        process.env.MANIFEST_SIGNING_KEY = seed;
+
+        const res = await request(app).get("/manifest-signing-key");
+
+        expect(res.status).toBe(200);
+        expect(res.body.algorithm).toBe("ed25519");
+        expect(res.body.public_key).toMatch(/^[0-9a-f]{64}$/);
+        expect(res.body.public_key).not.toBe(seed);
+        expect(res.text).not.toContain(seed);
+    });
+
+    it("is reachable without authentication", async () => {
+        const res = await request(app).get("/manifest-signing-key");
+        expect(res.status).not.toBe(401);
+    });
+
+    it("returns 500 rather than a stack trace when the key is malformed", async () => {
+        process.env.MANIFEST_SIGNING_KEY = "nonsense";
+
+        const res = await request(app).get("/manifest-signing-key");
+
+        expect(res.status).toBe(500);
+        expect(res.body.detail).toBe("Manifest signing key is misconfigured");
     });
 });
 

--- a/backend/src/__tests__/integration/projects.routes.test.ts
+++ b/backend/src/__tests__/integration/projects.routes.test.ts
@@ -107,10 +107,15 @@ vi.mock("../../lib/userDataCleanup", () => ({
 vi.mock("../../lib/documentVersions", () => ({
     attachActiveVersionPaths: vi.fn(async () => {}),
     attachLatestVersionNumbers: vi.fn(async () => {}),
+    contentSha256: vi.fn(() => "0".repeat(64)),
     loadActiveVersion: vi.fn(async () => null),
 }));
 
 import { app } from "../../app";
+import crypto from "crypto";
+import { manifestPublicKey } from "../../lib/manifestSigning";
+
+const SIGNING_KEY = "3b".repeat(32);
 
 const AUTH = ["Authorization", "Bearer test"] as const;
 
@@ -409,6 +414,159 @@ describe("projects.routes", () => {
 
             expect(res.status).toBe(500);
             expect(res.body.detail).toBe("cascade failed");
+        });
+    });
+    // ── GET /projects/:projectId/export (tamper-evident manifest) ─────────
+    describe("GET /projects/:projectId/export", () => {
+        function seedProjectWithOneVersion() {
+            supabaseState.tables.projects = {
+                data: {
+                    id: "p1",
+                    name: "Alpha",
+                    cm_number: "CM-1",
+                    created_at: "2026-01-01T00:00:00Z",
+                },
+                error: null,
+            };
+            supabaseState.tables.documents = {
+                data: [
+                    {
+                        id: "d1",
+                        project_id: "p1",
+                        status: "ready",
+                        current_version_id: "v1",
+                        created_at: "2026-01-02T00:00:00Z",
+                    },
+                ],
+                error: null,
+            };
+            supabaseState.tables.document_versions = {
+                data: [
+                    {
+                        id: "v1",
+                        document_id: "d1",
+                        version_number: 1,
+                        source: "upload",
+                        filename: "lease.docx",
+                        file_type: "docx",
+                        size_bytes: 12,
+                        content_sha256: "a".repeat(64),
+                        deleted_at: null,
+                        created_at: "2026-01-02T00:00:00Z",
+                    },
+                ],
+                error: null,
+            };
+            supabaseState.tables.document_edits = {
+                data: [
+                    {
+                        id: "e1",
+                        document_id: "d1",
+                        version_id: "v1",
+                        change_id: "c1",
+                        status: "accepted",
+                        created_at: "2026-01-03T00:00:00Z",
+                        resolved_at: "2026-01-03T01:00:00Z",
+                    },
+                ],
+                error: null,
+            };
+        }
+
+        it("returns 404 when the caller cannot access the project", async () => {
+            checkProjectAccess.mockResolvedValue({ ok: false });
+
+            const res = await request(app)
+                .get("/projects/p1/export")
+                .set(...AUTH);
+
+            expect(res.status).toBe(404);
+            expect(res.body.detail).toBe("Project not found");
+        });
+
+        it("returns the version hashes and the edit trail as an attachment", async () => {
+            seedProjectWithOneVersion();
+
+            const res = await request(app)
+                .get("/projects/p1/export")
+                .set(...AUTH);
+
+            expect(res.status).toBe(200);
+            expect(res.headers["content-disposition"]).toMatch(
+                /attachment; filename="mike-project-manifest-p1-/,
+            );
+            expect(res.body.manifest_version).toBe(1);
+            expect(res.body.project.name).toBe("Alpha");
+            const doc = res.body.documents[0];
+            expect(doc.versions[0].content_sha256).toBe("a".repeat(64));
+            expect(doc.edits[0].status).toBe("accepted");
+        });
+
+        it("carries a digest and no signature when signing is not configured", async () => {
+            seedProjectWithOneVersion();
+
+            const res = await request(app)
+                .get("/projects/p1/export")
+                .set(...AUTH);
+
+            expect(res.body.signature).toBeNull();
+            expect(res.body.digest.algorithm).toBe("sha256");
+            expect(res.body.digest.value).toMatch(/^[0-9a-f]{64}$/);
+        });
+
+        it("signs the digest when MANIFEST_SIGNING_KEY is set", async () => {
+            process.env.MANIFEST_SIGNING_KEY = SIGNING_KEY;
+            try {
+                seedProjectWithOneVersion();
+
+                const res = await request(app)
+                    .get("/projects/p1/export")
+                    .set(...AUTH);
+
+                // Checked the way a recipient would: pin the published key,
+                // rebuild the signed payload, verify with plain Ed25519.
+                const published = manifestPublicKey()!;
+                expect(res.body.signature.algorithm).toBe("ed25519");
+                expect(res.body.signature.public_key).toBe(published.public_key);
+                const spki = Buffer.concat([
+                    Buffer.from("302a300506032b6570032100", "hex"),
+                    Buffer.from(published.public_key, "hex"),
+                ]);
+                const payload = Buffer.concat([
+                    Buffer.from("mike-project-manifest-v1\0", "utf8"),
+                    Buffer.from(res.body.digest.value, "hex"),
+                ]);
+                expect(
+                    crypto.verify(
+                        null,
+                        payload,
+                        crypto.createPublicKey({
+                            key: spki,
+                            format: "der",
+                            type: "spki",
+                        }),
+                        Buffer.from(res.body.signature.value, "hex"),
+                    ),
+                ).toBe(true);
+            } finally {
+                delete process.env.MANIFEST_SIGNING_KEY;
+            }
+        });
+
+        it("does not leak the underlying error when the manifest build fails", async () => {
+            supabaseState.tables.projects = {
+                data: null,
+                error: { message: "relation \"projects\" does not exist" },
+            };
+
+            const res = await request(app)
+                .get("/projects/p1/export")
+                .set(...AUTH);
+
+            expect(res.status).toBe(500);
+            expect(res.body.detail).toBe(
+                "Failed to build project export manifest",
+            );
         });
     });
 });

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -13,6 +13,8 @@ import { workflowsRouter } from "./routes/workflows";
 import { userRouter } from "./routes/user";
 import { downloadsRouter } from "./routes/downloads";
 import { caseLawRouter } from "./routes/caseLaw";
+import { manifestPublicKey } from "./lib/manifestSigning";
+import { safeErrorLog } from "./lib/safeError";
 
 export const app = express();
 const isProduction = process.env.NODE_ENV === "production";
@@ -134,6 +136,7 @@ app.put(
   uploadLimiter,
 );
 app.post("/projects/:projectId/documents", uploadLimiter);
+app.get("/projects/:projectId/export", exportLimiter);
 app.get("/user/export", exportLimiter);
 app.get("/user/chats/export", exportLimiter);
 app.get("/user/tabular-reviews/export", exportLimiter);
@@ -159,3 +162,16 @@ app.use("/download", downloadsRouter);
 app.use("/case-law", caseLawRouter);
 
 app.get("/health", (_req, res) => res.json({ ok: true }));
+
+// The Ed25519 public key this deployment signs project export manifests with,
+// or null when no key is configured. Deliberately open: whoever checks a
+// manifest is usually outside the workspace, and they need to get the key from
+// the server rather than trust the copy inside the file they were handed.
+app.get("/manifest-signing-key", (_req, res) => {
+  try {
+    res.json(manifestPublicKey());
+  } catch (err) {
+    console.error("[manifest-signing-key] failed", safeErrorLog(err));
+    res.status(500).json({ detail: "Manifest signing key is misconfigured" });
+  }
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,21 @@
 import { app } from "./app";
+import { manifestPublicKey } from "./lib/manifestSigning";
 
 const PORT = process.env.PORT ?? 3001;
+
+// Surface a malformed MANIFEST_SIGNING_KEY at boot rather than when someone's
+// first export fails. Unset is a valid choice and means manifests go out
+// unsigned; malformed is a misconfiguration, so stop rather than serve a
+// deployment whose exports will fail later.
+try {
+  const signingKey = manifestPublicKey();
+  if (signingKey) {
+    console.log(`Export manifests signed with key ${signingKey.key_id}`);
+  }
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}
 
 app.listen(PORT, () => {
   console.log(`Mike backend running on port ${PORT}`);

--- a/backend/src/lib/__tests__/documentVersions.test.ts
+++ b/backend/src/lib/__tests__/documentVersions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+    contentSha256,
     loadActiveVersion,
     attachActiveVersionPaths,
     attachLatestVersionNumbers,
@@ -311,5 +312,44 @@ describe("attachLatestVersionNumbers", () => {
         });
         const docs = await attachLatestVersionNumbers<TestDoc>(db, [{ id: "doc-1" }]);
         expect(docs[0].latest_version_number).toBe(2);
+    });
+});
+
+// Known SHA-256 vector for "abc" (FIPS 180-4). Call sites hand this helper a
+// mix of Buffers, raw ArrayBuffers, and views into larger buffers (multer's
+// file.buffer is one), so each of those has to produce the same digest.
+const ABC_SHA256 =
+    "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+describe("contentSha256", () => {
+    it("matches the known digest for a Buffer", () => {
+        expect(contentSha256(Buffer.from("abc", "utf8"))).toBe(ABC_SHA256);
+    });
+
+    it("matches the known digest for a raw ArrayBuffer", () => {
+        const buf = Buffer.from("abc", "utf8");
+        const ab = buf.buffer.slice(
+            buf.byteOffset,
+            buf.byteOffset + buf.byteLength,
+        ) as ArrayBuffer;
+        expect(contentSha256(ab)).toBe(ABC_SHA256);
+    });
+
+    it("respects a view's offset and length rather than its backing buffer", () => {
+        const backing = Buffer.from("xxabcxx", "utf8");
+        const view = new Uint8Array(backing.buffer, backing.byteOffset + 2, 3);
+        expect(contentSha256(view)).toBe(ABC_SHA256);
+    });
+
+    it("hashes empty content without throwing", () => {
+        expect(contentSha256(Buffer.alloc(0))).toBe(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        );
+    });
+
+    it("produces different digests for a one-byte difference", () => {
+        expect(contentSha256(Buffer.from("abc"))).not.toBe(
+            contentSha256(Buffer.from("abd")),
+        );
     });
 });

--- a/backend/src/lib/__tests__/manifestSigning.test.ts
+++ b/backend/src/lib/__tests__/manifestSigning.test.ts
@@ -70,6 +70,21 @@ describe("canonicalize", () => {
         expect(() => canonicalize({ n: Infinity })).toThrow(/finite/);
     });
 
+    it("refuses non-plain objects rather than serialising them wrongly", () => {
+        // Each of these would otherwise pass silently and produce a digest
+        // over something other than what the value represents.
+        expect(() => canonicalize({ d: new Date() })).toThrow(/plain objects/);
+        expect(() => canonicalize({ b: Buffer.from("x") })).toThrow(
+            /plain objects/,
+        );
+        expect(() => canonicalize({ m: new Map() })).toThrow(/plain objects/);
+        // Plain objects, including null-prototype ones, still pass.
+        expect(canonicalize({ a: 1 })).toBe('{"a":1}');
+        expect(canonicalize(Object.assign(Object.create(null), { a: 1 }))).toBe(
+            '{"a":1}',
+        );
+    });
+
     it("gives a round-tripped manifest the same digest", () => {
         expect(digestManifestBody(JSON.parse(JSON.stringify(BODY))).value).toBe(
             digestManifestBody(BODY).value,

--- a/backend/src/lib/__tests__/manifestSigning.test.ts
+++ b/backend/src/lib/__tests__/manifestSigning.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, afterEach } from "vitest";
+import crypto from "crypto";
+import {
+    canonicalize,
+    digestManifestBody,
+    manifestPublicKey,
+    sealManifest,
+} from "../manifestSigning";
+
+const KEY = "11".repeat(32);
+
+afterEach(() => {
+    delete process.env.MANIFEST_SIGNING_KEY;
+});
+
+const BODY = {
+    manifest_version: 1,
+    exported_at: "2026-07-31T10:00:00.000Z",
+    project: { id: "p1", name: "Alpha" },
+    documents: [
+        { id: "d1", versions: [{ id: "v1", content_sha256: "a".repeat(64) }] },
+    ],
+};
+
+/**
+ * Rebuilds the signed payload and the public key independently of the module
+ * under test, so these tests pin the wire format rather than agreeing with the
+ * implementation. A recipient checking a manifest does exactly this.
+ */
+function payloadFor(digestHex: string, context = "mike-project-manifest-v1") {
+    return Buffer.concat([
+        Buffer.from(`${context}\0`, "utf8"),
+        Buffer.from(digestHex, "hex"),
+    ]);
+}
+
+function publicKeyOf(publicKeyHex: string): crypto.KeyObject {
+    return crypto.createPublicKey({
+        key: Buffer.concat([
+            Buffer.from("302a300506032b6570032100", "hex"),
+            Buffer.from(publicKeyHex, "hex"),
+        ]),
+        format: "der",
+        type: "spki",
+    });
+}
+
+describe("canonicalize", () => {
+    it("sorts object keys so parse order cannot change the digest", () => {
+        expect(canonicalize({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+        expect(canonicalize({ a: 2, b: 1 })).toBe('{"a":2,"b":1}');
+    });
+
+    it("sorts nested keys but preserves array order", () => {
+        expect(canonicalize({ x: [{ b: 1, a: 2 }, 3] })).toBe(
+            '{"x":[{"a":2,"b":1},3]}',
+        );
+        expect(canonicalize([3, 1, 2])).toBe("[3,1,2]");
+    });
+
+    it("emits no whitespace, keeps nulls, drops undefined members", () => {
+        expect(canonicalize(BODY)).not.toMatch(/\s/);
+        expect(canonicalize({ a: null, b: undefined, c: 1 })).toBe(
+            '{"a":null,"c":1}',
+        );
+    });
+
+    it("refuses non-finite numbers rather than collapsing them onto null", () => {
+        expect(() => canonicalize({ n: Number.NaN })).toThrow(/finite/);
+        expect(() => canonicalize({ n: Infinity })).toThrow(/finite/);
+    });
+
+    it("gives a round-tripped manifest the same digest", () => {
+        expect(digestManifestBody(JSON.parse(JSON.stringify(BODY))).value).toBe(
+            digestManifestBody(BODY).value,
+        );
+    });
+});
+
+describe("sealManifest", () => {
+    it("attaches a digest and a null signature when no key is set", () => {
+        expect(manifestPublicKey()).toBeNull();
+        const sealed = sealManifest(BODY);
+        expect(sealed.signature).toBeNull();
+        expect(sealed.digest.algorithm).toBe("sha256");
+        expect(sealed.digest.value).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("publishes the same key it signs with, and never the seed", () => {
+        process.env.MANIFEST_SIGNING_KEY = KEY;
+        const sealed = sealManifest(BODY);
+        const published = manifestPublicKey()!;
+        expect(sealed.signature!.public_key).toBe(published.public_key);
+        expect(sealed.signature!.key_id).toBe(published.key_id);
+        expect(published.public_key).not.toBe(KEY);
+    });
+
+    it("produces a signature any Ed25519 implementation can check", () => {
+        process.env.MANIFEST_SIGNING_KEY = KEY;
+        const sealed = sealManifest(BODY);
+        expect(
+            crypto.verify(
+                null,
+                payloadFor(sealed.digest.value),
+                publicKeyOf(sealed.signature!.public_key),
+                Buffer.from(sealed.signature!.value, "hex"),
+            ),
+        ).toBe(true);
+    });
+
+    it("does not verify once the body has been edited", () => {
+        process.env.MANIFEST_SIGNING_KEY = KEY;
+        const sealed = sealManifest(BODY);
+        const edited = { ...sealed, project: { id: "p1", name: "Beta" } };
+        const { digest: _d, signature: _s, ...body } = edited;
+        expect(digestManifestBody(body).value).not.toBe(sealed.digest.value);
+    });
+
+    it("rejects a signature made over a different domain context", () => {
+        // Domain separation: the same key signing the same digest under
+        // another label must not pass as a manifest signature, so one signing
+        // key can serve other object types later without signatures crossing
+        // between them.
+        process.env.MANIFEST_SIGNING_KEY = KEY;
+        const sealed = sealManifest(BODY);
+        const privateKey = crypto.createPrivateKey({
+            key: Buffer.concat([
+                Buffer.from("302e020100300506032b657004220420", "hex"),
+                Buffer.from(KEY, "hex"),
+            ]),
+            format: "der",
+            type: "pkcs8",
+        });
+        const publicKey = publicKeyOf(sealed.signature!.public_key);
+
+        for (const payload of [
+            payloadFor(sealed.digest.value, "mike-project-manifest-v2"),
+            payloadFor(sealed.digest.value, ""),
+            Buffer.from(sealed.digest.value, "hex"), // bare digest, no context
+        ]) {
+            const foreign = crypto.sign(null, payload, privateKey);
+            expect(
+                crypto.verify(
+                    null,
+                    payloadFor(sealed.digest.value),
+                    publicKey,
+                    foreign,
+                ),
+            ).toBe(false);
+        }
+    });
+
+    it("is deterministic for the same body and key", () => {
+        process.env.MANIFEST_SIGNING_KEY = KEY;
+        const a = sealManifest({ ...BODY });
+        const b = sealManifest({ ...BODY });
+        expect(a.digest.value).toBe(b.digest.value);
+        expect(a.signature!.value).toBe(b.signature!.value);
+    });
+
+    it("throws on a malformed key rather than exporting unsigned", () => {
+        process.env.MANIFEST_SIGNING_KEY = "not-hex";
+        expect(() => sealManifest(BODY)).toThrow(/MANIFEST_SIGNING_KEY/);
+        expect(() => manifestPublicKey()).toThrow(/MANIFEST_SIGNING_KEY/);
+
+        process.env.MANIFEST_SIGNING_KEY = "ab".repeat(16);
+        expect(() => sealManifest(BODY)).toThrow(/32-byte hex/);
+    });
+});

--- a/backend/src/lib/chat/tools/documentOps.ts
+++ b/backend/src/lib/chat/tools/documentOps.ts
@@ -11,7 +11,10 @@ import {
   type EditInput,
 } from "../../docxTrackedChanges";
 import { buildDownloadUrl } from "../../downloadTokens";
-import { loadActiveVersion } from "../../documentVersions";
+import {
+  contentSha256,
+  loadActiveVersion,
+} from "../../documentVersions";
 import {
   type DocStore,
   type DocIndex,
@@ -550,6 +553,7 @@ export async function generateDocx(
         file_type: "docx",
         size_bytes: buf.byteLength,
         page_count: null,
+        content_sha256: contentSha256(buf),
       })
       .select("id")
       .single();
@@ -1001,6 +1005,7 @@ async function persistGeneratedFile(params: {
       file_type: extension,
       size_bytes: buffer.byteLength,
       page_count: null,
+      content_sha256: contentSha256(buffer),
     })
     .select("id")
     .single();
@@ -1178,6 +1183,16 @@ export async function runEditDocument(params: {
     newPath = reuseVersion.storagePath;
     versionRowId = reuseVersion.versionId;
     nextVersionNumber = reuseVersion.versionNumber;
+
+    // Clear the hash before the bytes change; the update below sets it again.
+    // Storage and Postgres cannot be written atomically, so a failure between
+    // the two leaves the version unhashed and therefore unverifiable, rather
+    // than hashed against content it no longer holds.
+    await db
+      .from("document_versions")
+      .update({ content_sha256: null })
+      .eq("id", versionRowId);
+
     await uploadFile(
       newPath,
       ab,
@@ -1189,6 +1204,7 @@ export async function runEditDocument(params: {
         file_type: "docx",
         size_bytes: editedBytes.byteLength,
         page_count: null,
+        content_sha256: contentSha256(editedBytes),
       })
       .eq("id", versionRowId);
   } else {
@@ -1240,6 +1256,7 @@ export async function runEditDocument(params: {
         file_type: "docx",
         size_bytes: editedBytes.byteLength,
         page_count: null,
+        content_sha256: contentSha256(editedBytes),
       })
       .select("id")
       .single();

--- a/backend/src/lib/chat/tools/toolDispatcher.ts
+++ b/backend/src/lib/chat/tools/toolDispatcher.ts
@@ -1681,7 +1681,10 @@ export async function runToolCalls(
                 version_number: 1,
                 filename: d.filename,
                 file_type: active?.file_type ?? sourceInfo.file_type,
-                size_bytes: active?.size_bytes ?? raw.byteLength,
+                // From `raw`, not `active`, so size and hash always describe
+                // the same bytes. A verifier that stats a file before hashing
+                // it must not see a size that disagrees with content_sha256.
+                size_bytes: raw.byteLength,
                 page_count: active?.page_count ?? null,
                 content_sha256: contentSha256(raw),
               }));

--- a/backend/src/lib/chat/tools/toolDispatcher.ts
+++ b/backend/src/lib/chat/tools/toolDispatcher.ts
@@ -33,7 +33,10 @@ import {
 import { convertedPdfKey } from "../../convert";
 import { contentTypeForDocumentType } from "../../documentTypes";
 import { buildDownloadUrl } from "../../downloadTokens";
-import { loadActiveVersion } from "../../documentVersions";
+import {
+  contentSha256,
+  loadActiveVersion,
+} from "../../documentVersions";
 import { type EditInput } from "../../docxTrackedChanges";
 import {
   citationReminder,
@@ -1680,6 +1683,7 @@ export async function runToolCalls(
                 file_type: active?.file_type ?? sourceInfo.file_type,
                 size_bytes: active?.size_bytes ?? raw.byteLength,
                 page_count: active?.page_count ?? null,
+                content_sha256: contentSha256(raw),
               }));
               const { data: insertedVersions, error: verErr } = await db
                 .from("document_versions")

--- a/backend/src/lib/documentVersions.ts
+++ b/backend/src/lib/documentVersions.ts
@@ -1,6 +1,24 @@
+import { createHash } from "node:crypto";
 import type { createServerSupabase } from "./supabase";
 
 type Supa = ReturnType<typeof createServerSupabase>;
+
+/**
+ * SHA-256 hex digest of a version's file bytes. Stored on
+ * `document_versions.content_sha256` at write time so an export manifest can
+ * prove a file matches the bytes the workspace held. Recompute whenever the
+ * stored bytes change — a new version row, or an in-place overwrite.
+ *
+ * Accepts a view (e.g. multer's `file.buffer`) as well as a raw ArrayBuffer;
+ * several call sites pass views into a larger backing buffer, so the offset
+ * and length must be respected rather than hashing the whole buffer.
+ */
+export function contentSha256(bytes: ArrayBuffer | ArrayBufferView): string {
+    const buf = ArrayBuffer.isView(bytes)
+        ? Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+        : Buffer.from(bytes);
+    return createHash("sha256").update(buf).digest("hex");
+}
 
 interface DocRow {
     id: string;

--- a/backend/src/lib/manifestSigning.ts
+++ b/backend/src/lib/manifestSigning.ts
@@ -1,0 +1,188 @@
+import crypto from "crypto";
+
+/**
+ * Ed25519 signing for project export manifests.
+ *
+ * A manifest carries a SHA-256 per document version, which proves an exported
+ * file has not changed *if you trust the manifest*. Signing closes that gap:
+ * the manifest's own digest is signed with a server-held key, so a recipient
+ * holding the deployment's public key can tell an untouched manifest from an
+ * edited one.
+ *
+ * Optional by design. Mike self-hosts, and a deployment that has not set up a
+ * key should still be able to export — it just gets `signature: null` and the
+ * weaker guarantee. Set MANIFEST_SIGNING_KEY to turn signing on; a malformed
+ * key throws rather than silently downgrading to unsigned, because a manifest
+ * that is quietly unsigned is the failure signing exists to prevent.
+ *
+ * Key material is a raw 32-byte Ed25519 seed, hex-encoded, matching the
+ * `openssl rand -hex 32` pattern already used for DOWNLOAD_SIGNING_SECRET.
+ */
+
+// PKCS#8 DER prefix for an Ed25519 private key (RFC 8410). Node will not build
+// a key object from a bare 32-byte seed, so the seed is wrapped in this fixed
+// envelope first. Ed25519 seeds and public keys are both 32 bytes.
+const PKCS8_ED25519_PREFIX = Buffer.from(
+    "302e020100300506032b657004220420",
+    "hex",
+);
+const ED25519_KEY_BYTES = 32;
+
+/**
+ * Domain separation. The signature covers this context string and a NUL byte
+ * before the digest bytes, so a manifest signature can never be replayed as a
+ * signature over some other object that hashes to the same 32 bytes. Bump the
+ * version suffix if the signed payload's shape changes.
+ */
+const SIGNING_CONTEXT = "mike-project-manifest-v1";
+
+function signedPayload(digestHex: string): Buffer {
+    return Buffer.concat([
+        Buffer.from(`${SIGNING_CONTEXT}\0`, "utf8"),
+        Buffer.from(digestHex, "hex"),
+    ]);
+}
+
+export interface ManifestSignature {
+    algorithm: "ed25519";
+    /** First 16 hex chars of SHA-256 over the raw public key. Rotation aid. */
+    key_id: string;
+    /** Raw Ed25519 public key, hex. */
+    public_key: string;
+    /** Signature over SIGNING_CONTEXT + NUL + the raw digest bytes, hex. */
+    value: string;
+}
+
+export interface ManifestDigest {
+    algorithm: "sha256";
+    value: string;
+}
+
+export interface SigningIdentity {
+    algorithm: "ed25519";
+    key_id: string;
+    public_key: string;
+}
+
+function seedFromEnv(): Buffer | null {
+    const raw = process.env.MANIFEST_SIGNING_KEY?.trim();
+    if (!raw) return null;
+    if (!/^[0-9a-fA-F]{64}$/.test(raw)) {
+        throw new Error(
+            "MANIFEST_SIGNING_KEY must be a 32-byte hex string " +
+                "(generate with `openssl rand -hex 32`). Unset it to export " +
+                "unsigned manifests.",
+        );
+    }
+    return Buffer.from(raw, "hex");
+}
+
+/**
+ * The configured signing key, or null when signing is off. Signing and key
+ * publication both go through here so they cannot disagree about the key id.
+ */
+function signingKey(): {
+    privateKey: crypto.KeyObject;
+    identity: SigningIdentity;
+} | null {
+    const seed = seedFromEnv();
+    if (!seed) return null;
+
+    const privateKey = crypto.createPrivateKey({
+        key: Buffer.concat([PKCS8_ED25519_PREFIX, seed]),
+        format: "der",
+        type: "pkcs8",
+    });
+    const spki = crypto.createPublicKey(privateKey).export({
+        format: "der",
+        type: "spki",
+    }) as Buffer;
+    const publicKeyRaw = spki.subarray(spki.length - ED25519_KEY_BYTES);
+
+    return {
+        privateKey,
+        identity: {
+            algorithm: "ed25519",
+            key_id: crypto
+                .createHash("sha256")
+                .update(publicKeyRaw)
+                .digest("hex")
+                .slice(0, 16),
+            public_key: publicKeyRaw.toString("hex"),
+        },
+    };
+}
+
+/**
+ * The deployment's manifest public key, or null when signing is off. Served
+ * over HTTP so a recipient can get the key from the deployment rather than
+ * trusting the copy inside the manifest they were handed — anyone who edits a
+ * manifest can re-sign it with a key of their own.
+ */
+export function manifestPublicKey(): SigningIdentity | null {
+    return signingKey()?.identity ?? null;
+}
+
+/**
+ * Deterministic JSON: object keys sorted, no whitespace.
+ *
+ * A verifier holding only the parsed manifest has to recompute the same
+ * digest, and JSON parsers do not preserve key order. Sorting is therefore
+ * part of the format, not an implementation detail. (RFC 8785 in spirit; the
+ * manifest holds no floats, so that spec's number rules do not bite.)
+ */
+export function canonicalize(value: unknown): string {
+    // NaN and Infinity both stringify to "null", which would let two different
+    // bodies share a digest. Nothing in a manifest is a float, so this guards
+    // a case that should not arise — but a digest collision is the one thing
+    // canonicalisation must not permit.
+    if (typeof value === "number" && !Number.isFinite(value)) {
+        throw new TypeError("Manifest bodies must hold finite numbers");
+    }
+    if (value === null || typeof value !== "object") return JSON.stringify(value);
+    if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+
+    return `{${Object.entries(value as Record<string, unknown>)
+        .filter(([, v]) => v !== undefined)
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+        .map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`)
+        .join(",")}}`;
+}
+
+/** SHA-256 over the canonical form of the manifest body. */
+export function digestManifestBody(body: unknown): ManifestDigest {
+    return {
+        algorithm: "sha256",
+        value: crypto
+            .createHash("sha256")
+            .update(canonicalize(body), "utf8")
+            .digest("hex"),
+    };
+}
+
+/**
+ * Attach `digest` and `signature` to a manifest body.
+ *
+ * The digest covers the body only — neither `digest` nor `signature` is an
+ * input to itself. The signature is a raw Ed25519 signature over
+ * SIGNING_CONTEXT + NUL + the digest bytes, so it can be checked with any
+ * Ed25519 implementation and none of this code.
+ */
+export function sealManifest<T extends Record<string, unknown>>(
+    body: T,
+): T & { digest: ManifestDigest; signature: ManifestSignature | null } {
+    const digest = digestManifestBody(body);
+    const key = signingKey();
+    if (!key) return { ...body, digest, signature: null };
+
+    return {
+        ...body,
+        digest,
+        signature: {
+            ...key.identity,
+            value: crypto
+                .sign(null, signedPayload(digest.value), key.privateKey)
+                .toString("hex"),
+        },
+    };
+}

--- a/backend/src/lib/manifestSigning.ts
+++ b/backend/src/lib/manifestSigning.ts
@@ -142,6 +142,17 @@ export function canonicalize(value: unknown): string {
     if (value === null || typeof value !== "object") return JSON.stringify(value);
     if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
 
+    // Anything that is not a plain object serialises wrongly and quietly: a
+    // Date becomes {} where JSON.stringify gives an ISO string, a Buffer
+    // enumerates its indices, a Map becomes {}. A manifest body only ever
+    // holds JSON from the database, so this should not arise — but a silently
+    // wrong serialisation is the same failure as the non-finite number above,
+    // and this function is what every digest rests on.
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+        throw new TypeError("Manifest bodies must hold plain objects");
+    }
+
     return `{${Object.entries(value as Record<string, unknown>)
         .filter(([, v]) => v !== undefined)
         .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))

--- a/backend/src/lib/userDataExport.ts
+++ b/backend/src/lib/userDataExport.ts
@@ -1,3 +1,4 @@
+import { sealManifest } from "./manifestSigning";
 import { createServerSupabase } from "./supabase";
 
 type Db = ReturnType<typeof createServerSupabase>;
@@ -158,6 +159,115 @@ export async function buildUserTabularReviewsExport(
             messages,
         },
     };
+}
+
+export function projectManifestFilename(projectId: string) {
+    return `mike-project-manifest-${projectId.slice(0, 8)}-${nowStamp()}.json`;
+}
+
+/**
+ * Tamper-evident manifest for one project: every document version with its
+ * content_sha256, plus the accept/reject trail. To check an exported file
+ * against what the workspace held, recompute its SHA-256 and compare.
+ *
+ * `sealManifest` then hashes the body and signs that digest with the
+ * deployment's Ed25519 key, if it has one. Unsigned, the manifest shows the
+ * *files* are unmodified but says nothing about itself.
+ *
+ * Versions written before content hashing shipped carry a null hash rather
+ * than a wrong one, so an old file set reads as unverifiable and never as
+ * verified.
+ */
+export async function buildProjectExportManifest(db: Db, projectId: string) {
+    const { data: project, error: projectError } = await db
+        .from("projects")
+        .select("id, name, cm_number, created_at")
+        .eq("id", projectId)
+        .single();
+    await throwIfError(projectError, "Failed to export project");
+
+    const documents = await selectAll(
+        db,
+        "documents",
+        (query) =>
+            query
+                .eq("project_id", projectId)
+                .order("created_at", { ascending: true })
+                .order("id", { ascending: true }),
+        "id, project_id, status, current_version_id, created_at",
+    );
+    const documentIds = idsFrom(documents);
+
+    const [versions, edits] = await Promise.all([
+        documentIds.length === 0
+            ? Promise.resolve([])
+            : selectAll(
+                  db,
+                  "document_versions",
+                  (query) =>
+                      query
+                          .in("document_id", documentIds)
+                          .order("created_at", { ascending: true })
+                          .order("id", { ascending: true }),
+                  "id, document_id, version_number, source, filename, file_type, size_bytes, content_sha256, deleted_at, created_at",
+              ),
+        documentIds.length === 0
+            ? Promise.resolve([])
+            : selectAll(
+                  db,
+                  "document_edits",
+                  (query) =>
+                      query
+                          .in("document_id", documentIds)
+                          .order("created_at", { ascending: true })
+                          .order("id", { ascending: true }),
+                  "id, document_id, version_id, change_id, status, created_at, resolved_at",
+              ),
+    ]);
+
+    const groupByDocument = (rows: Record<string, unknown>[]) => {
+        const byDoc = new Map<string, Record<string, unknown>[]>();
+        for (const row of rows) {
+            const docId = row.document_id as string;
+            const list = byDoc.get(docId) ?? [];
+            list.push(row);
+            byDoc.set(docId, list);
+        }
+        return byDoc;
+    };
+    const versionsByDoc = groupByDocument(versions);
+    const editsByDoc = groupByDocument(edits);
+
+    return sealManifest({
+        manifest_version: 1,
+        exported_at: new Date().toISOString(),
+        project,
+        documents: documents.map((doc) => ({
+            id: doc.id,
+            status: doc.status,
+            current_version_id: doc.current_version_id,
+            created_at: doc.created_at,
+            versions: (versionsByDoc.get(doc.id as string) ?? []).map((v) => ({
+                id: v.id,
+                version_number: v.version_number,
+                source: v.source,
+                filename: v.filename,
+                file_type: v.file_type,
+                size_bytes: v.size_bytes,
+                content_sha256: v.content_sha256,
+                deleted_at: v.deleted_at,
+                created_at: v.created_at,
+            })),
+            edits: (editsByDoc.get(doc.id as string) ?? []).map((e) => ({
+                id: e.id,
+                version_id: e.version_id,
+                change_id: e.change_id,
+                status: e.status,
+                created_at: e.created_at,
+                resolved_at: e.resolved_at,
+            })),
+        })),
+    });
 }
 
 export async function buildUserAccountExport(

--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -19,6 +19,7 @@ import { buildDownloadUrl } from "../lib/downloadTokens";
 import {
   attachActiveVersionPaths,
   attachLatestVersionNumbers,
+  contentSha256,
   loadActiveVersion,
 } from "../lib/documentVersions";
 import { ensureDocAccess } from "../lib/access";
@@ -533,6 +534,7 @@ documentsRouter.post(
         file_type: sourceType || null,
         size_bytes: active.size_bytes ?? bytes.byteLength,
         page_count: active.page_count,
+        content_sha256: contentSha256(bytes),
       })
       .select("id, version_number, source, created_at, filename")
       .single();
@@ -702,6 +704,7 @@ documentsRouter.post(
         file_type: suffix,
         size_bytes: file.buffer.byteLength,
         page_count: pageCount,
+        content_sha256: contentSha256(file.buffer),
       })
       .select("id, version_number, source, created_at, filename")
       .single();
@@ -897,6 +900,7 @@ documentsRouter.put(
         file_type: suffix,
         size_bytes: file.buffer.byteLength,
         page_count: pageCount,
+        content_sha256: contentSha256(file.buffer),
         created_at: uploadedAt,
       })
       .eq("id", versionId)
@@ -1231,6 +1235,18 @@ async function handleEditResolution(
     resolvedBytes.byteOffset,
     resolvedBytes.byteOffset + resolvedBytes.byteLength,
   ) as ArrayBuffer;
+
+  // Clear the hash before the bytes change, and set it again after. The stored
+  // object and the hash live in different systems, so they cannot be written
+  // atomically; ordering it this way means a failure in between leaves the
+  // version unhashed, which the manifest reports as unverifiable. The
+  // alternative ordering can leave a hash attesting to content the version no
+  // longer holds, which is the one thing the manifest must never do.
+  await db
+    .from("document_versions")
+    .update({ content_sha256: null })
+    .eq("id", doc.current_version_id);
+
   devLog(`[edit-resolution] overwriting bytes in place`, {
     latestPath,
     byteLength: ab.byteLength,
@@ -1240,6 +1256,11 @@ async function handleEditResolution(
     ab,
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   );
+
+  await db
+    .from("document_versions")
+    .update({ content_sha256: contentSha256(ab) })
+    .eq("id", doc.current_version_id);
 
   const { error: statusErr } = await db
     .from("document_edits")
@@ -1253,7 +1274,6 @@ async function handleEditResolution(
     newStatus: mode === "accept" ? "accepted" : "rejected",
     statusErr,
   });
-
   const { count: remainingPending } = await db
     .from("document_edits")
     .select("id", { count: "exact", head: true })
@@ -1400,6 +1420,7 @@ export async function handleDocumentUpload(
         file_type: suffix,
         size_bytes: content.byteLength,
         page_count: pageCount,
+        content_sha256: contentSha256(content),
       })
       .select("id")
       .single();

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -1,11 +1,17 @@
 import { Router } from "express";
-import { requireAuth } from "../middleware/auth";
+import { requireAuth, requireMfaIfEnrolled } from "../middleware/auth";
 import { createServerSupabase } from "../lib/supabase";
 import { createClient } from "@supabase/supabase-js";
 import {
   attachActiveVersionPaths,
   attachLatestVersionNumbers,
+  contentSha256,
 } from "../lib/documentVersions";
+import { safeErrorLog } from "../lib/safeError";
+import {
+  buildProjectExportManifest,
+  projectManifestFilename,
+} from "../lib/userDataExport";
 import {
   deleteFile,
   downloadFile,
@@ -461,6 +467,46 @@ projectsRouter.get("/:projectId/documents", requireAuth, async (req, res) => {
   res.json(docsTyped);
 });
 
+// GET /projects/:projectId/export — tamper-evident manifest of the project's
+// documents: every version with its content_sha256 plus the accept/reject
+// trail, under a SHA-256 digest that is Ed25519-signed when the deployment has
+// MANIFEST_SIGNING_KEY set. To check an export, recompute a downloaded file's
+// SHA-256 and compare, then check the manifest's signature against the key
+// served at GET /manifest-signing-key. See the README.
+projectsRouter.get(
+  "/:projectId/export",
+  requireAuth,
+  requireMfaIfEnrolled,
+  async (req, res) => {
+    const userId = res.locals.userId as string;
+    const userEmail = res.locals.userEmail as string | undefined;
+    const { projectId } = req.params;
+    const db = createServerSupabase();
+
+    const access = await checkProjectAccess(projectId, userId, userEmail, db);
+    if (!access.ok)
+      return void res.status(404).json({ detail: "Project not found" });
+
+    try {
+      const data = await buildProjectExportManifest(db, projectId);
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="${projectManifestFilename(projectId)}"`,
+      );
+      res.json(data);
+    } catch (err) {
+      console.error("[projects/export] failed", {
+        projectId,
+        error: safeErrorLog(err),
+      });
+      res
+        .status(500)
+        .json({ detail: "Failed to build project export manifest" });
+    }
+  },
+);
+
 // POST /projects/:projectId/documents/:documentId — assign or copy existing doc into project
 projectsRouter.post(
   "/:projectId/documents/:documentId",
@@ -601,6 +647,7 @@ projectsRouter.post(
               (srcV.size_bytes as number | null) ?? doc.size_bytes ?? null,
             page_count:
               (srcV.page_count as number | null) ?? doc.page_count ?? null,
+            content_sha256: contentSha256(srcBytes),
           })
           .select("id")
           .single();
@@ -1012,6 +1059,7 @@ export async function handleDocumentUpload(
         file_type: suffix,
         size_bytes: content.byteLength,
         page_count: pageCount,
+        content_sha256: contentSha256(content),
       })
       .select("id")
       .single();


### PR DESCRIPTION
Rebase of #181 onto current main, with the manifest signing you asked for there.

## What it does

Exports cannot currently prove that a document version is the file the workspace held. This stores a SHA-256 of every version's bytes at write time and adds a per-project manifest listing them, alongside the accept/reject trail. To check a file: `shasum -a 256 lease.docx` against the manifest.

Versions written before this shipped carry a `null` hash, so an old file set reads as unverifiable rather than as falsely verified.

## Signing

The manifest carries a SHA-256 digest over its own body, meaning everything except `digest` and `signature`. Serialising sorts object keys, keeps array order, and emits no whitespace, so a recipient can recompute the digest from parsed JSON.

Set `MANIFEST_SIGNING_KEY` and that digest is signed. Optional rather than required, because Mike self-hosts and a deployment without key custody should still be able to export: it gets `signature: null` and the weaker guarantee. A *malformed* key fails the export with a clear error instead of quietly producing an unsigned manifest, which is the failure signing exists to prevent.

The signature is a raw Ed25519 signature over the bytes `mike-project-manifest-v1`, a NUL byte, then the digest bytes. Two consequences worth stating:

- The context prefix means a manifest signature cannot be replayed as a signature over some other object that hashes to the same 32 bytes, so one key can cover other object types later.
- There is no library to adopt. Any Ed25519 implementation checks it in three lines, shown in the README.

The public key is served at `GET /manifest-signing-key`, unauthenticated. Take the key from there rather than from the manifest: whoever edits a manifest can re-sign it with a key of their own, so the embedded copy shows consistency, never provenance.

Key material is a hex seed from `openssl rand -hex 32`, the same pattern as `DOWNLOAD_SIGNING_SECRET`.

## Against current main

Not a git rebase. The branch on #181 predates the `app.ts` factory, the vitest suite, and the `chatTools.ts` to `lib/chat/tools/` split, so I re-applied it by hand:

- Hashes at every byte-write site on current main, including the three that did not exist in June: `generateOfficeDoc`, the library upload path, and the project upload path. `library.ts` renames do not touch bytes, so no hash there.
- Accept/reject resolution and assistant-edit reuse rewrite bytes in place, as they do today. Storage and Postgres cannot be written atomically, so the hash is cleared before the bytes change and set again after. An interrupted resolution leaves the version unhashed and therefore unverifiable, never hashed against content it no longer holds.
- Export route registered with the existing `exportLimiter` and `requireMfaIfEnrolled`, matching the account export routes.
- Migration under `backend/migrations/` with the current dated naming, nullable column, safe to re-run.

The diff adds 892 lines and removes 5. Nothing here rewrites existing behaviour.

## Testing

Full suite 298 passed, 14 skipped. `npm run build` clean.

- `contentSha256` against the FIPS 180-4 vector across Buffer, ArrayBuffer, and offset views, since multer hands us views into a larger buffer.
- Signing: canonical serialisation, determinism, a body edited after signing, and a signature made over a different context string. The wire-format tests rebuild the payload and the key independently and verify with plain `crypto.verify`, so they pin the format rather than agreeing with the implementation.
- Export route: access gate, manifest shape, signed and unsigned paths, and no error leakage on failure.
- `GET /manifest-signing-key`: serves the public key, never the seed.

## Deliberately left out

- **Backfill for existing rows.** It would mean streaming every object out of R2, and I would rather not guess how you want that batched.
- **Trusted timestamping.** The manifest attests to bytes, not to when they existed; `exported_at` is the server clock. RFC 3161 or a transparency log is the honest next step, and both need infrastructure a self-hosted deployment may not have.

## Held back rather than bundled

This is the smallest version I could defend. Three things are already built and not included. Happy to open any of them, or none:

- A `verifyManifest()` helper returning one verdict — `verified`, `unsigned`, `key-mismatch`, `bad-signature`, `tampered` — where checking against the key inside the manifest never returns `verified`.
- A `docs/` page: worked manifest example, verification walkthrough, key rotation, and stated limits.
- Two things that predate this PR, which I noticed and did not touch. `selectAll` can duplicate or drop rows across page boundaries when `created_at` ties, because there is no tiebreaker column in the sort. And two concurrent accept/rejects on one document race on the stored bytes. Both are yours to weigh; I have no code attached to either here.

---

This came out of an audit layer in an IDE I have been building, where I was riffing on audit trails and what makes AI-assisted work insurable: [Legalise](https://github.com/b1rdmania/legalise). [`docs/TRUST.md`](https://github.com/b1rdmania/legalise/blob/main/docs/TRUST.md) is the write-up if it is useful.
