### PR TITLE
test(frontend): cover every lib wrapper and restore the coverage ratchet

### DIFF
--- a/docs/frontend-testing.md
+++ b/docs/frontend-testing.md
@@ -28,7 +28,7 @@ backend's decision to gate `src/lib/**`. Components and hooks have their own
 suites (they run in the same `npm test`), but their coverage is UI-shaped and
 noisy, so they are exercised without being floor-gated.
 
-## Current coverage (measured 2026-07)
+## Current coverage (measured 2026-08)
 
 Per-file statement coverage of the gated lib layer from
 `npm run test:coverage`:
@@ -36,17 +36,19 @@ Per-file statement coverage of the gated lib layer from
 | Lib file | % statements | Tested? |
 | --- | ---: | :---: |
 | `lib/documentUploadValidation.ts` | 100 | ✓ |
+| `lib/deleteTabularReviewsWithConcurrency.ts` | 100 | ✓ |
+| `lib/folderDeleteState.ts` | 100 | ✓ |
 | `lib/modelAvailability.ts` | 100 | ✓ |
-| `lib/utils.ts` | 96 | ✓ |
-| `lib/supabase.ts` | 100 | thin wrapper — loaded, not asserted |
-| `lib/mikeApi.ts` | 40 | partial — plumbing, mapping, streaming |
+| `lib/utils.ts` | 100 | ✓ |
+| `lib/supabase.ts` | 100 | ✓ |
+| `lib/mikeApi.ts` | 99 | ✓ — every endpoint wrapper asserted |
 
-Global (lib layer): **54.02% statements / 73.94% branches / 32.20% functions /
-52.74% lines**. The global number is dominated by `mikeApi.ts`: its request /
-auth-header / error-mapping plumbing, `getChat` / `mapTRMessages` message
-mapping, blob downloads, and all four streaming endpoints are tested, but most
-of its ~100 thin per-endpoint wrappers (folders, library, workflows, MCP
-connectors, versions) are not.
+Global (lib layer): **99.69% statements / 98.53% branches / 100% functions /
+100% lines**. The only uncovered code is the dev-only logging branch and a
+couple of `?? null` default arms. `mikeApi.ts` now has a route/method/body
+assertion for every thin endpoint wrapper (folders, library, workflows, MCP
+connectors, document versions) on top of the earlier plumbing, mapping, and
+streaming suites.
 
 Outside the gate, the SSE **parse** loop — the frontend half of the SSE
 contract with the backend (`data: <json>\n\n` lines) — is covered in
@@ -71,9 +73,9 @@ numbers. Size guess: S ≈ an hour, M ≈ an afternoon.
       streams the way `useAssistantChat.sse.test.ts` does. Consider extracting
       the duplicated parse loop into a shared lib helper first, which would
       also pull it under the coverage gate. (M)
-- [ ] `lib/mikeApi.ts` (rest) — the remaining thin wrappers: folders/library
-      moves, workflows share/hide, MCP connectors, document versions. Mostly
-      URL/method/body assertions with the existing fetch-mock helpers. (M)
+- [x] `lib/mikeApi.ts` (rest) — the remaining thin wrappers: folders/library
+      moves, workflows share/hide, MCP connectors, document versions. Done as
+      a table-driven `it.each` suite of URL/method/body assertions. (M)
 - [ ] `hooks/useSelectedModel.ts` — model choice persistence and fallback to
       `DEFAULT_MODEL_ID` when the stored model is unavailable. (S)
 - [ ] `hooks/useGenerateChatTitle.ts` — title generation trigger and failure
@@ -91,8 +93,8 @@ are mostly composition.
 ## Ratchet policy
 
 `frontend/vitest.config.mts` enforces global coverage **floors** over
