### PR TITLE
feat(llm): support a custom OpenAI-compatible endpoint

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,6 +18,14 @@ ANTHROPIC_API_KEY=your-anthropic-key
 OPENAI_API_KEY=your-openai-key
 USER_API_KEYS_ENCRYPTION_SECRET=your-long-random-secret
 
+# Optional: a remote OpenAI-compatible endpoint (a hosted gateway or proxy such
+# as LiteLLM, OpenRouter, Together, Azure OpenAI, or your own service). When
+# CUSTOM_OPENAI_BASE_URL is set, its models appear under a "Custom" group in the
+# model picker and are selectable as "custom/<model>".
+# CUSTOM_OPENAI_BASE_URL=https://your-gateway.example.com/v1
+# CUSTOM_OPENAI_API_KEY=your-endpoint-api-key
+# CUSTOM_OPENAI_MODEL=your-default-model
+
 # Optional: enables higher-rate CourtListener case law/citation lookup tools.
 COURTLISTENER_API_TOKEN=your-courtlistener-token
 

--- a/backend/src/lib/__tests__/llmModels.test.ts
+++ b/backend/src/lib/__tests__/llmModels.test.ts
@@ -50,6 +50,12 @@ describe("providerForModel", () => {
         expect(providerForModel("claude-nonexistent")).toBe("claude");
         expect(providerForModel("gpt-nonexistent")).toBe("openai");
     });
