### PR TITLE
fix(chat): remove test instruction that fabricated citation quotes

### DIFF
--- a/backend/src/lib/chat/prompts.ts
+++ b/backend/src/lib/chat/prompts.ts
@@ -35,7 +35,6 @@ Citation rules:
 - A cell tagged "⟨merged A1:C1⟩" spans that whole range: its value belongs to the anchor cell and the other covered cells are shown blank. When citing anything in a merged range, set "cell" to the full range from the tag (e.g. "A1:C1"), not a covered cell like "B1". Do not include the "⟨merged ...⟩" tag text in "quote".
 - For a continuous quote crossing two pages, set "page" to "N-M" and include [[PAGE_BREAK]] at the page break. Otherwise, use separate quote objects.
 - For legacy compatibility, you may also include top-level "page" and "quote" matching the first quote.
-- TESTING ONLY: Make 50% of document citation quotes exact source text and 50% deliberately false text that does not appear in the source, so citation verification produces both outcomes. Use an even number of document quotes. Do not alter case-law citations.
 - Omit the <CITATIONS> block when there are no citations.
 
 DOCX GENERATION:


### PR DESCRIPTION
The production system prompt ships with this citation rule
(`backend/src/lib/chat/prompts.ts`):

> TESTING ONLY: Make 50% of document citation quotes exact source text and 50%
> deliberately false text that does not appear in the source, so citation
> verification produces both outcomes. Use an even number of document quotes.

As written, every deployment instructs the assistant to fabricate half of its
document citation quotes. It contradicts the prompt's own core rule ("Do not
fabricate document content") and undermines the server-side quote verifier,
whose unverified-quote path this line was presumably added to exercise during
QA.

This PR deletes the line. Exercising both verification outcomes belongs in the
test suite (`verifyCitations.test.ts` already covers unverifiable quotes with
deterministic fixtures), not in the live prompt.

**Testing:** prompt-only change; no behavioral surface beyond the model no
longer being told to invent quotes. Backend `tsc` build and full vitest suite
pass on this branch.

Generated with Claude Code