### PR TITLE
Extend `/docx` downloads to `/file` for arbitrary file types

### DIFF
--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -174,6 +174,45 @@ documentsRouter.get("/:documentId/display", requireAuth, async (req, res) => {
   }
 });
 
+// GET /single-documents/:documentId/file
+// Streams active-version source bytes for browser editors. Unlike /display,
+// this never substitutes a generated PDF rendition for an Office document.
+documentsRouter.get("/:documentId/file", requireAuth, async (req, res) => {
+  const userId = res.locals.userId as string;
+  const userEmail = res.locals.userEmail as string | undefined;
+  const { documentId } = req.params;
+  const versionIdParam =
+    typeof req.query.version_id === "string" ? req.query.version_id : null;
+  const db = createServerSupabase();
+
+  const { data: doc } = await db
+    .from("documents")
+    .select("id, user_id, project_id")
+    .eq("id", documentId)
+    .single();
+  if (!doc)
+    return void res.status(404).json({ detail: "Document not found" });
+  const access = await ensureDocAccess(doc, userId, userEmail, db);
+  if (!access.ok)
+    return void res.status(404).json({ detail: "Document not found" });
+
+  const active = await loadActiveVersion(documentId, db, versionIdParam);
+  if (!active)
+    return void res.status(404).json({ detail: "No file available" });
+  const raw = await downloadFile(active.storage_path);
+  if (!raw)
+    return void res.status(404).json({ detail: "Document bytes not available" });
+
+  const filename = downloadFilenameForVersion(
+    active.filename,
+    active.version_number,
+    active.source === "assistant_edit",
+  );
+  res.setHeader("Content-Type", contentTypeForDocumentType(active.file_type));
+  res.setHeader("Content-Disposition", buildContentDisposition("inline", filename));
+  res.send(Buffer.from(raw));
+});
+
 // POST /single-documents/download-zip
 documentsRouter.post("/download-zip", requireAuth, async (req, res) => {
   const userId = res.locals.userId as string;

--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -175,7 +175,9 @@ documentsRouter.get("/:documentId/display", requireAuth, async (req, res) => {
 });
 
 // GET /single-documents/:documentId/file
-// Streams active-version source bytes for browser editors. Unlike /display,
+// Downloads active-version or `?version_id` source bytes for browser editors. 
+// this bypasses R2 (avoids the browser CORS problem on signed URLs) so the frontend
+// docx-preview viewer can load tracked-change documents directly. Unlike /display,
 // this never substitutes a generated PDF rendition for an Office document.
 documentsRouter.get("/:documentId/file", requireAuth, async (req, res) => {
   const userId = res.locals.userId as string;
@@ -323,52 +325,15 @@ documentsRouter.get("/:documentId/url", requireAuth, async (req, res) => {
 });
 
 // GET /single-documents/:documentId/docx
-// Streams the raw .docx bytes for the given document, optionally at a
-// specific tracked-changes version. Unlike /url, this bypasses R2 (avoids
-// the browser CORS problem on signed URLs) so the frontend docx-preview
-// viewer can load tracked-change documents directly.
-documentsRouter.get("/:documentId/docx", requireAuth, async (req, res) => {
-  const userId = res.locals.userId as string;
-  const userEmail = res.locals.userEmail as string | undefined;
-  const { documentId } = req.params;
-  const versionIdParam = typeof req.query.version_id === "string" ? req.query.version_id : null;
-  const db = createServerSupabase();
-
-  const { data: doc, error } = await db
-    .from("documents")
-    .select("id, user_id, project_id")
-    .eq("id", documentId)
-    .single();
-  if (error || !doc)
-    return void res.status(404).json({ detail: "Document not found" });
-  const access = await ensureDocAccess(doc, userId, userEmail, db);
-  if (!access.ok)
-    return void res.status(404).json({ detail: "Document not found" });
-
-  const active = await loadActiveVersion(documentId, db, versionIdParam);
-  if (!active)
-    return void res.status(404).json({ detail: "No file available" });
-
-  const raw = await downloadFile(active.storage_path);
-  if (!raw)
-    return void res.status(404).json({ detail: "Document bytes not available" });
-
-  res.setHeader(
-    "Content-Type",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+// Permanent compatibility redirect for old docx-preview callers. /file owns
+// source-byte downloads and query parameters, including ?version_id=.
+documentsRouter.get("/:documentId/docx", (req, res) => {
+  const queryIndex = req.originalUrl.indexOf("?");
+  const query = queryIndex >= 0 ? req.originalUrl.slice(queryIndex) : "";
+  res.redirect(
+    301,
+    `${req.baseUrl}/${encodeURIComponent(req.params.documentId)}/file${query}`,
   );
-  res.setHeader(
-    "Content-Disposition",
-    buildContentDisposition(
-      "inline",
-      downloadFilenameForVersion(
-        active.filename,
-        active.version_number,
-        active.source === "assistant_edit",
-      ),
-    ),
-  );
-  res.send(Buffer.from(raw));
 });
 
 // Produce the filename a download should present to the user. Version

--- a/frontend/src/app/components/documents/DocTable.tsx
+++ b/frontend/src/app/components/documents/DocTable.tsx
@@ -63,6 +63,7 @@ import {
     type ProjectContextMenu,
 } from "@/app/components/projects/ProjectPageParts";
 import { DocumentSidePanel } from "@/app/components/shared/DocumentSidePanel";
+import { TritiumEditor } from "@/app/components/documents/TritiumEditor";
 import { LibrarySkeuoIcon } from "@/app/components/shared/AppSidebarSkeuoIcons";
 import {
     APP_SURFACE_ACTIVE_CLASS,
@@ -88,6 +89,11 @@ export interface DocTableSelectionActions {
     onRemoveFromFolder: () => Promise<void>;
     onDelete: () => Promise<void>;
 }
+
+type TritiumEditorTarget = {
+    documents: Document[];
+    folderName?: string;
+};
 
 type DocumentSortKey = "name" | "size" | "version" | "created" | "updated";
 
@@ -281,6 +287,8 @@ export function DocTable({
         id: string;
         label: string;
     } | null>(null);
+    const [tritiumTarget, setTritiumTarget] =
+        useState<TritiumEditorTarget | null>(null);
     const [selectedDocIds, setSelectedDocIds] = useState<string[]>([]);
     const [typeFilter, setTypeFilter] = useState<string | null>(null);
     const [sort, setSort] = useState<{
@@ -421,6 +429,14 @@ export function DocTable({
         } catch (e) {
             console.error("uploadDocumentVersion failed", e);
         }
+    }
+
+    function canOpenInTritium(doc: Document) {
+        if (scopeKey !== "files" && scopeKey !== "templates") return false;
+        const extension = (doc.file_type ?? doc.filename.split(".").pop() ?? "")
+            .toLowerCase()
+            .trim();
+        return extension === "docx" || extension === "pdf";
     }
 
     async function replaceVersionFile(
@@ -3030,6 +3046,14 @@ export function DocTable({
                                                     onDownload={() =>
                                                         downloadDoc(menuDoc.id)
                                                     }
+                                                    onOpenInTritium={
+                                                        canOpenInTritium(menuDoc)
+                                                            ? () =>
+                                                                  setTritiumTarget({
+                                                                      documents: [menuDoc],
+                                                                  })
+                                                            : undefined
+                                                    }
                                                     onShowAllVersions={
                                                         menuDocHasVersions &&
                                                         !menuDocVersionsOpen
@@ -3087,6 +3111,29 @@ export function DocTable({
                                                         contextMenu.showFolderActions
                                                             ? "New subfolder inside"
                                                             : "New subfolder"
+                                                    }
+                                                    onOpenInTritium={
+                                                        (scopeKey === "files" ||
+                                                            scopeKey === "templates") &&
+                                                        contextMenu.folderId
+                                                            ? () => {
+                                                                  const folder = folders.find(
+                                                                      (candidate) =>
+                                                                          candidate.id ===
+                                                                          contextMenu.folderId,
+                                                                  );
+                                                                  if (!folder) return;
+                                                                  const folderDocuments = docs.filter(
+                                                                      (document) =>
+                                                                          document.folder_id ===
+                                                                          folder.id,
+                                                                  );
+                                                                  setTritiumTarget({
+                                                                      documents: folderDocuments,
+                                                                      folderName: folder.name,
+                                                                  });
+                                                              }
+                                                            : undefined
                                                     }
                                                     onRename={
                                                         contextMenu.showFolderActions &&
@@ -3175,6 +3222,24 @@ export function DocTable({
                     await handleRemoveDoc(doc.id);
                 }}
             />
+
+            {tritiumTarget && (
+                <TritiumEditor
+                    documents={tritiumTarget.documents}
+                    folderName={tritiumTarget.folderName}
+                    onClose={async () => {
+                        setTritiumTarget(null);
+                        await Promise.all(
+                            tritiumTarget.documents.map((document) =>
+                                refreshDocumentVersionState(document.id),
+                            ),
+                        );
+                    }}
+                    onSave={async (document, file) => {
+                        await uploadDocumentVersion(document.id, file, file.name);
+                    }}
+                />
+            )}
 
         </div>
     );

--- a/frontend/src/app/components/documents/TritiumEditor.tsx
+++ b/frontend/src/app/components/documents/TritiumEditor.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
+import type { Document } from "@/app/components/shared/types";
+import { getDocumentFile } from "@/app/lib/mikeApi";
+
+type TritiumApi = {
+    start: ({ folder, files }: { folder?: string; files: File[] }) => void;
+    shutdown: () => void;
+    open_file: (file: File) => Promise<void>;
+    open_folder: (path: string, files: File[]) => Promise<void>;
+    set_exit_handler: (handler: () => void) => void;
+    set_save_handler: (
+        handler: (file: File) => void | Promise<void>,
+    ) => void;
+};
+
+const TRITIUM_SCRIPT_URL = "http://localhost:8080/static/init.js";
+
+let tritiumModulePromise: Promise<TritiumApi> | null = null;
+
+function loadTritium(): Promise<TritiumApi> {
+    tritiumModulePromise ??= import(
+        /* webpackIgnore: true */ TRITIUM_SCRIPT_URL
+    ) as Promise<TritiumApi>;
+    return tritiumModulePromise;
+}
+
+export function TritiumEditor({
+    documents,
+    folderName,
+    onClose,
+    onSave,
+}: {
+    documents: Document[];
+    folderName?: string;
+    onClose: () => void;
+    onSave: (document: Document, file: File) => Promise<void>;
+}) {
+    const [error, setError] = useState<string | null>(null);
+    const documentsRef = useRef(documents);
+    const onCloseRef = useRef(onClose);
+    const onSaveRef = useRef(onSave);
+    const tritiumRef = useRef<TritiumApi | null>(null);
+    documentsRef.current = documents;
+    onCloseRef.current = onClose;
+    onSaveRef.current = onSave;
+
+    useEffect(() => {
+        async function openTarget() {
+            try {
+                setError(null);
+                const tritium = await loadTritium();
+                tritiumRef.current = tritium;
+                const fileResponses = await Promise.all(
+                    documents.map(async (document) => ({
+                        document,
+                        response: await getDocumentFile(document.id),
+                    })),
+                );
+                tritium.set_exit_handler(() => onCloseRef.current());
+                tritium.set_save_handler(async (file) => {
+                    const source = documentsRef.current.find(
+                        (document) => document.filename === file.name,
+                    );
+                    if (!source) {
+                        setError(
+                            `Could not match ${file.name || "this file"} to a Library document.`,
+                        );
+                        return;
+                    }
+                    setError(null);
+                    try {
+                        await onSaveRef.current(source, file);
+                    } catch (saveError) {
+                        setError(
+                            saveError instanceof Error
+                                ? saveError.message
+                                : "Could not save a new version.",
+                        );
+                    }
+                });
+                const files = fileResponses.map(({ document, response }) =>
+                    new File(
+                        [response.blob],
+                        response.filename ?? document.filename,
+                        { type: response.blob.type },
+                    ),
+                );
+                tritium.start({ folder: folderName, files });
+            } catch (openError) {
+                setError(
+                    openError instanceof Error
+                        ? openError.message
+                        : "Could not open this file in Tritium.",
+                );
+            }
+        }
+        void openTarget();
+        return () => {};
+    }, [documents, folderName]);
+
+    return (
+        <div className="fixed inset-0 z-[100] flex flex-col bg-white">
+            <header className="flex h-12 shrink-0 items-center border-b border-gray-200 px-4">
+                <span className="min-w-0 flex-1 truncate text-sm font-medium text-gray-900">
+                    {folderName ?? documents[0]?.filename ?? "Tritium"}
+                </span>
+                <button
+                    type="button"
+                    onClick={() => tritiumRef.current?.shutdown()}
+                    aria-label="Close editor"
+                    className="ml-4 flex h-8 w-8 items-center justify-center rounded text-gray-600 hover:bg-gray-100"
+                >
+                    <X className="h-4 w-4" />
+                </button>
+            </header>
+            <div className="relative min-h-0 flex-1">
+                <canvas id="tritium-canvas" className="h-full w-full" />
+                {(error) && (
+                    <div className="absolute left-4 top-4 flex max-w-md items-center gap-2 rounded border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm">
+                        <span>{error}</span>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/app/components/shared/RowActions.tsx
+++ b/frontend/src/app/components/shared/RowActions.tsx
@@ -12,6 +12,7 @@ import {
     Download,
     Eye,
     EyeOff,
+    FolderOpen,
     FolderMinus,
     Hash,
     History,
@@ -43,6 +44,7 @@ interface Props {
     onRemoveFromFolder?: () => void;
     onShowAllVersions?: () => void;
     onUploadNewVersion?: () => void;
+    onOpenInTritium?: () => void;
     onNewSubfolder?: () => void;
     deleting?: boolean;
     deleteDisabled?: boolean;
@@ -74,6 +76,7 @@ export const RowActionMenuItems = forwardRef<
     onRemoveFromFolder,
     onShowAllVersions,
     onUploadNewVersion,
+    onOpenInTritium,
     onNewSubfolder,
     deleting,
     deleteDisabled = false,
@@ -156,6 +159,15 @@ export const RowActionMenuItems = forwardRef<
                 >
                     <Upload className="h-3.5 w-3.5 shrink-0" />
                     Upload new version
+                </LiquidDropdownButton>
+            )}
+            {onOpenInTritium && (
+                <LiquidDropdownButton
+                    onClick={() => { onClose(); onOpenInTritium(); }}
+                    className={ROW_ACTION_LEFT_ITEM_CLASS}
+                >
+                    <FolderOpen className="h-3.5 w-3.5 shrink-0" />
+                    Open in Tritium
                 </LiquidDropdownButton>
             )}
             {onRemoveFromFolder && (

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -840,6 +840,14 @@ export async function getDocumentUrl(
     return apiRequest(`/single-documents/${documentId}/url${qs}`);
 }
 
+export async function getDocumentFile(
+    documentId: string,
+    versionId?: string | null,
+): Promise<{ blob: Blob; filename: string | null }> {
+    const qs = versionId ? `?version_id=${encodeURIComponent(versionId)}` : "";
+    return apiBlobRequest(`/single-documents/${documentId}/file${qs}`);
+}
+
 export async function downloadDocumentsZip(
     documentIds: string[],
 ): Promise<Blob> {


### PR DESCRIPTION
## Summary

This extends the existing `/docx` endpoint to allow for download of arbitrary files, not just DOCX. It consolidates the old `/docx` endpoint with a new `/file` endpoint and redirects the former there.

It's just a suggestion to allow other folks to extend it as we have.

## Why / Motivation

Folks implementing in-browser editors and document viewers for the miscellaneous supported formats will want access to the raw  file bytes as opposed to the results supplied by `/display`.

## Changes

As above.

## Tradeoffs & risks

The very minor trade-off is that folks who want to avoid the imperceptible redirect from `/docx` to `/file` will need to migrate. Then the `/docx` endpoint could be deprecated in favor of the more general `/file`.

## How verified

We ran the test suite, which was unaffected by the changes.

## Checklist

- [x] Ran the relevant build/test command for the area changed.
- [x] Reviewed `git diff` and removed unrelated changes.
- [x] Updated docs / env examples if setup, config, or behavior changed.
- [x] No secrets, API keys, real documents, or `.env` files committed.