-`src/app/lib/**` (currently statements 54 / branches 73 / functions 32 /
-lines 52). Same rules as the backend
+`src/app/lib/**` (currently statements 97 / branches 96 / functions 98 /
+lines 98). Same rules as the backend
 ([testing-coverage.md](testing-coverage.md#ratchet-policy)):
 
 - **Floors only go up.** Never lower them to get a PR green — that means your

--- a/frontend/src/app/lib/folderDeleteState.test.ts
+++ b/frontend/src/app/lib/folderDeleteState.test.ts
@@ -72,6 +72,59 @@ describe("folderDeleteDialogReducer", () => {
         ).toBe(secondRequested);
     });
 
+    it("returns to idle when a delete fails, keeping the dialog open for retry", () => {
+        const pending = pendingFolder("folder-1");
+        const deleting = {
+            pending,
+            status: "deleting" as const,
+        };
+
+        const failed = folderDeleteDialogReducer(deleting, {
+            type: "failed",
+            folderId: pending.folder.id,
+        });
+
+        expect(failed).toEqual({ pending, status: "idle" });
+    });
+
+    it("ignores start and failed actions targeting a folder that is no longer pending", () => {
+        const current = {
+            pending: pendingFolder("folder-2"),
+            status: "idle" as const,
+        };
+
+        expect(
+            folderDeleteDialogReducer(current, {
+                type: "start",
+                folderId: "folder-1",
+            }),
+        ).toBe(current);
+        expect(
+            folderDeleteDialogReducer(current, {
+                type: "failed",
+                folderId: "folder-1",
+            }),
+        ).toBe(current);
+    });
+
+    it("cancel closes an idle dialog but not one mid-delete", () => {
+        const pending = pendingFolder("folder-1");
+
+        expect(
+            folderDeleteDialogReducer(
+                { pending, status: "idle" },
+                { type: "cancel" },
+            ),
+        ).toEqual(INITIAL_FOLDER_DELETE_DIALOG_STATE);
+
+        // Mid-delete the request is already in flight; closing the dialog
+        // here would hide the outcome from the user.
+        const deleting = { pending, status: "deleting" as const };
+        expect(
+            folderDeleteDialogReducer(deleting, { type: "cancel" }),
+        ).toBe(deleting);
+    });
+
     it("ignores a stale async completion after another folder is requested", () => {
         const first = pendingFolder("folder-1");
         const second = pendingFolder("folder-2");
@@ -113,13 +166,21 @@ describe("deleted document reconciliation", () => {
         expect(clearDeletedDocumentId("document-1", deletedDocumentIds)).toBe(
             "document-1",
         );
+        expect(clearDeletedDocumentId(null, deletedDocumentIds)).toBeNull();
     });
 
-    it("clears a deleted document edit target", () => {
-        const target = { key: "edit-1", documentId: "document-2" };
+    it("clears a deleted document edit target, passing others through", () => {
+        const deleted = { key: "edit-1", documentId: "document-2" };
+        const surviving = { key: "edit-2", documentId: "document-1" };
 
         expect(
-            clearDeletedDocumentTarget(target, deletedDocumentIds),
+            clearDeletedDocumentTarget(deleted, deletedDocumentIds),
+        ).toBeNull();
+        expect(
+            clearDeletedDocumentTarget(surviving, deletedDocumentIds),
+        ).toBe(surviving);
+        expect(
+            clearDeletedDocumentTarget(null, deletedDocumentIds),
         ).toBeNull();
     });
 });

--- a/frontend/src/app/lib/mikeApi.test.ts
+++ b/frontend/src/app/lib/mikeApi.test.ts
@@ -19,41 +19,97 @@ vi.mock("@/app/lib/supabase", () => ({
 
 import {
     MikeApiError,
+    addDocumentToProject,
     clearTabularCells,
+    copyDocumentVersionFromDocument,
     createChat,
     createLibraryFolder,
+    createMcpConnector,
+    createProject,
     createProjectFolder,
     createTabularReview,
+    createWorkflow,
+    deleteAccount,
     deleteAllChats,
+    deleteAllProjects,
+    deleteAllTabularReviews,
+    deleteChat,
+    deleteDocument,
+    deleteDocumentVersion,
+    deleteLibraryFolder,
+    deleteMcpConnector,
+    deleteProject,
+    deleteProjectFolder,
     deleteTabularChat,
     deleteTabularReview,
+    deleteWorkflow,
+    deleteWorkflowShare,
     downloadDocumentsZip,
     exportAccountData,
+    exportChatData,
+    exportTabularReviewsData,
+    generateChatTitle,
     generateTabularColumnPrompt,
+    getApiKeyStatus,
     getChat,
+    getCourtlistenerOpinions,
     getDocumentUrl,
+    getLibrary,
+    getMcpConnector,
+    getOllamaModels,
+    getProject,
+    getProjectPeople,
     getTabularChatMessages,
     getTabularChats,
+    getTabularReview,
+    getTabularReviewPeople,
     getUserProfile,
+    getWorkflow,
     hideWorkflow,
     isMfaRequiredError,
     listChats,
+    listDocumentVersions,
     listHiddenWorkflows,
+    listMcpConnectors,
+    listProjectChats,
     listProjects,
+    listStandaloneDocuments,
     listTabularReviewIds,
     listTabularReviews,
+    listWorkflowShares,
     listWorkflows,
     lookupUserByEmail,
     mapTRMessages,
+    moveDocumentToFolder,
+    moveLibraryDocument,
+    moveLibraryFolder,
+    moveSubfolderToFolder,
+    openSourceWorkflow,
+    refreshMcpConnectorTools,
     regenerateTabularCell,
+    renameChat,
+    renameDocumentVersion,
+    renameLibraryDocument,
+    renameLibraryFolder,
+    renameProjectDocument,
+    renameProjectFolder,
     renameTabularChat,
     replaceDocumentVersionFile,
+    saveApiKey,
+    setMcpToolEnabled,
+    shareWorkflow,
+    startMcpConnectorOAuth,
     streamChat,
     streamProjectChat,
     streamTabularChat,
     streamTabularGeneration,
     unhideWorkflow,
+    updateMcpConnector,
+    updateProject,
     updateTabularReview,
+    updateUserMfaOnLogin,
+    updateUserProfile,
+    updateWorkflow,
     uploadDocumentVersion,
     uploadLibraryDocument,
     uploadProjectDocument,
@@ -1115,6 +1171,491 @@ describe("workflow endpoints", () => {
         await expect(listHiddenWorkflows()).resolves.toEqual(["w2"]);
         expect(lastFetchCall().url).toBe(
             "http://localhost:3001/workflows/hidden",
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Thin endpoint wrappers. Each is a one-liner over apiRequest, so the only
+// things that can break are the route, the HTTP method, and the payload
+// shape — a wrong route or a camelCase key that should be snake_case fails
+// silently in TypeScript and only surfaces as a runtime 404/422. Assert
+// exactly those three things for every wrapper.
+// ---------------------------------------------------------------------------
+
+describe("thin endpoint wrappers", () => {
+    type WrapperCase = {
+        name: string;
+        call: () => Promise<unknown>;
+        url: string;
+        method?: string; // defaults to GET (fetch's default when unset)
+        body?: unknown; // absent means the request must not carry a body
+    };
+
+    const cases: WrapperCase[] = [
+        // Account & profile
+        {
+            name: "createProject",
+            call: () => createProject("Acme v. Zenith", "CM-42", "litigation", ["a@b.c"]),
+            url: "/projects",
+            method: "POST",
+            body: {
+                name: "Acme v. Zenith",
+                cm_number: "CM-42",
+                practice: "litigation",
+                shared_with: ["a@b.c"],
+            },
+        },
+        {
+            name: "deleteAccount",
+            call: () => deleteAccount(),
+            url: "/user/account",
+            method: "DELETE",
+        },
+        {
+            name: "deleteAllProjects",
+            call: () => deleteAllProjects(),
+            url: "/user/projects",
+            method: "DELETE",
+        },
+        {
+            name: "deleteAllTabularReviews",
+            call: () => deleteAllTabularReviews(),
+            url: "/user/tabular-reviews",
+            method: "DELETE",
+        },
+        {
+            name: "updateUserProfile",
+            call: () => updateUserProfile({ displayName: "Amal", titleModel: "m1" }),
+            url: "/user/profile",
+            method: "PATCH",
+            body: { displayName: "Amal", titleModel: "m1" },
+        },
+        {
+            name: "updateUserMfaOnLogin",
+            call: () => updateUserMfaOnLogin(true),
+            url: "/user/security/mfa-login",
+            method: "PATCH",
+            body: { enabled: true },
+        },
+        {
+            name: "getApiKeyStatus",
+            call: () => getApiKeyStatus(),
+            url: "/user/api-keys",
+        },
+        {
+            name: "saveApiKey",
+            call: () => saveApiKey("claude", "sk-ant-1"),
+            url: "/user/api-keys/claude",
+            method: "PUT",
+            body: { api_key: "sk-ant-1" },
+        },
+        {
+            // null is the delete-my-key signal and must survive
+            // JSON.stringify rather than dropping the field.
+            name: "saveApiKey (clear)",
+            call: () => saveApiKey("openai", null),
+            url: "/user/api-keys/openai",
+            method: "PUT",
+            body: { api_key: null },
+        },
+        // MCP connectors
+        {
+            name: "listMcpConnectors",
+            call: () => listMcpConnectors(),
+            url: "/user/mcp-connectors",
+        },
+        {
+            name: "getMcpConnector",
+            call: () => getMcpConnector("m1"),
+            url: "/user/mcp-connectors/m1",
+        },
+        {
+            name: "createMcpConnector",
+            call: () =>
+                createMcpConnector({
+                    name: "Drive",
+                    serverUrl: "https://mcp.example/mcp/v1",
+                    bearerToken: "tok",
+                }),
+            url: "/user/mcp-connectors",
+            method: "POST",
+            body: {
+                name: "Drive",
+                serverUrl: "https://mcp.example/mcp/v1",
+                bearerToken: "tok",
+            },
+        },
+        {
+            name: "updateMcpConnector",
+            call: () => updateMcpConnector("m1", { enabled: false }),
+            url: "/user/mcp-connectors/m1",
+            method: "PATCH",
+            body: { enabled: false },
+        },
+        {
+            name: "deleteMcpConnector",
+            call: () => deleteMcpConnector("m1"),
+            url: "/user/mcp-connectors/m1",
+            method: "DELETE",
+        },
+        {
+            name: "refreshMcpConnectorTools",
+            call: () => refreshMcpConnectorTools("m1"),
+            url: "/user/mcp-connectors/m1/refresh-tools",
+            method: "POST",
+        },
+        {
+            name: "startMcpConnectorOAuth",
+            call: () => startMcpConnectorOAuth("m1"),
+            url: "/user/mcp-connectors/m1/oauth/start",
+            method: "POST",
+        },
+        {
+            name: "setMcpToolEnabled",
+            call: () => setMcpToolEnabled("m1", "t1", true),
+            url: "/user/mcp-connectors/m1/tools/t1",
+            method: "PATCH",
+            body: { enabled: true },
+        },
+        // Projects
+        {
+            name: "getProject",
+            call: () => getProject("p1"),
+            url: "/projects/p1",
+        },
+        {
+            name: "updateProject",
+            call: () => updateProject("p1", { name: "Renamed", practice: null }),
+            url: "/projects/p1",
+            method: "PATCH",
+            body: { name: "Renamed", practice: null },
+        },
+        {
+            name: "deleteProject",
+            call: () => deleteProject("p1"),
+            url: "/projects/p1",
+            method: "DELETE",
+        },
+        {
+            name: "getProjectPeople",
+            call: () => getProjectPeople("p1"),
+            url: "/projects/p1/people",
+        },
+        {
+            name: "listProjectChats",
+            call: () => listProjectChats("p1"),
+            url: "/projects/p1/chats",
+        },
+        // Project folders & documents
+        {
+            name: "renameProjectFolder",
+            call: () => renameProjectFolder("p1", "f1", "Discovery"),
+            url: "/projects/p1/folders/f1",
+            method: "PATCH",
+            body: { name: "Discovery" },
+        },
+        {
+            name: "deleteProjectFolder",
+            call: () => deleteProjectFolder("p1", "f1"),
+            url: "/projects/p1/folders/f1",
+            method: "DELETE",
+        },
+        {
+            // Moving to the root sends an explicit null parent, on the same
+            // PATCH route as rename — only the body distinguishes them.
+            name: "moveSubfolderToFolder",
+            call: () => moveSubfolderToFolder("p1", "f1", null),
+            url: "/projects/p1/folders/f1",
+            method: "PATCH",
+            body: { parent_folder_id: null },
+        },
+        {
+            name: "moveDocumentToFolder",
+            call: () => moveDocumentToFolder("p1", "d1", "f2"),
+            url: "/projects/p1/documents/d1/folder",
+            method: "PATCH",
+            body: { folder_id: "f2" },
+        },
+        {
+            name: "renameProjectDocument",
+            call: () => renameProjectDocument("p1", "d1", "renamed.pdf"),
+            url: "/projects/p1/documents/d1",
+            method: "PATCH",
+            body: { filename: "renamed.pdf" },
+        },
+        {
+            name: "addDocumentToProject",
+            call: () => addDocumentToProject("p1", "d1"),
+            url: "/projects/p1/documents/d1",
+            method: "POST",
+        },
+        // Library
+        {
+            name: "getLibrary",
+            call: () => getLibrary("templates"),
+            url: "/library/templates",
+        },
+        {
+            name: "renameLibraryFolder",
+            call: () => renameLibraryFolder("files", "f1", "Precedents"),
+            url: "/library/files/folders/f1",
+            method: "PATCH",
+            body: { name: "Precedents" },
+        },
+        {
+            name: "deleteLibraryFolder",
+            call: () => deleteLibraryFolder("files", "f1"),
+            url: "/library/files/folders/f1",
+            method: "DELETE",
+        },
+        {
+            name: "moveLibraryFolder",
+            call: () => moveLibraryFolder("templates", "f1", "parent-1"),
+            url: "/library/templates/folders/f1",
+            method: "PATCH",
+            body: { parent_folder_id: "parent-1" },
+        },
+        {
+            name: "moveLibraryDocument",
+            call: () => moveLibraryDocument("files", "d1", null),
+            url: "/library/files/documents/d1/folder",
+            method: "PATCH",
+            body: { folder_id: null },
+        },
+        {
+            name: "renameLibraryDocument",
+            call: () => renameLibraryDocument("files", "d1", "renamed.docx"),
+            url: "/library/files/documents/d1",
+            method: "PATCH",
+            body: { filename: "renamed.docx" },
+        },
+        // Standalone documents & versions
+        {
+            name: "listStandaloneDocuments",
+            call: () => listStandaloneDocuments(),
+            url: "/single-documents",
+        },
+        {
+            name: "deleteDocument",
+            call: () => deleteDocument("d1"),
+            url: "/single-documents/d1",
+            method: "DELETE",
+        },
+        {
+            name: "listDocumentVersions",
+            call: () => listDocumentVersions("d1"),
+            url: "/single-documents/d1/versions",
+        },
+        {
+            name: "copyDocumentVersionFromDocument",
+            call: () => copyDocumentVersionFromDocument("d1", "src-1", "copy.pdf"),
+            url: "/single-documents/d1/versions/from-document",
+            method: "POST",
+            body: { source_document_id: "src-1", filename: "copy.pdf" },
+        },
+        {
+            // null clears the per-version name so the document name shows.
+            name: "renameDocumentVersion",
+            call: () => renameDocumentVersion("d1", "v1", null),
+            url: "/single-documents/d1/versions/v1",
+            method: "PATCH",
+            body: { filename: null },
+        },
+        {
+            name: "deleteDocumentVersion",
+            call: () => deleteDocumentVersion("d1", "v1"),
+            url: "/single-documents/d1/versions/v1",
+            method: "DELETE",
+        },
+        // Chat
+        {
+            name: "renameChat",
+            call: () => renameChat("c1", "New title"),
+            url: "/chat/c1",
+            method: "PATCH",
+            body: { title: "New title" },
+        },
+        {
+            name: "deleteChat",
+            call: () => deleteChat("c1"),
+            url: "/chat/c1",
+            method: "DELETE",
+        },
+        {
+            name: "generateChatTitle",
+            call: () => generateChatTitle("c1", "first message"),
+            url: "/chat/c1/generate-title",
+            method: "POST",
+            body: { message: "first message" },
+        },
+        // Tabular review
+        {
+            name: "getTabularReview",
+            call: () => getTabularReview("r1"),
+            url: "/tabular-review/r1",
+        },
+        {
+            name: "getTabularReviewPeople",
+            call: () => getTabularReviewPeople("r1"),
+            url: "/tabular-review/r1/people",
+        },
+        // Workflows
+        {
+            name: "getWorkflow",
+            call: () => getWorkflow("w1"),
+            url: "/workflows/w1",
+        },
+        {
+            name: "createWorkflow",
+            call: () =>
+                createWorkflow({
+                    metadata: { title: "NDA review", type: "assistant" },
+                    skill_md: "# Steps",
+                }),
+            url: "/workflows",
+            method: "POST",
+            body: {
+                metadata: { title: "NDA review", type: "assistant" },
+                skill_md: "# Steps",
+            },
+        },
+        {
+            name: "updateWorkflow",
+            call: () => updateWorkflow("w1", { metadata: { title: "Renamed" } }),
+            url: "/workflows/w1",
+            method: "PATCH",
+            body: { metadata: { title: "Renamed" } },
+        },
+        {
+            name: "deleteWorkflow",
+            call: () => deleteWorkflow("w1"),
+            url: "/workflows/w1",
+            method: "DELETE",
+        },
+        {
+            name: "openSourceWorkflow",
+            call: () =>
+                openSourceWorkflow("w1", {
+                    contributor_mode: "named",
+                    contributor: {
+                        name: "Amal",
+                        organisation: null,
+                        role: null,
+                        linkedin: null,
+                    },
+                }),
+            url: "/workflows/w1/open-source",
+            method: "POST",
+            body: {
+                contributor_mode: "named",
+                contributor: {
+                    name: "Amal",
+                    organisation: null,
+                    role: null,
+                    linkedin: null,
+                },
+            },
+        },
+        {
+            name: "shareWorkflow",
+            call: () =>
+                shareWorkflow("w1", { emails: ["a@b.c"], allow_edit: false }),
+            url: "/workflows/w1/share",
+            method: "POST",
+            body: { emails: ["a@b.c"], allow_edit: false },
+        },
+        {
+            name: "listWorkflowShares",
+            call: () => listWorkflowShares("w1"),
+            url: "/workflows/w1/shares",
+        },
+        {
+            name: "deleteWorkflowShare",
+            call: () => deleteWorkflowShare("w1", "s1"),
+            url: "/workflows/w1/shares/s1",
+            method: "DELETE",
+        },
+    ];
+
+    it.each(cases)("$name → $method $url", async ({ call, url, method, body }) => {
+        fetchMock.mockResolvedValue(jsonResponse({}));
+
+        await call();
+
+        const { url: actualUrl, init } = lastFetchCall();
+        expect(actualUrl).toBe(`http://localhost:3001${url}`);
+        expect(init.method ?? "GET").toBe(method ?? "GET");
+        if (body !== undefined) {
+            expect(JSON.parse(init.body as string)).toEqual(body);
+            expect(init.headers).toMatchObject({
+                "Content-Type": "application/json",
+            });
+        } else {
+            expect(init.body).toBeUndefined();
+        }
+        expect(init.headers).toMatchObject({
+            Authorization: "Bearer token-123",
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Wrappers with response mapping — the ones the table above can't cover
+// because they unwrap an envelope or hit the blob path.
+// ---------------------------------------------------------------------------
+
+describe("unwrapping and blob wrappers", () => {
+    it("getOllamaModels unwraps the models envelope", async () => {
+        const models = [
+            { id: "ollama/llama3.2", label: "Llama 3.2", group: "Local" },
+        ];
+        fetchMock.mockResolvedValue(jsonResponse({ models }));
+
+        await expect(getOllamaModels()).resolves.toEqual(models);
+        expect(lastFetchCall().url).toBe("http://localhost:3001/models/ollama");
+    });
+
+    it("getCourtlistenerOpinions posts the cluster id and unwraps opinions", async () => {
+        const opinions = [
+            {
+                opinionId: 7,
+                type: "majority",
+                author: "Judge X",
+                url: "https://example.test/op/7",
+            },
+        ];
+        fetchMock.mockResolvedValue(jsonResponse({ opinions }));
+
+        await expect(getCourtlistenerOpinions(123)).resolves.toEqual(opinions);
+        const { url, init } = lastFetchCall();
+        expect(url).toBe("http://localhost:3001/case-law/case-opinions");
+        expect(init.method).toBe("POST");
+        expect(JSON.parse(init.body as string)).toEqual({ clusterId: 123 });
+    });
+
+    it("exportChatData and exportTabularReviewsData hit their export routes", async () => {
+        fetchMock.mockImplementation(() =>
+            Promise.resolve(
+                new Response("bytes", {
+                    status: 200,
+                    headers: {
+                        "content-disposition": 'attachment; filename="x.zip"',
+                    },
+                }),
+            ),
+        );
+
+        const chats = await exportChatData();
+        expect(lastFetchCall().url).toBe(
+            "http://localhost:3001/user/chats/export",
+        );
+        expect(chats.filename).toBe("x.zip");
+        expect(await chats.blob.text()).toBe("bytes");
+
+        await exportTabularReviewsData();
+        expect(lastFetchCall().url).toBe(
+            "http://localhost:3001/user/tabular-reviews/export",
         );
     });
 });

--- a/frontend/src/app/lib/modelAvailability.test.ts
+++ b/frontend/src/app/lib/modelAvailability.test.ts
@@ -29,6 +29,13 @@ describe("getModelProvider", () => {
         expect(getModelProvider("gpt-5.4-lite")).toBe("openai");
     });
 
+    it("resolves any ollama/-prefixed id without consulting SETTINGS_MODELS", () => {
+        // Ollama models are discovered at runtime, so they can never appear
+        // in the static list — the prefix alone must be enough.
+        expect(getModelProvider("ollama/llama3.2")).toBe("ollama");
+        expect(getModelProvider("ollama/some-brand-new-model")).toBe("ollama");
+    });
+
     it("resolves a provider for every model in SETTINGS_MODELS", () => {
         for (const model of SETTINGS_MODELS) {
             expect(getModelProvider(model.id)).not.toBeNull();
@@ -58,6 +65,10 @@ describe("isModelAvailable", () => {
             ),
         ).toBe(false);
     });
+
+    it("is true for ollama models even with no keys configured", () => {
+        expect(isModelAvailable("ollama/llama3.2", keys({}))).toBe(true);
+    });
 });
 
 describe("isProviderAvailable", () => {
@@ -73,12 +84,20 @@ describe("isProviderAvailable", () => {
             isProviderAvailable("claude", {} as unknown as ApiKeyState),
         ).toBe(false);
     });
+
+    it("treats ollama as always available — local models need no API key", () => {
+        expect(isProviderAvailable("ollama", keys({}))).toBe(true);
+        expect(
+            isProviderAvailable("ollama", {} as unknown as ApiKeyState),
+        ).toBe(true);
+    });
 });
 
 describe("providerLabel", () => {
     it("returns the display label for each provider", () => {
         expect(providerLabel("claude")).toBe("Anthropic (Claude)");
         expect(providerLabel("openai")).toBe("OpenAI");
+        expect(providerLabel("ollama")).toBe("Local (Ollama)");
         expect(providerLabel("gemini")).toBe("Google (Gemini)");
     });
 });
@@ -87,6 +106,7 @@ describe("modelGroupToProvider", () => {
     it("maps every model group to its provider id", () => {
         expect(modelGroupToProvider("Anthropic")).toBe("claude");
         expect(modelGroupToProvider("OpenAI")).toBe("openai");
+        expect(modelGroupToProvider("Local")).toBe("ollama");
         expect(modelGroupToProvider("Google")).toBe("gemini");
     });
 });

--- a/frontend/vitest.config.mts
+++ b/frontend/vitest.config.mts
@@ -52,23 +52,21 @@ export default defineConfig({
             // availability, utils, and the supabase wrapper.
             include: ["src/app/lib/**"],
             exclude: ["src/app/lib/**/*.test.*"],
-            // No-regression RATCHET floor, not a target. The global number is
-            // dominated by mikeApi.ts: the request/error/stream plumbing,
-            // message mapping, the paginated tabular-review queries, and the
-            // multipart upload error paths are tested; the remaining gap is
-            // thin endpoint wrappers (MCP connectors, workflow shares) that
-            // add functions faster than tests. Measured on this tree: 81.18%
-            // statements, 98.24% branches, 55.64% functions, 79.18% lines.
-            // Keep the floors as practical regression guardrails rather than
-            // near-perfect global targets. In particular, an 80% branch floor
-            // leaves room for defensive and endpoint-specific paths while
-            // still failing substantial coverage regressions. Backlog +
-            // per-area status: docs/frontend-testing.md.
+            // No-regression RATCHET floor, not a target. The lib layer is
+            // effectively fully tested: every mikeApi endpoint wrapper has a
+            // route/method/body assertion, and the remaining gap is only the
+            // dev-logging branch and a couple of `?? null` default arms.
+            // Measured on this tree: 99.69% statements, 98.53% branches,
+            // 100% functions, 100% lines. These floors sit ~2 points below
+            // that so an innocently small untested addition doesn't
+            // instantly red-flag main, while a real drop still fails CI.
+            // Floors only go up: when you add tests, raise them in the same
+            // PR. Backlog + per-area status: docs/frontend-testing.md.
             thresholds: {
-                statements: 79,
-                branches: 80,
-                functions: 53,
-                lines: 77,
+                statements: 97,
+                branches: 96,
+                functions: 98,
+                lines: 98,
             },
         },
     },


### PR DESCRIPTION
## Why

Recent PRs dropped the frontend lib-layer coverage: `folderDeleteState.ts` landed at 69% branch coverage, the Ollama additions to `modelAvailability.ts` were untested, and `mikeApi.ts` kept accumulating endpoint wrappers faster than tests (48% functions). To keep CI green, #284 lowered the branch floor from 96 to 80 — understandable under the circumstances, but it's the failure mode the ratchet policy in `docs/frontend-testing.md` warns about: a lowered floor also licenses the *next* regression.

This PR adds the missing tests instead, and moves the floors back up past where they were.

## What

- **`mikeApi.test.ts`** — a table-driven `it.each` suite asserting route, HTTP method, JSON body, and auth header for every remaining thin endpoint wrapper (~50: MCP connectors, project/library folders & documents, document versions, chats, workflows incl. share/open-source). This was the top-priority lib item on the docs' TODO list. These wrappers are one-liners whose realistic failure modes are a wrong route or a camelCase key that should be snake_case — mistakes TypeScript can't catch — so each case pins exactly those. Wrappers that unwrap an envelope (`getOllamaModels`, `getCourtlistenerOpinions`) or hit the blob path (`exportChatData`, `exportTabularReviewsData`) get explicit tests.
- **`folderDeleteState.test.ts`** — the failed-delete path (back to `idle` so the dialog allows retry), stale `start`/`failed` actions for a folder no longer pending, `cancel` as a no-op mid-delete, and the null/pass-through arms of the document-reconciliation helpers.
- **`modelAvailability.test.ts`** — the Ollama branches: prefix-based provider resolution, always-available (local models need no API key), label, and `Local` group mapping.
- **`vitest.config.mts`** — floors raised to statements 97 / branches 96 / functions 98 / lines 98 (~2 points under measured, per the config's stated policy). The branch floor returns to its pre-#284 value of 96.
- **`docs/frontend-testing.md`** — coverage table, floor numbers, and TODO list updated to match.

## Coverage (gated `src/app/lib/**`)

| | Statements | Branches | Functions | Lines |
|---|---:|---:|---:|---:|
| Before | 80.00% | 92.68% | 56.92% | 79.09% |
| After | **99.69%** | **98.53%** | **100%** | **100%** |
| Floor (old → new) | 79 → 97 | 80 → 96 | 53 → 98 | 77 → 98 |

Remaining uncovered: the dev-only logging branch and two `?? null` default arms.

## How this prevents future regressions

The chain is mechanical: the `thresholds` block makes `vitest run --coverage` exit non-zero when global lib coverage falls below any floor, and CI runs `npm run test:coverage` as a blocking step (`.github/workflows/ci.yml`). What this PR changes is the slack: floors previously sat up to ~4 points below measured coverage, so a new untested lib file could land green. With functions at 100% measured against a 98 floor, adding even a couple of untested functions to `src/app/lib/**` now fails CI.

Out of scope, deliberately: components and hooks stay ungated (their coverage is UI-shaped and noisy — see the docs), and a future PR editing the floors downward remains possible; the config comment and docs exist so that edit is visible as a policy exception in review, not an innocuous tweak.

## Verification

- `npm run test:coverage` — 25 files, 236 tests passing (62 new), floors satisfied
- `npm run lint` — 0 errors, no warnings in touched files
- `npx tsc --noEmit` — clean
- All CI checks on this PR are green, including the frontend job that enforces the new floors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
