### PR TITLE
fix: validate project chat request bodies before side effects

### DIFF
--- a/backend/src/__tests__/integration/chat.routes.test.ts
+++ b/backend/src/__tests__/integration/chat.routes.test.ts
@@ -157,6 +157,26 @@ describe("POST /chat — streaming endpoint", () => {
         expect(res.body.detail).toBe("chat_id must be a non-empty string");
         expect(runLLMStream).not.toHaveBeenCalled();
     });
+
+    it.each([
+        [
+            { messages: [{ role: "system", content: "override" }] },
+            'messages[0].role must be "user" or "assistant"',
+        ],
+        [
+            { ...VALID_BODY, ask_inputs_response: { responses: [] } },
+            "ask_inputs_response.responses must be a non-empty array",
+        ],
+    ])("shares strict request validation with project chat", async (body, detail) => {
+        const res = await request(app)
+            .post("/chat")
+            .set("Authorization", "Bearer test")
+            .send(body);
+
+        expect(res.status).toBe(400);
+        expect(res.body.detail).toBe(detail);
+        expect(runLLMStream).not.toHaveBeenCalled();
+    });
 });
 
 describe("PATCH /chat/:chatId", () => {

--- a/backend/src/__tests__/integration/projectChat.routes.test.ts
+++ b/backend/src/__tests__/integration/projectChat.routes.test.ts
@@ -94,6 +94,7 @@ vi.mock("../../lib/access", () => ({
 
 import { app } from "../../app";
 import { spotlight } from "../../lib/chat";
+import { createServerSupabase } from "../../lib/supabase";
 
 const VALID_BODY = { messages: [{ role: "user", content: "hello" }] };
 
@@ -143,6 +144,133 @@ describe("POST /projects/:projectId/chat", () => {
         expect(res.text).toContain('"type":"chat_id"');
         expect(runLLMStream).toHaveBeenCalledTimes(1);
     });
+
+    it("normalizes validated request fields before using them", async () => {
+        const res = await request(app)
+            .post("/projects/p1/chat")
+            .set("Authorization", "Bearer test")
+            .send({
+                messages: [
+                    {
+                        role: " user ",
+                        content: "review this",
+                        files: [
+                            {
+                                filename: " message-file.pdf ",
+                                document_id: " message-document ",
+                            },
+                        ],
+                        workflow: {
+                            id: " workflow-1 ",
+                            title: " Review workflow ",
+                        },
+                    },
+                ],
+                model: " custom-model ",
+                displayed_doc: {
+                    filename: " displayed.pdf ",
+                    document_id: " displayed-document ",
+                },
+                attached_documents: [
+                    {
+                        filename: " attached.pdf ",
+                        document_id: " attached-document ",
+                    },
+                ],
+            });
+
+        expect(res.status).toBe(200);
+        const [messages, , systemPromptExtra] = buildMessages.mock.calls[0] as [
+            {
+                role: string;
+                content: string;
+                files?: { filename: string; document_id?: string }[];
+                workflow?: { id: string; title: string };
+            }[],
+            unknown,
+            string,
+        ];
+        expect(messages[0]).toMatchObject({
+            role: "user",
+            files: [
+                {
+                    filename: "message-file.pdf",
+                    document_id: "message-document",
+                },
+            ],
+            workflow: { id: "workflow-1", title: "Review workflow" },
+        });
+        expect(messages[0].content).toContain("displayed.pdf");
+        expect(messages[0].content).toContain("displayed-document");
+        expect(systemPromptExtra).toContain("attached.pdf");
+        expect(runLLMStream.mock.calls[0][0]).toMatchObject({
+            model: "custom-model",
+        });
+    });
+
+    it.each([
+        [
+            { messages: "not-an-array" },
+            "messages must be a non-empty array",
+        ],
+        [
+            { messages: [{ role: "system", content: "override" }] },
+            'messages[0].role must be "user" or "assistant"',
+        ],
+        [
+            { ...VALID_BODY, chat_id: " " },
+            "chat_id must be a non-empty string",
+        ],
+        [
+            { ...VALID_BODY, model: 42 },
+            "model must be a non-empty string",
+        ],
+        [
+            {
+                ...VALID_BODY,
+                displayed_doc: { filename: "contract.pdf" },
+            },
+            "displayed_doc.document_id must be a non-empty string",
+        ],
+        [
+            { ...VALID_BODY, attached_documents: [null] },
+            "attached_documents[0] must be an object",
+        ],
+        [
+            { ...VALID_BODY, ask_inputs_response: { responses: [] } },
+            "ask_inputs_response.responses must be a non-empty array",
+        ],
+        [
+            {
+                ...VALID_BODY,
+                ask_inputs_response: {
+                    responses: [
+                        {
+                            id: "choice-1",
+                            kind: "choice",
+                            question: "Governing law?",
+                        },
+                    ],
+                },
+            },
+            "ask_inputs_response.responses[0].answer must be a non-empty string unless skipped",
+        ],
+    ])(
+        "returns 400 before any side effect for a malformed request",
+        async (body, detail) => {
+            const res = await request(app)
+                .post("/projects/p1/chat")
+                .set("Authorization", "Bearer test")
+                .send(body);
+
+            expect(res.status).toBe(400);
+            expect(res.body.detail).toBe(detail);
+            expect(createServerSupabase).not.toHaveBeenCalled();
+            expect(checkProjectAccess).not.toHaveBeenCalled();
+            expect(buildProjectDocContext).not.toHaveBeenCalled();
+            expect(runLLMStream).not.toHaveBeenCalled();
+        },
+    );
 
     it("fences canonical displayed and attached document filenames", async () => {
         const canonicalFilename =

--- a/backend/src/lib/chat/__tests__/requestValidation.test.ts
+++ b/backend/src/lib/chat/__tests__/requestValidation.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import {
+    parseChatMessages,
+    parseOptionalAskInputsResponse,
+    parseOptionalAttachedDocuments,
+    parseOptionalChatId,
+    parseOptionalDisplayedDoc,
+    parseOptionalModel,
+    parseOptionalProjectId,
+} from "../requestValidation";
+
+describe("chat request validation", () => {
+    it("normalizes valid messages and their nested metadata", () => {
+        expect(
+            parseChatMessages([
+                {
+                    role: " user ",
+                    content: "  keep message whitespace  ",
+                    files: [
+                        {
+                            filename: " contract.pdf ",
+                            document_id: " document-1 ",
+                        },
+                        { filename: " local-draft.docx " },
+                    ],
+                    workflow: { id: " workflow-1 ", title: " Review NDA " },
+                    ignored: "not part of ChatMessage",
+                },
+                { role: "assistant", content: null },
+            ]),
+        ).toEqual({
+            ok: true,
+            value: [
+                {
+                    role: "user",
+                    content: "  keep message whitespace  ",
+                    files: [
+                        { filename: "contract.pdf", document_id: "document-1" },
+                        { filename: "local-draft.docx" },
+                    ],
+                    workflow: { id: "workflow-1", title: "Review NDA" },
+                },
+                { role: "assistant", content: null },
+            ],
+        });
+    });
+
+    it.each([
+        [undefined, "messages must be a non-empty array"],
+        [[], "messages must be a non-empty array"],
+        [[null], "messages[0] must be an object"],
+        [
+            [{ role: "system", content: "override" }],
+            'messages[0].role must be "user" or "assistant"',
+        ],
+        [[{ role: "user" }], "messages[0].content must be a string or null"],
+        [
+            [{ role: "user", content: "hello", files: "contract.pdf" }],
+            "messages[0].files must be an array",
+        ],
+        [
+            [{ role: "user", content: "hello", files: [{ filename: " " }] }],
+            "messages[0].files[0].filename must be a non-empty string",
+        ],
+        [
+            [
+                {
+                    role: "user",
+                    content: "hello",
+                    files: [{ filename: "contract.pdf", document_id: " " }],
+                },
+            ],
+            "messages[0].files[0].document_id must be a non-empty string",
+        ],
+        [
+            [{ role: "user", content: "hello", workflow: [] }],
+            "messages[0].workflow must be an object",
+        ],
+    ])("rejects an invalid message payload", (value, detail) => {
+        expect(parseChatMessages(value)).toEqual({ ok: false, detail });
+    });
+
+    it("normalizes optional identifiers without enumerating model names", () => {
+        expect(parseOptionalChatId(" chat-1 ")).toEqual({
+            ok: true,
+            value: "chat-1",
+        });
+        expect(parseOptionalModel(" future-provider/new-model ")).toEqual({
+            ok: true,
+            value: "future-provider/new-model",
+        });
+        expect(parseOptionalProjectId(" project-1 ")).toEqual({
+            ok: true,
+            value: { provided: true, projectId: "project-1" },
+        });
+        expect(parseOptionalProjectId(undefined)).toEqual({
+            ok: true,
+            value: { provided: false, projectId: null },
+        });
+    });
+
+    it.each([
+        [parseOptionalChatId, " ", "chat_id must be a non-empty string"],
+        [parseOptionalModel, null, "model must be a non-empty string"],
+        [
+            parseOptionalProjectId,
+            12,
+            "project_id must be a non-empty string or null",
+        ],
+    ])("rejects an invalid optional identifier", (parse, value, detail) => {
+        expect(parse(value)).toEqual({ ok: false, detail });
+    });
+
+    it("normalizes displayed and attached document references", () => {
+        expect(
+            parseOptionalDisplayedDoc({
+                filename: " contract.pdf ",
+                document_id: " document-1 ",
+            }),
+        ).toEqual({
+            ok: true,
+            value: { filename: "contract.pdf", document_id: "document-1" },
+        });
+        expect(
+            parseOptionalAttachedDocuments([
+                { filename: " exhibit.pdf ", document_id: " document-2 " },
+            ]),
+        ).toEqual({
+            ok: true,
+            value: [{ filename: "exhibit.pdf", document_id: "document-2" }],
+        });
+    });
+
+    it.each([
+        [
+            () => parseOptionalDisplayedDoc("contract.pdf"),
+            "displayed_doc must be an object",
+        ],
+        [
+            () =>
+                parseOptionalDisplayedDoc({
+                    filename: "contract.pdf",
+                    document_id: " ",
+                }),
+            "displayed_doc.document_id must be a non-empty string",
+        ],
+        [
+            () => parseOptionalAttachedDocuments({}),
+            "attached_documents must be an array",
+        ],
+        [
+            () => parseOptionalAttachedDocuments([null]),
+            "attached_documents[0] must be an object",
+        ],
+    ])("rejects an invalid document reference", (parse, detail) => {
+        expect(parse()).toEqual({ ok: false, detail });
+    });
+
+    it("validates and normalizes ask-input responses", () => {
+        expect(
+            parseOptionalAskInputsResponse({
+                type: "ask_inputs_response",
+                responses: [
+                    {
+                        id: " choice-1 ",
+                        kind: "choice",
+                        question: " Governing law? ",
+                        answer: " New York ",
+                    },
+                    {
+                        id: " docs-1 ",
+                        kind: "documents",
+                        filenames: [" exhibit-a.pdf ", " exhibit-b.pdf "],
+                    },
+                ],
+            }),
+        ).toEqual({
+            ok: true,
+            value: {
+                responses: [
+                    {
+                        id: "choice-1",
+                        kind: "choice",
+                        question: "Governing law?",
+                        answer: "New York",
+                    },
+                    {
+                        id: "docs-1",
+                        kind: "documents",
+                        filenames: ["exhibit-a.pdf", "exhibit-b.pdf"],
+                    },
+                ],
+            },
+        });
+    });
+
+    it.each([
+        ["answer", "ask_inputs_response must be an object"],
+        [
+            { responses: [] },
+            "ask_inputs_response.responses must be a non-empty array",
+        ],
+        [
+            { responses: [{ id: "choice-1", kind: "other" }] },
+            'ask_inputs_response.responses[0].kind must be "choice" or "documents"',
+        ],
+        [
+            {
+                responses: [
+                    {
+                        id: "choice-1",
+                        kind: "choice",
+                        question: "Question",
+                        answer: " ",
+                    },
+                ],
+            },
+            "ask_inputs_response.responses[0].answer must be a non-empty string unless skipped",
+        ],
+        [
+            {
+                responses: [
+                    {
+                        id: "docs-1",
+                        kind: "documents",
+                        filenames: ["valid.pdf", 42],
+                    },
+                ],
+            },
+            "ask_inputs_response.responses[0].filenames[1] must be a non-empty string",
+        ],
+    ])("rejects an invalid ask-input response", (value, detail) => {
+        expect(parseOptionalAskInputsResponse(value)).toEqual({
+            ok: false,
+            detail,
+        });
+    });
+});

--- a/backend/src/lib/chat/index.ts
+++ b/backend/src/lib/chat/index.ts
@@ -6,3 +6,4 @@ export * from "./tools/documentOps";
 export * from "./tools/toolDispatcher";
 export * from "./streaming";
 export * from "./contextBuilders";
+export * from "./requestValidation";

--- a/backend/src/lib/chat/requestValidation.ts
+++ b/backend/src/lib/chat/requestValidation.ts
@@ -1,0 +1,329 @@
+import { parseAskInputsResponsePayload } from "./contextBuilders";
+import type { AskInputsResponseRequest, ChatMessage } from "./types";
+
+type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; detail: string };
+
+export type ChatDocumentReference = {
+  filename: string;
+  document_id: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseNonEmptyString(
+  value: unknown,
+  detail: string,
+): ValidationResult<string> {
+  if (typeof value !== "string" || !value.trim()) {
+    return { ok: false, detail };
+  }
+  return { ok: true, value: value.trim() };
+}
+
+export function parseOptionalProjectId(
+  value: unknown,
+): ValidationResult<{ provided: boolean; projectId: string | null }> {
+  if (value === undefined) {
+    return { ok: true, value: { provided: false, projectId: null } };
+  }
+  if (value === null) {
+    return { ok: true, value: { provided: true, projectId: null } };
+  }
+  const parsed = parseNonEmptyString(
+    value,
+    "project_id must be a non-empty string or null",
+  );
+  if (!parsed.ok) return parsed;
+  return {
+    ok: true,
+    value: { provided: true, projectId: parsed.value },
+  };
+}
+
+export function parseOptionalChatId(
+  value: unknown,
+): ValidationResult<string | null> {
+  if (value === undefined || value === null) {
+    return { ok: true, value: null };
+  }
+  return parseNonEmptyString(value, "chat_id must be a non-empty string");
+}
+
+export function parseOptionalModel(
+  value: unknown,
+): ValidationResult<string | undefined> {
+  if (value === undefined) return { ok: true, value: undefined };
+  return parseNonEmptyString(value, "model must be a non-empty string");
+}
+
+function parseMessageFiles(
+  value: unknown,
+  messageIndex: number,
+): ValidationResult<NonNullable<ChatMessage["files"]>> {
+  if (!Array.isArray(value)) {
+    return {
+      ok: false,
+      detail: `messages[${messageIndex}].files must be an array`,
+    };
+  }
+
+  const files: NonNullable<ChatMessage["files"]> = [];
+  for (const [fileIndex, file] of value.entries()) {
+    if (!isRecord(file)) {
+      return {
+        ok: false,
+        detail: `messages[${messageIndex}].files[${fileIndex}] must be an object`,
+      };
+    }
+    const filename = parseNonEmptyString(
+      file.filename,
+      `messages[${messageIndex}].files[${fileIndex}].filename must be a non-empty string`,
+    );
+    if (!filename.ok) return filename;
+
+    let documentId: string | undefined;
+    if (file.document_id !== undefined) {
+      const parsedDocumentId = parseNonEmptyString(
+        file.document_id,
+        `messages[${messageIndex}].files[${fileIndex}].document_id must be a non-empty string`,
+      );
+      if (!parsedDocumentId.ok) return parsedDocumentId;
+      documentId = parsedDocumentId.value;
+    }
+
+    files.push({
+      filename: filename.value,
+      ...(documentId ? { document_id: documentId } : {}),
+    });
+  }
+  return { ok: true, value: files };
+}
+
+function parseMessageWorkflow(
+  value: unknown,
+  messageIndex: number,
+): ValidationResult<NonNullable<ChatMessage["workflow"]>> {
+  if (!isRecord(value)) {
+    return {
+      ok: false,
+      detail: `messages[${messageIndex}].workflow must be an object`,
+    };
+  }
+  const id = parseNonEmptyString(
+    value.id,
+    `messages[${messageIndex}].workflow.id must be a non-empty string`,
+  );
+  if (!id.ok) return id;
+  const title = parseNonEmptyString(
+    value.title,
+    `messages[${messageIndex}].workflow.title must be a non-empty string`,
+  );
+  if (!title.ok) return title;
+  return { ok: true, value: { id: id.value, title: title.value } };
+}
+
+export function parseChatMessages(
+  value: unknown,
+): ValidationResult<ChatMessage[]> {
+  if (!Array.isArray(value) || value.length === 0) {
+    return { ok: false, detail: "messages must be a non-empty array" };
+  }
+
+  const messages: ChatMessage[] = [];
+  for (const [index, message] of value.entries()) {
+    if (!isRecord(message)) {
+      return {
+        ok: false,
+        detail: `messages[${index}] must be an object`,
+      };
+    }
+
+    const role = typeof message.role === "string" ? message.role.trim() : "";
+    if (role !== "user" && role !== "assistant") {
+      return {
+        ok: false,
+        detail: `messages[${index}].role must be "user" or "assistant"`,
+      };
+    }
+    if (message.content !== null && typeof message.content !== "string") {
+      return {
+        ok: false,
+        detail: `messages[${index}].content must be a string or null`,
+      };
+    }
+
+    let files: ChatMessage["files"];
+    if (message.files !== undefined) {
+      const parsedFiles = parseMessageFiles(message.files, index);
+      if (!parsedFiles.ok) return parsedFiles;
+      files = parsedFiles.value;
+    }
+
+    let workflow: ChatMessage["workflow"];
+    if (message.workflow !== undefined) {
+      const parsedWorkflow = parseMessageWorkflow(message.workflow, index);
+      if (!parsedWorkflow.ok) return parsedWorkflow;
+      workflow = parsedWorkflow.value;
+    }
+
+    messages.push({
+      role,
+      content: message.content,
+      ...(files ? { files } : {}),
+      ...(workflow ? { workflow } : {}),
+    });
+  }
+
+  return { ok: true, value: messages };
+}
+
+function parseDocumentReference(
+  value: unknown,
+  field: string,
+): ValidationResult<ChatDocumentReference> {
+  if (!isRecord(value)) {
+    return { ok: false, detail: `${field} must be an object` };
+  }
+  const filename = parseNonEmptyString(
+    value.filename,
+    `${field}.filename must be a non-empty string`,
+  );
+  if (!filename.ok) return filename;
+  const documentId = parseNonEmptyString(
+    value.document_id,
+    `${field}.document_id must be a non-empty string`,
+  );
+  if (!documentId.ok) return documentId;
+  return {
+    ok: true,
+    value: { filename: filename.value, document_id: documentId.value },
+  };
+}
+
+export function parseOptionalDisplayedDoc(
+  value: unknown,
+): ValidationResult<ChatDocumentReference | undefined> {
+  if (value === undefined || value === null) {
+    return { ok: true, value: undefined };
+  }
+  return parseDocumentReference(value, "displayed_doc");
+}
+
+export function parseOptionalAttachedDocuments(
+  value: unknown,
+): ValidationResult<ChatDocumentReference[] | undefined> {
+  if (value === undefined || value === null) {
+    return { ok: true, value: undefined };
+  }
+  if (!Array.isArray(value)) {
+    return {
+      ok: false,
+      detail: "attached_documents must be an array",
+    };
+  }
+
+  const documents: ChatDocumentReference[] = [];
+  for (const [index, document] of value.entries()) {
+    const parsed = parseDocumentReference(
+      document,
+      `attached_documents[${index}]`,
+    );
+    if (!parsed.ok) return parsed;
+    documents.push(parsed.value);
+  }
+  return { ok: true, value: documents };
+}
+
+export function parseOptionalAskInputsResponse(
+  value: unknown,
+): ValidationResult<AskInputsResponseRequest | null> {
+  if (value === undefined || value === null) {
+    return { ok: true, value: null };
+  }
+  if (!isRecord(value)) {
+    return {
+      ok: false,
+      detail: "ask_inputs_response must be an object",
+    };
+  }
+  if (!Array.isArray(value.responses) || value.responses.length === 0) {
+    return {
+      ok: false,
+      detail: "ask_inputs_response.responses must be a non-empty array",
+    };
+  }
+
+  for (const [index, response] of value.responses.entries()) {
+    const field = `ask_inputs_response.responses[${index}]`;
+    if (!isRecord(response)) {
+      return { ok: false, detail: `${field} must be an object` };
+    }
+    const id = parseNonEmptyString(
+      response.id,
+      `${field}.id must be a non-empty string`,
+    );
+    if (!id.ok) return id;
+    if (response.kind !== "choice" && response.kind !== "documents") {
+      return {
+        ok: false,
+        detail: `${field}.kind must be "choice" or "documents"`,
+      };
+    }
+    if (
+      response.skipped !== undefined &&
+      typeof response.skipped !== "boolean"
+    ) {
+      return { ok: false, detail: `${field}.skipped must be a boolean` };
+    }
+
+    if (response.kind === "choice") {
+      const question = parseNonEmptyString(
+        response.question,
+        `${field}.question must be a non-empty string`,
+      );
+      if (!question.ok) return question;
+      if (
+        response.answer !== undefined &&
+        typeof response.answer !== "string"
+      ) {
+        return { ok: false, detail: `${field}.answer must be a string` };
+      }
+      if (
+        response.skipped !== true &&
+        (typeof response.answer !== "string" || !response.answer.trim())
+      ) {
+        return {
+          ok: false,
+          detail: `${field}.answer must be a non-empty string unless skipped`,
+        };
+      }
+      continue;
+    }
+
+    if (!Array.isArray(response.filenames)) {
+      return { ok: false, detail: `${field}.filenames must be an array` };
+    }
+    for (const [filenameIndex, filename] of response.filenames.entries()) {
+      const parsedFilename = parseNonEmptyString(
+        filename,
+        `${field}.filenames[${filenameIndex}] must be a non-empty string`,
+      );
+      if (!parsedFilename.ok) return parsedFilename;
+    }
+  }
+
+  // Shape validation above makes the existing normalizer safe to call while
+  // preserving its established length and item-count limits.
+  const response = parseAskInputsResponsePayload(value);
+  if (!response) {
+    return {
+      ok: false,
+      detail: "ask_inputs_response must contain at least one valid response",
+    };
+  }
+  return { ok: true, value: response };
+}

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -15,8 +15,11 @@ import {
     isAbortError,
     runLLMStream,
     stripTransientAssistantEvents,
-    parseAskInputsResponsePayload,
-    type ChatMessage,
+    parseChatMessages,
+    parseOptionalAskInputsResponse,
+    parseOptionalChatId,
+    parseOptionalModel,
+    parseOptionalProjectId,
 } from "../lib/chat";
 import { completeText } from "../lib/llm";
 import {
@@ -47,67 +50,6 @@ type AccessibleChat = {
     user_id: string;
     project_id: string | null;
 } & Record<string, unknown>;
-
-function parseOptionalProjectId(value: unknown):
-    | { ok: true; provided: boolean; projectId: string | null }
-    | { ok: false; detail: string } {
-    if (value === undefined)
-        return { ok: true, provided: false, projectId: null };
-    if (value === null) return { ok: true, provided: true, projectId: null };
-    if (typeof value !== "string" || !value.trim()) {
-        return {
-            ok: false,
-            detail: "project_id must be a non-empty string or null",
-        };
-    }
-    return { ok: true, provided: true, projectId: value.trim() };
-}
-
-function parseOptionalChatId(value: unknown):
-    | { ok: true; chatId: string | null }
-    | { ok: false; detail: string } {
-    if (value === undefined || value === null) return { ok: true, chatId: null };
-    if (typeof value !== "string" || !value.trim()) {
-        return { ok: false, detail: "chat_id must be a non-empty string" };
-    }
-    return { ok: true, chatId: value.trim() };
-}
-
-function parseChatMessages(value: unknown):
-    | { ok: true; messages: ChatMessage[] }
-    | { ok: false; detail: string } {
-    if (!Array.isArray(value) || value.length === 0) {
-        return { ok: false, detail: "messages must be a non-empty array" };
-    }
-
-    for (const message of value) {
-        if (!message || typeof message !== "object" || Array.isArray(message)) {
-            return { ok: false, detail: "messages must contain objects" };
-        }
-        const row = message as Record<string, unknown>;
-        if (typeof row.role !== "string") {
-            return { ok: false, detail: "message.role must be a string" };
-        }
-        if (row.content !== null && typeof row.content !== "string") {
-            return {
-                ok: false,
-                detail: "message.content must be a string or null",
-            };
-        }
-    }
-
-    return { ok: true, messages: value as ChatMessage[] };
-}
-
-function parseOptionalModel(value: unknown):
-    | { ok: true; model: string | undefined }
-    | { ok: false; detail: string } {
-    if (value === undefined) return { ok: true, model: undefined };
-    if (typeof value !== "string" || !value.trim()) {
-        return { ok: false, detail: "model must be a non-empty string" };
-    }
-    return { ok: true, model: value.trim() };
-}
 
 async function validateAccessibleProjectId(
     projectId: string | null,
@@ -181,7 +123,7 @@ chatRouter.post("/create", requireAuth, async (req, res) => {
     if (!parsedProjectId.ok) {
         return void res.status(400).json({ detail: parsedProjectId.detail });
     }
-    const projectId = parsedProjectId.projectId;
+    const projectId = parsedProjectId.value.projectId;
     const db = createServerSupabase();
     const projectAccess = await validateAccessibleProjectId(
         projectId,
@@ -439,14 +381,20 @@ chatRouter.post("/", requireAuth, async (req, res) => {
     if (!parsedModel.ok) {
         return void res.status(400).json({ detail: parsedModel.detail });
     }
-    const askInputsResponse = parseAskInputsResponsePayload(
+    const parsedAskInputsResponse = parseOptionalAskInputsResponse(
         body.ask_inputs_response,
     );
+    if (!parsedAskInputsResponse.ok) {
+        return void res
+            .status(400)
+            .json({ detail: parsedAskInputsResponse.detail });
+    }
 
-    const messages = parsedMessages.messages;
-    const chat_id = parsedChatId.chatId;
-    const project_id = parsedProjectId.projectId;
-    const model = parsedModel.model;
+    const messages = parsedMessages.value;
+    const chat_id = parsedChatId.value;
+    const project_id = parsedProjectId.value.projectId;
+    const model = parsedModel.value;
+    const askInputsResponse = parsedAskInputsResponse.value;
 
     devLog("[chat/stream] incoming request", {
         userId,
@@ -460,7 +408,7 @@ chatRouter.post("/", requireAuth, async (req, res) => {
     const db = createServerSupabase();
     let chatId = chat_id ?? null;
     let chatTitle: string | null = null;
-    let resolvedProjectId: string | null = parsedProjectId.projectId;
+    let resolvedProjectId: string | null = parsedProjectId.value.projectId;
 
     if (chatId) {
         const existing = await getAccessibleChat(chatId, userId, userEmail, db);
@@ -469,8 +417,8 @@ chatRouter.post("/", requireAuth, async (req, res) => {
 
         const existingProjectId = existing.project_id ?? null;
         if (
-            parsedProjectId.provided &&
-            parsedProjectId.projectId !== existingProjectId
+            parsedProjectId.value.provided &&
+            parsedProjectId.value.projectId !== existingProjectId
         ) {
             return void res
                 .status(400)

--- a/backend/src/routes/projectChat.ts
+++ b/backend/src/routes/projectChat.ts
@@ -17,7 +17,12 @@ import {
     spotlightFilename,
     stripTransientAssistantEvents,
     PROJECT_EXTRA_TOOLS,
-    parseAskInputsResponsePayload,
+    parseChatMessages,
+    parseOptionalAskInputsResponse,
+    parseOptionalAttachedDocuments,
+    parseOptionalChatId,
+    parseOptionalDisplayedDoc,
+    parseOptionalModel,
     type ChatMessage,
 } from "../lib/chat";
 import {
@@ -41,25 +46,49 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
     const userId = res.locals.userId as string;
     const userEmail = res.locals.userEmail as string | undefined;
     const { projectId } = req.params;
-    const {
-        messages,
-        chat_id,
-        model,
-        displayed_doc,
-        attached_documents,
-        ask_inputs_response,
-    } =
-        req.body as {
-            messages: ChatMessage[];
-            chat_id?: string;
-            model?: string;
-            displayed_doc?: { filename: string; document_id: string };
-            attached_documents?: { filename: string; document_id: string }[];
-            ask_inputs_response?: unknown;
-        };
-    const askInputsResponse = parseAskInputsResponsePayload(
-        ask_inputs_response,
+    const body =
+        req.body && typeof req.body === "object" && !Array.isArray(req.body)
+            ? (req.body as Record<string, unknown>)
+            : {};
+    const parsedMessages = parseChatMessages(body.messages);
+    if (!parsedMessages.ok) {
+        return void res.status(400).json({ detail: parsedMessages.detail });
+    }
+    const parsedChatId = parseOptionalChatId(body.chat_id);
+    if (!parsedChatId.ok) {
+        return void res.status(400).json({ detail: parsedChatId.detail });
+    }
+    const parsedModel = parseOptionalModel(body.model);
+    if (!parsedModel.ok) {
+        return void res.status(400).json({ detail: parsedModel.detail });
+    }
+    const parsedDisplayedDoc = parseOptionalDisplayedDoc(body.displayed_doc);
+    if (!parsedDisplayedDoc.ok) {
+        return void res.status(400).json({ detail: parsedDisplayedDoc.detail });
+    }
+    const parsedAttachedDocuments = parseOptionalAttachedDocuments(
+        body.attached_documents,
     );
+    if (!parsedAttachedDocuments.ok) {
+        return void res
+            .status(400)
+            .json({ detail: parsedAttachedDocuments.detail });
+    }
+    const parsedAskInputsResponse = parseOptionalAskInputsResponse(
+        body.ask_inputs_response,
+    );
+    if (!parsedAskInputsResponse.ok) {
+        return void res
+            .status(400)
+            .json({ detail: parsedAskInputsResponse.detail });
+    }
+
+    const messages = parsedMessages.value;
+    const chat_id = parsedChatId.value;
+    const model = parsedModel.value;
+    const displayed_doc = parsedDisplayedDoc.value;
+    const attached_documents = parsedAttachedDocuments.value;
+    const askInputsResponse = parsedAskInputsResponse.value;
 
     const db = createServerSupabase();
 


### PR DESCRIPTION
## Summary

Validate project-chat request payloads at runtime before database, document-context, or LLM work. The shared parsers also keep `/chat` and project chat from drifting apart.

Closes #278. Supersedes the stale implementation in #155.

## Why / Motivation

`POST /projects/:projectId/chat` previously trusted a TypeScript assertion. Malformed values could create a chat and reach downstream document and model work before failing.

## Changes

- Add shared parsers for messages, chat and project IDs, model, displayed and attached documents, and `ask_inputs_response`.
- Restrict message roles to `user` and `assistant`, normalize accepted strings, and return field-specific `400` details.
- Validate both chat routes before side effects while preserving canonical filename lookup and spotlighting.
- Add parser tests and route integration tests that assert malformed project-chat requests do not reach database, document-context, or LLM seams.

## Tradeoffs & risks

- `/chat` now applies the same strict role and nested-payload validation as project chat; malformed payloads that were previously tolerated return `400`.
- Open PRs #156, #170, #221, #260, #267, #268, and #271 touch one or both route files for separate downstream behavior, so this branch may need a rebase if one lands first.
- This is request-shape validation only; it does not change authorization or model selection.

## How verified

- `npm test --prefix backend -- --run src/lib/chat/__tests__/requestValidation.test.ts src/__tests__/integration/chat.routes.test.ts src/__tests__/integration/projectChat.routes.test.ts` - 46 passed.
- `npm test --prefix backend` - 462 passed, 14 skipped.
- `npm run build --prefix backend`
- A baseline regression test confirmed malformed `messages` crossed database, document-context, and LLM seams on current `main`; the candidate route tests verify rejection before those seams.

## Checklist

- [x] Ran the relevant build/test command for the area changed.
- [x] Reviewed `git diff` and removed unrelated changes.
- [x] No documentation or environment example updates are needed for this request-validation fix.
- [x] No secrets, API keys, real documents, or `.env` files committed.
