### PR TITLE
add raw File bytes streaming to API

### DIFF
--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -174,6 +174,45 @@ documentsRouter.get("/:documentId/display", requireAuth, async (req, res) => {
   }
 });
 
+// GET /single-documents/:documentId/file
+// Streams active-version source bytes for browser editors. Unlike /display,
+// this never substitutes a generated PDF rendition for an Office document.
+documentsRouter.get("/:documentId/file", requireAuth, async (req, res) => {
+  const userId = res.locals.userId as string;
+  const userEmail = res.locals.userEmail as string | undefined;
+  const { documentId } = req.params;
+  const versionIdParam =
+    typeof req.query.version_id === "string" ? req.query.version_id : null;
+  const db = createServerSupabase();
+
+  const { data: doc } = await db
+    .from("documents")
+    .select("id, user_id, project_id")
+    .eq("id", documentId)
+    .single();
+  if (!doc)
+    return void res.status(404).json({ detail: "Document not found" });
+  const access = await ensureDocAccess(doc, userId, userEmail, db);
+  if (!access.ok)
+    return void res.status(404).json({ detail: "Document not found" });
+
+  const active = await loadActiveVersion(documentId, db, versionIdParam);
+  if (!active)
+    return void res.status(404).json({ detail: "No file available" });
+  const raw = await downloadFile(active.storage_path);
+  if (!raw)
+    return void res.status(404).json({ detail: "Document bytes not available" });
+
+  const filename = downloadFilenameForVersion(
+    active.filename,
+    active.version_number,
+    active.source === "assistant_edit",
+  );
+  res.setHeader("Content-Type", contentTypeForDocumentType(active.file_type));
+  res.setHeader("Content-Disposition", buildContentDisposition("inline", filename));
+  res.send(Buffer.from(raw));
+});
+
 // POST /single-documents/download-zip
 documentsRouter.post("/download-zip", requireAuth, async (req, res) => {
   const userId = res.locals.userId as string;

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -840,6 +840,14 @@ export async function getDocumentUrl(
     return apiRequest(`/single-documents/${documentId}/url${qs}`);
 }
 
+export async function getDocumentFile(
+    documentId: string,
+    versionId?: string | null,
+): Promise<{ blob: Blob; filename: string | null }> {
+    const qs = versionId ? `?version_id=${encodeURIComponent(versionId)}` : "";
+    return apiBlobRequest(`/single-documents/${documentId}/file${qs}`);
+}
+
 export async function downloadDocumentsZip(
     documentIds: string[],
 ): Promise<Blob> {


### PR DESCRIPTION
## Summary

This adds raw File access to the backend API for serving raw bytes to the frontend without pre-rendering.

## Why / Motivation

This is in connection with enabling online file editing.

## Changes

<!-- The notable changes, at a high level. Describe the outcome, not the diff. -->

## Tradeoffs & risks

There shouldn't be any tradeoffs.

## How verified

We're building an integration which leverages the new API endpoints.

## Checklist

- [x] Ran the relevant build/test command for the area changed.
- [x] Reviewed `git diff` and removed unrelated changes.
- [N/A] Updated docs / env examples if setup, config, or behavior changed.
- [x] No secrets, API keys, real documents, or `.env` files committed.
