### PR TITLE
fix(research): expose courtlistener_search_case_law in the tool schema

### DIFF
--- a/backend/src/lib/chat/tools/courtlistenerTools.ts
+++ b/backend/src/lib/chat/tools/courtlistenerTools.ts
@@ -73,10 +73,11 @@ export const COURTLISTENER_SYSTEM_PROMPT = `US CASE LAW RESEARCH:
 Use CourtListener when answering US-law questions that require case law.
 
 Workflow:
-1. If you have reporter citations, verify them with courtlistener_verify_citations using only clean citations: {"citations":["467 U.S. 837","323 U.S. 134"]}. Never pass case names to this tool.
-2. Fetch matched clusters with courtlistener_get_cases.
-3. Get cite-worthy text from the fetched cases with courtlistener_find_in_case. Use short 1-3 word searches, maximum 3 searches per assistant turn.
-4. If snippets are not enough, read only the necessary opinion(s) with courtlistener_read_case. For multi-opinion cases, choose the specific opinion_id/opinionIds needed; do not read all opinions by default.
+1. If you need to find authority on a topic and do not already have citations, search with courtlistener_search_case_law using a focused query. Search results are leads only: they return metadata and snippets, never citable text.
+2. If you have reporter citations, verify them with courtlistener_verify_citations using only clean citations: {"citations":["467 U.S. 837","323 U.S. 134"]}. Never pass case names to this tool.
+3. Fetch matched or search-result clusters with courtlistener_get_cases.
+4. Get cite-worthy text from the fetched cases with courtlistener_find_in_case. Use short 1-3 word searches, maximum 3 searches per assistant turn.
+5. If snippets are not enough, read only the necessary opinion(s) with courtlistener_read_case. For multi-opinion cases, choose the specific opinion_id/opinionIds needed; do not read all opinions by default.
 
 Citation rules:
 - Final case citations must be based on opinion text or passage snippets supplied in this turn. Do not cite cases based only on memory, metadata, search results, citationLinks, or verification results.
@@ -90,6 +91,45 @@ Limits:
 - If any CourtListener call returns a rate-limit/throttling/429 error, stop all CourtListener calls for that turn and answer using only information already available.`;
 
 export const COURTLISTENER_TOOLS = [
+    {
+        type: "function",
+        function: {
+            name: COURTLISTENER_TOOL_NAMES.searchCaseLaw,
+            description:
+                "Search CourtListener for US case law on a topic when you do not already have citations. Returns up to 20 matches with cluster ID, case name, citation, court, date filed, and a snippet. Results are leads only, not citable text: fetch promising clusters with courtlistener_get_cases and read passages before citing any case.",
+            parameters: {
+                type: "object",
+                properties: {
+                    query: {
+                        type: "string",
+                        description:
+                            "Focused search query describing the legal issue, doctrine, or case name to find.",
+                    },
+                    court: {
+                        type: "string",
+                        description:
+                            "Optional CourtListener court identifier to restrict results, e.g. \"scotus\" or \"del\" (Delaware Supreme Court). Omit to search all courts.",
+                    },
+                    filedAfter: {
+                        type: "string",
+                        description:
+                            "Optional earliest filing date filter, formatted YYYY-MM-DD.",
+                    },
+                    filedBefore: {
+                        type: "string",
+                        description:
+                            "Optional latest filing date filter, formatted YYYY-MM-DD.",
+                    },
+                    limit: {
+                        type: "integer",
+                        description:
+                            "Maximum number of results to return, 1-20. Default 10.",
+                    },
+                },
+                required: ["query"],
+            },
+        },
+    },
     {
         type: "function",
         function: {


### PR DESCRIPTION
`courtlistener_search_case_law` is fully implemented — the dispatcher handles
it (`toolDispatcher.ts`), `searchCourtlistenerCaseLaw` exists in
`lib/courtlistener.ts`, the event type is declared, and the frontend renders
its events (`eventUtils.ts`, `useAssistantChat.ts`, `TRChatPanel.tsx`). But it
was never added to the `COURTLISTENER_TOOLS` schema array, so the model is
never told the tool exists and can never call it.

Net effect today: the assistant can verify and read citations the user (or its
own memory) supplies, but cannot *find* authority on a topic. The README's
description of "targeted opinion search" doesn't hold as shipped.

This PR:

- adds the missing schema entry (`query`, optional `court` / `filedAfter` /
  `filedBefore` filters, `limit` 1–20 matching the implementation's clamp);
- adds a discovery step to the CourtListener workflow prompt, with an explicit
  rule that search results are leads only — metadata and snippets, never
  citable text — consistent with the existing grounding rule that final
  citations must come from opinion text fetched in the same turn.

No dispatcher, API-client, or frontend changes needed — those paths already
exist and are reached the moment the schema exposes the tool.

**Testing:** schema/prompt-only change; existing dispatcher and frontend event
handling are unchanged. Backend `tsc` build and full vitest suite pass on
this branch.

Generated with Claude Code