+
+    it("maps ollama and custom prefixes to their dynamic providers", () => {
+        expect(providerForModel("ollama/qwen3.6")).toBe("ollama");
+        expect(providerForModel("custom/gpt-4o-mini")).toBe("custom");
+        expect(providerForModel("custom")).toBe("custom");
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -69,6 +75,15 @@ describe("resolveModel", () => {
     it("falls back for unknown model ids", () => {
         expect(resolveModel("gpt-3.5-turbo", DEFAULT_MAIN_MODEL)).toBe(
             DEFAULT_MAIN_MODEL,
+        );
+    });
+
+    it("accepts dynamic ollama/* and custom/* endpoint models", () => {
+        expect(resolveModel("ollama/qwen3.6", DEFAULT_MAIN_MODEL)).toBe(
+            "ollama/qwen3.6",
+        );
+        expect(resolveModel("custom/my-model", DEFAULT_MAIN_MODEL)).toBe(
+            "custom/my-model",
         );
     });
 

--- a/backend/src/lib/llm/custom.ts
+++ b/backend/src/lib/llm/custom.ts
@@ -1,0 +1,219 @@
+// Custom provider — talks to any remote OpenAI-compatible /v1/chat/completions
+// endpoint (a hosted gateway or proxy such as LiteLLM, OpenRouter, Together,
+// Azure OpenAI, or your own OpenAI-compatible service). Configured per-instance:
+//   CUSTOM_OPENAI_BASE_URL  (e.g. https://your-gateway.example.com/v1) — required
+//   CUSTOM_OPENAI_API_KEY   (optional bearer token for the endpoint)
+//   CUSTOM_OPENAI_MODEL     (fallback model for a bare "custom" id)
+//
+// Model ids take the form "custom/<model>"; the tag after the slash is sent to
+// the endpoint verbatim (see providerForModel / resolveModel).
+import type {
+  StreamChatParams,
+  StreamChatResult,
+  NormalizedToolCall,
+  LlmMessage,
+} from "./types";
+
+export function customBaseUrl(): string {
+  return (process.env.CUSTOM_OPENAI_BASE_URL?.trim() || "").replace(/\/$/, "");
+}
+
+// Whether a custom endpoint is configured for this instance.
+export function customConfigured(): boolean {
+  return customBaseUrl().length > 0;
+}
+
+// Optional bearer auth — most hosted OpenAI-compatible endpoints require it.
+export function customAuthHeaders(): Record<string, string> {
+  const key = process.env.CUSTOM_OPENAI_API_KEY?.trim();
+  return key ? { Authorization: `Bearer ${key}` } : {};
+}
+
+function modelName(modelId: string): string {
+  // The id's tag (e.g. "custom/gpt-4o-mini" -> "gpt-4o-mini") wins; the
+  // CUSTOM_OPENAI_MODEL env is only a fallback for a bare "custom" id.
+  const tag = modelId.replace(/^custom\/?/, "");
+  return tag || process.env.CUSTOM_OPENAI_MODEL?.trim() || "";
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+  if (signal?.aborted) throw new Error("Request aborted");
+}
+
+// Chat-completions message shape (superset of LlmMessage with tool roles).
+type ChatMessage =
+  | { role: "system" | "user" | "assistant"; content: string }
+  | {
+      role: "assistant";
+      content: string;
+      tool_calls: {
+        id: string;
+        type: "function";
+        function: { name: string; arguments: string };
+      }[];
+    }
+  | { role: "tool"; tool_call_id: string; content: string };
+
+function initialMessages(systemPrompt: string, messages: LlmMessage[]): ChatMessage[] {
+  const out: ChatMessage[] = [];
+  if (systemPrompt.trim()) out.push({ role: "system", content: systemPrompt });
+  for (const m of messages) out.push({ role: m.role, content: m.content });
+  return out;
+}
+
+// Accumulates streamed tool-call deltas (id/name arrive once, arguments stream).
+type PartialToolCall = { id: string; name: string; arguments: string };
+
+async function postChat(
+  body: unknown,
+  signal: AbortSignal | undefined,
+): Promise<Response> {
+  const base = customBaseUrl();
+  if (!base) {
+    throw new Error(
+      "Custom endpoint is not configured. Set CUSTOM_OPENAI_BASE_URL.",
+    );
+  }
+  const response = await fetch(`${base}/chat/completions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...customAuthHeaders() },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `Custom endpoint request failed (${response.status}): ${text || response.statusText}`,
+    );
+  }
+  return response;
+}
+
+export async function streamCustom(
+  params: StreamChatParams,
+): Promise<StreamChatResult> {
+  const { model, systemPrompt, tools = [], callbacks = {}, runTools } = params;
+  const maxIter = params.maxIterations ?? 10;
+  const messages = initialMessages(systemPrompt, params.messages);
+  let fullText = "";
+  // Some models/endpoints reject the `tools` param. Drop it and carry on (the
+  // model just can't call tools) rather than failing the whole chat.
+  let useTools = tools.length > 0;
+
+  for (let iter = 0; iter < maxIter; iter++) {
+    throwIfAborted(params.abortSignal);
+    const sendBody = () => ({
+      model: modelName(model),
+      messages,
+      tools: useTools ? tools : undefined,
+      stream: true,
+    });
+    let response: Response;
+    try {
+      response = await postChat(sendBody(), params.abortSignal);
+    } catch (err) {
+      if (useTools && /does not support tools|tools.*not.*support/i.test(String((err as Error)?.message))) {
+        useTools = false;
+        response = await postChat(sendBody(), params.abortSignal);
+      } else {
+        throw err;
+      }
+    }
+    if (!response.body) throw new Error("Custom endpoint response had no body");
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    const partials = new Map<number, PartialToolCall>();
+    let assistantText = "";
+    let buffer = "";
+
+    while (true) {
+      throwIfAborted(params.abortSignal);
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      // SSE: events are newline-delimited "data: {json}" lines.
+      let nl: number;
+      while ((nl = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, nl).trim();
+        buffer = buffer.slice(nl + 1);
+        if (!line.startsWith("data:")) continue;
+        const data = line.slice(5).trim();
+        if (data === "[DONE]") continue;
+
+        const delta = JSON.parse(data)?.choices?.[0]?.delta;
+        if (!delta) continue;
+
+        if (typeof delta.content === "string" && delta.content) {
+          assistantText += delta.content;
+          fullText += delta.content;
+          callbacks.onContentDelta?.(delta.content);
+        }
+        for (const tc of delta.tool_calls ?? []) {
+          const idx = tc.index ?? 0;
+          const acc = partials.get(idx) ?? { id: "", name: "", arguments: "" };
+          if (tc.id) acc.id = tc.id;
+          if (tc.function?.name) acc.name = tc.function.name;
+          if (tc.function?.arguments) acc.arguments += tc.function.arguments;
+          partials.set(idx, acc);
+        }
+      }
+    }
+
+    const toolCalls: NormalizedToolCall[] = [...partials.values()].map((p) => {
+      let input: Record<string, unknown> = {};
+      try {
+        input = p.arguments ? JSON.parse(p.arguments) : {};
+      } catch {
+        input = {};
+      }
+      return { id: p.id || p.name, name: p.name, input };
+    });
+
+    if (!toolCalls.length || !runTools) break;
+
+    // Echo the assistant turn (with tool_calls) then feed tool results back.
+    messages.push({
+      role: "assistant",
+      content: assistantText,
+      tool_calls: toolCalls.map((c) => ({
+        id: c.id,
+        type: "function",
+        function: { name: c.name, arguments: JSON.stringify(c.input) },
+      })),
+    });
+    for (const call of toolCalls) callbacks.onToolCallStart?.(call);
+
+    throwIfAborted(params.abortSignal);
+    const results = await runTools(toolCalls);
+    for (const r of results) {
+      messages.push({ role: "tool", tool_call_id: r.tool_use_id, content: r.content });
+    }
+  }
+
+  return { fullText };
+}
+
+export async function completeCustomText(params: {
+  model: string;
+  systemPrompt?: string;
+  user: string;
+  maxTokens?: number;
+}): Promise<string> {
+  const response = await postChat(
+    {
+      model: modelName(params.model),
+      messages: initialMessages(params.systemPrompt ?? "", [
+        { role: "user", content: params.user },
+      ]),
+      max_tokens: params.maxTokens ?? 512,
+      stream: false,
+    },
+    undefined,
+  );
+  const json = (await response.json()) as {
+    choices?: { message?: { content?: string } }[];
+  };
+  return json.choices?.[0]?.message?.content ?? "";
+}

--- a/backend/src/lib/llm/index.ts
+++ b/backend/src/lib/llm/index.ts
@@ -2,6 +2,7 @@ import { streamClaude, completeClaudeText } from "./claude";
 import { streamGemini, completeGeminiText } from "./gemini";
 import { streamOpenAI, completeOpenAIText } from "./openai";
 import { streamOllama, completeOllamaText } from "./ollama";
+import { streamCustom, completeCustomText } from "./custom";
 import { providerForModel } from "./models";
 import type { StreamChatParams, StreamChatResult, UserApiKeys } from "./types";
 
@@ -15,6 +16,7 @@ export async function streamChatWithTools(
     if (provider === "claude") return streamClaude(params);
     if (provider === "openai") return streamOpenAI(params);
     if (provider === "ollama") return streamOllama(params);
+    if (provider === "custom") return streamCustom(params);
     return streamGemini(params);
 }
 
@@ -29,5 +31,6 @@ export async function completeText(params: {
     if (provider === "claude") return completeClaudeText(params);
     if (provider === "openai") return completeOpenAIText(params);
     if (provider === "ollama") return completeOllamaText(params);
+    if (provider === "custom") return completeCustomText(params);
     return completeGeminiText(params);
 }

--- a/backend/src/lib/llm/models.ts
+++ b/backend/src/lib/llm/models.ts
@@ -18,6 +18,8 @@ export const GEMINI_MAIN_MODELS = [
 export const OPENAI_MAIN_MODELS = ["gpt-5.5", "gpt-5.4"] as const;
 // Ollama models are detected dynamically (see GET /models/ollama). Any id of
 // the form "ollama/<tag>" is valid — see providerForModel / resolveModel.
+// Custom OpenAI-compatible endpoint models work the same way (GET /models/custom);
+// any id of the form "custom/<model>" is valid.
 
 // Mid-tier (used for tabular review) — user picks one in account settings.
 export const CLAUDE_MID_MODELS = ["claude-sonnet-4-6"] as const;
@@ -52,6 +54,7 @@ const ALL_MODELS = new Set<string>([
 
 export function providerForModel(model: string): Provider {
     if (model.startsWith("ollama")) return "ollama";
+    if (model.startsWith("custom")) return "custom";
     if (model.startsWith("claude")) return "claude";
     if (model.startsWith("gemini")) return "gemini";
     if (model.startsWith("gpt-")) return "openai";
@@ -59,6 +62,10 @@ export function providerForModel(model: string): Provider {
 }
 
 export function resolveModel(id: string | null | undefined, fallback: string): string {
-    if (id && (ALL_MODELS.has(id) || id.startsWith("ollama/"))) return id;
+    if (
+        id &&
+        (ALL_MODELS.has(id) || id.startsWith("ollama/") || id.startsWith("custom/"))
+    )
+        return id;
     return fallback;
 }

--- a/backend/src/lib/llm/types.ts
+++ b/backend/src/lib/llm/types.ts
@@ -2,7 +2,7 @@
 // Callers always speak OpenAI-style tools + { role, content } messages; each
 // provider translates internally.
 
-export type Provider = "claude" | "gemini" | "openai" | "ollama";
+export type Provider = "claude" | "gemini" | "openai" | "ollama" | "custom";
 
 export type OpenAIToolSchema = {
     type: "function";

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { requireAuth } from "../middleware/auth";
 import { authHeaders } from "../lib/llm/ollama";
+import { customBaseUrl, customAuthHeaders } from "../lib/llm/custom";
 
 export const modelsRouter = Router();
 
@@ -18,6 +19,27 @@ modelsRouter.get("/ollama", requireAuth, async (_req, res) => {
             id: `ollama/${m.id}`,
             label: `${m.id} (local)`,
             group: "Local",
+        }));
+        res.json({ models });
+    } catch {
+        res.json({ models: [] });
+    }
+});
+
+// Live list of models from the configured remote OpenAI-compatible endpoint,
+// shaped like the frontend's ModelOption. Returns [] when no endpoint is
+// configured or it is unreachable, so the app still works.
+modelsRouter.get("/custom", requireAuth, async (_req, res) => {
+    const base = customBaseUrl();
+    if (!base) return void res.json({ models: [] });
+    try {
+        const r = await fetch(`${base}/models`, { headers: customAuthHeaders() });
+        if (!r.ok) return void res.json({ models: [] });
+        const data = (await r.json()) as { data?: { id: string }[] };
+        const models = (data.data ?? []).map((m) => ({
+            id: `custom/${m.id}`,
+            label: m.id,
+            group: "Custom",
         }));
         res.json({ models });
     } catch {

--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -475,6 +475,7 @@ function providerLabel(provider: Provider): string {
 function missingModelApiKey(model: string, apiKeys: UserApiKeys) {
     const provider = providerForModel(model);
     if (provider === "ollama") return null; // local, no key
+    if (provider === "custom") return null; // endpoint configured via env
     if (apiKeys[provider]?.trim()) return null;
     return {
         provider,

--- a/frontend/src/app/(pages)/account/models/page.tsx
+++ b/frontend/src/app/(pages)/account/models/page.tsx
@@ -29,12 +29,14 @@ import {
 } from "../accountStyles";
 import { AccountSection } from "../AccountSection";
 import { useOllamaModels } from "@/app/hooks/useOllamaModels";
+import { useCustomModels } from "@/app/hooks/useCustomModels";
 
 type ModelPreferenceField = "titleModel" | "tabularModel";
 
 export default function ModelPreferencesPage() {
     const { profile, updateModelPreference } = useUserProfile();
     const ollamaModels = useOllamaModels();
+    const customModels = useCustomModels();
     const [savingField, setSavingField] = useState<ModelPreferenceField | null>(
         null,
     );
@@ -97,7 +99,7 @@ export default function ModelPreferencesPage() {
                             profile?.titleModel ??
                             "gemini-3.1-flash-lite-preview"
                         }
-                        options={[...SETTINGS_MODELS, ...ollamaModels]}
+                        options={[...SETTINGS_MODELS, ...ollamaModels, ...customModels]}
                         apiKeys={profile?.apiKeys}
                         isSaving={savingField === "titleModel"}
                         isSaved={savedField === "titleModel"}
@@ -119,7 +121,7 @@ export default function ModelPreferencesPage() {
                             profile?.tabularModel ??
                             "gemini-3-flash-preview"
                         }
-                        options={[...MODELS, ...ollamaModels]}
+                        options={[...MODELS, ...ollamaModels, ...customModels]}
                         apiKeys={profile?.apiKeys}
                         isSaving={savingField === "tabularModel"}
                         isSaved={savedField === "tabularModel"}

--- a/frontend/src/app/components/assistant/ModelToggle.tsx
+++ b/frontend/src/app/components/assistant/ModelToggle.tsx
@@ -15,11 +15,12 @@ import {
 import { isModelAvailable } from "@/app/lib/modelAvailability";
 import type { ApiKeyState } from "@/app/lib/mikeApi";
 import { useOllamaModels } from "@/app/hooks/useOllamaModels";
+import { useCustomModels } from "@/app/hooks/useCustomModels";
 
 export interface ModelOption {
     id: string;
     label: string;
-    group: "Anthropic" | "Google" | "OpenAI" | "Local";
+    group: "Anthropic" | "Google" | "OpenAI" | "Local" | "Custom";
 }
 
 export const MODELS: ModelOption[] = [
@@ -50,7 +51,7 @@ export const DEFAULT_MODEL_ID = "gemini-3-flash-preview";
 
 export const ALLOWED_MODEL_IDS = new Set(MODELS.map((m) => m.id));
 
-const GROUP_ORDER: ModelOption["group"][] = ["Anthropic", "Google", "OpenAI", "Local"];
+const GROUP_ORDER: ModelOption["group"][] = ["Anthropic", "Google", "OpenAI", "Local", "Custom"];
 const itemClassName =
     "rounded-xl px-2.5 py-1.5 text-gray-700 focus:bg-app-surface-hover focus:text-gray-900 data-[highlighted]:bg-app-surface-hover data-[highlighted]:text-gray-900";
 
@@ -63,7 +64,8 @@ interface Props {
 export function ModelToggle({ value, onChange, apiKeys }: Props) {
     const [isOpen, setIsOpen] = useState(false);
     const ollamaModels = useOllamaModels();
-    const models = [...MODELS, ...ollamaModels];
+    const customModels = useCustomModels();
+    const models = [...MODELS, ...ollamaModels, ...customModels];
     const selected = models.find((m) => m.id === value);
     const selectedLabel = selected?.label ?? "Model";
     const selectedAvailable = apiKeys

--- a/frontend/src/app/hooks/useCustomModels.ts
+++ b/frontend/src/app/hooks/useCustomModels.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { getCustomModels, type CustomModelOption } from "@/app/lib/mikeApi";
+
+// Module-level store so every picker shares one fetch and a refresh propagates
+// to all of them. Empty list when no custom endpoint is configured — the app
+// works without it.
+let cache: CustomModelOption[] | null = null;
+let inflight: Promise<CustomModelOption[]> | null = null;
+const listeners = new Set<() => void>();
+
+function load(force = false): Promise<CustomModelOption[]> {
+    if (force) {
+        cache = null;
+        inflight = null;
+    }
+    if (cache) return Promise.resolve(cache);
+    if (!inflight) {
+        inflight = getCustomModels()
+            .then((m) => {
+                cache = m;
+                listeners.forEach((l) => l());
+                return m;
+            })
+            .catch(() => {
+                inflight = null; // don't poison cache — retry on next load
+                return [];
+            });
+    }
+    return inflight;
+}
+
+// Clear the cache and refetch; mounted pickers update automatically.
+export function refreshCustomModels(): Promise<CustomModelOption[]> {
+    return load(true);
+}
+
+export function useCustomModels(): CustomModelOption[] {
+    const [models, setModels] = useState<CustomModelOption[]>(cache ?? []);
+
+    useEffect(() => {
+        const update = () => setModels(cache ?? []);
+        listeners.add(update);
+        void load().then(update);
+        return () => {
+            listeners.delete(update);
+        };
+    }, []);
+
+    return models;
+}

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -312,6 +312,21 @@ export async function getOllamaModels(): Promise<OllamaModelOption[]> {
     return models;
 }
 
+export interface CustomModelOption {
+    id: string;
+    label: string;
+    group: "Custom";
+}
+
+// Models from the configured remote OpenAI-compatible endpoint. Empty when no
+// endpoint is configured (CUSTOM_OPENAI_BASE_URL unset) or it is unreachable.
+export async function getCustomModels(): Promise<CustomModelOption[]> {
+    const { models } = await apiRequest<{ models: CustomModelOption[] }>(
+        "/models/custom",
+    );
+    return models;
+}
+
 export async function saveApiKey(
     provider: ApiKeyProvider,
     apiKey: string | null,

--- a/frontend/src/app/lib/modelAvailability.test.ts
+++ b/frontend/src/app/lib/modelAvailability.test.ts
@@ -36,6 +36,12 @@ describe("getModelProvider", () => {
         expect(getModelProvider("ollama/some-brand-new-model")).toBe("ollama");
     });
 
+    it("resolves any custom/-prefixed id without consulting SETTINGS_MODELS", () => {
+        // Custom endpoint models are discovered at runtime like ollama's.
+        expect(getModelProvider("custom/gpt-4o-mini")).toBe("custom");
+        expect(getModelProvider("custom/some-remote-model")).toBe("custom");
+    });
+
     it("resolves a provider for every model in SETTINGS_MODELS", () => {
         for (const model of SETTINGS_MODELS) {
             expect(getModelProvider(model.id)).not.toBeNull();
@@ -69,6 +75,10 @@ describe("isModelAvailable", () => {
     it("is true for ollama models even with no keys configured", () => {
         expect(isModelAvailable("ollama/llama3.2", keys({}))).toBe(true);
     });
+
+    it("is true for custom endpoint models even with no keys configured", () => {
+        expect(isModelAvailable("custom/gpt-4o-mini", keys({}))).toBe(true);
+    });
 });
 
 describe("isProviderAvailable", () => {
@@ -91,6 +101,13 @@ describe("isProviderAvailable", () => {
             isProviderAvailable("ollama", {} as unknown as ApiKeyState),
         ).toBe(true);
     });
+
+    it("treats custom as always available — endpoint configured via env", () => {
+        expect(isProviderAvailable("custom", keys({}))).toBe(true);
+        expect(
+            isProviderAvailable("custom", {} as unknown as ApiKeyState),
+        ).toBe(true);
+    });
 });
 
 describe("providerLabel", () => {
@@ -98,6 +115,7 @@ describe("providerLabel", () => {
         expect(providerLabel("claude")).toBe("Anthropic (Claude)");
         expect(providerLabel("openai")).toBe("OpenAI");
         expect(providerLabel("ollama")).toBe("Local (Ollama)");
+        expect(providerLabel("custom")).toBe("Custom endpoint");
         expect(providerLabel("gemini")).toBe("Google (Gemini)");
     });
 });
@@ -107,6 +125,7 @@ describe("modelGroupToProvider", () => {
         expect(modelGroupToProvider("Anthropic")).toBe("claude");
         expect(modelGroupToProvider("OpenAI")).toBe("openai");
         expect(modelGroupToProvider("Local")).toBe("ollama");
+        expect(modelGroupToProvider("Custom")).toBe("custom");
         expect(modelGroupToProvider("Google")).toBe("gemini");
     });
 });

--- a/frontend/src/app/lib/modelAvailability.ts
+++ b/frontend/src/app/lib/modelAvailability.ts
@@ -1,10 +1,11 @@
 import { SETTINGS_MODELS, type ModelOption } from "../components/assistant/ModelToggle";
 import type { ApiKeyState } from "@/app/lib/mikeApi";
 
-export type ModelProvider = "claude" | "gemini" | "openai" | "ollama";
+export type ModelProvider = "claude" | "gemini" | "openai" | "ollama" | "custom";
 
 export function getModelProvider(modelId: string): ModelProvider | null {
     if (modelId.startsWith("ollama/")) return "ollama"; // dynamic, not in the static list
+    if (modelId.startsWith("custom/")) return "custom"; // dynamic, not in the static list
     const model = SETTINGS_MODELS.find((m) => m.id === modelId);
     if (!model) return null;
     return modelGroupToProvider(model.group);
@@ -24,6 +25,7 @@ export function isProviderAvailable(
     apiKeys: ApiKeyState,
 ): boolean {
     if (provider === "ollama") return true; // local, no key needed
+    if (provider === "custom") return true; // endpoint configured via env
     return !!apiKeys[provider]?.configured;
 }
 
@@ -31,6 +33,7 @@ export function providerLabel(provider: ModelProvider): string {
     if (provider === "claude") return "Anthropic (Claude)";
     if (provider === "openai") return "OpenAI";
     if (provider === "ollama") return "Local (Ollama)";
+    if (provider === "custom") return "Custom endpoint";
     return "Google (Gemini)";
 }
 
@@ -40,5 +43,6 @@ export function modelGroupToProvider(
     if (group === "Anthropic") return "claude";
     if (group === "OpenAI") return "openai";
     if (group === "Local") return "ollama";
+    if (group === "Custom") return "custom";
     return "gemini";
 }


### PR DESCRIPTION
## Summary

Adds a `custom` LLM provider so an instance can point Mike at any **remote OpenAI-compatible** `/v1/chat/completions` endpoint — a hosted gateway or proxy such as LiteLLM, OpenRouter, Together, Azure OpenAI, or an in-house service. It mirrors the existing Ollama provider: env-configured base URL, optional bearer token, and a model tag, so it introduces no new config model or storage.

## Why / Motivation

Many teams standardize LLM access behind a single OpenAI-compatible gateway — for governance, routing, rate-limiting, cost control, or access to models not offered by the three built-in vendors. Mike currently supports Anthropic/Google/OpenAI keys plus a local Ollama, but there is no way to target an arbitrary *remote* OpenAI-compatible endpoint without patching the code.

This is deliberately **not** a local-hosting refactor (per `CONTRIBUTING.md`): it is a remote-endpoint option that reuses the existing provider abstraction.

## Changes

**Backend**
- `lib/llm/custom.ts` (new): adapter for OpenAI-compatible `/v1/chat/completions`, closely mirroring `ollama.ts` — SSE streaming, streamed `tool_calls` accumulation, tool-result round-trip, graceful fallback when a model rejects the `tools` param.
- `lib/llm/types.ts`: `"custom"` added to `Provider`.
- `lib/llm/models.ts`: `providerForModel` maps the `custom` prefix; `resolveModel` accepts `custom/*` ids (same treatment as `ollama/*`).
- `lib/llm/index.ts`: dispatch for stream + complete.
- `routes/models.ts`: `GET /models/custom` lists the endpoint's models (returns `[]` when unconfigured or unreachable, so the app degrades gracefully).
- `routes/tabular.ts`: `missingModelApiKey` treats `custom` as env-configured (like `ollama`), so it does not demand a per-user key.
- `backend/.env.example`: documents `CUSTOM_OPENAI_BASE_URL` / `CUSTOM_OPENAI_API_KEY` / `CUSTOM_OPENAI_MODEL`.

**Frontend**
- `hooks/useCustomModels.ts` (new) + `getCustomModels()` in `mikeApi.ts`, mirroring the Ollama hook/fetch.
- `ModelToggle.tsx`: new `"Custom"` group in the picker.
- `account/models`: custom models selectable for title/tabular preferences.
- `modelAvailability.ts`: provider mapping, label, and availability.

**Tests**
- `llmModels.test.ts`: prefix → provider mapping and `resolveModel` for `custom/*`.
- `modelAvailability.test.ts`: provider resolution, availability, label, group mapping.

## Tradeoffs & risks

- **Config is per-instance (env), not per-user.** This matches the Ollama precedent and avoids changing the `user_api_keys` schema, which stores a single secret per provider (a custom endpoint needs URL + key + model). A per-user variant could follow later if wanted.
- The bearer token lives in env alongside `OLLAMA_API_KEY`, so there is nothing new to encrypt at rest.
- Model ids are free-form `custom/<model>` and are not validated against a catalog — the same behavior `ollama/<tag>` already has.
- No change to any existing provider's behavior; all new code paths are inert unless `CUSTOM_OPENAI_BASE_URL` is set.

## How verified

- **Live end-to-end against a running OpenAI-compatible server** (Ollama's OpenAI-compatible API on a separate port, serving `llama3.2:3b`, with a bearer token set to exercise the auth header):
  - model listing returns `custom/llama3.2:3b`;
  - `completeText()` (non-streaming) via the public dispatcher;
  - `streamChatWithTools()` streams incrementally — 129 content deltas / 871 chars, first delta at ~0.9s;
  - **tool-calling loop**: the model emitted `get_weather{"city":"Paris"}`, the tool result was fed back, and the final answer incorporated it;
  - a clear error is raised when `CUSTOM_OPENAI_BASE_URL` is unset.
- `backend`: `npm test` → 497 passing; `npm run build` (tsc) clean.
- `frontend`: new unit tests pass; `npm run lint` → 0 errors; `tsc --noEmit` clean.
- Note: 3 pre-existing failures in `frontend/src/app/lib/mikeApi.test.ts` (blob export helpers) reproduce on the base branch with no changes applied — a local Node 25 `Blob` artifact, unrelated to this PR; CI runs Node 22.

## Checklist

- [x] Ran the relevant build/test commands
- [x] Reviewed the diff for unrelated changes
- [x] Updated docs / env examples
- [x] No secrets committed
