### PR TITLE
fix(tabular): verify cell citations server-side, flag unverifiable quotes

### DIFF
--- a/backend/src/lib/chat/verifyTabularCitations.test.ts
+++ b/backend/src/lib/chat/verifyTabularCitations.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Same module-graph isolation as verifyCitations.test.ts: the verifier only
+// reuses the pure quote matcher, but importing documentOps pulls in the
+// storage/supabase graph. Keep those side-effects offline.
+vi.mock("../supabase", () => ({ createServerSupabase: vi.fn() }));
+vi.mock("../storage", () => ({ downloadFile: vi.fn() }));
+
+import {
+  verifyInlineCitations,
+  verifyTabularCellResult,
+  type TabularCellSources,
+} from "./verifyTabularCitations";
+
+const DOC_A = "doc-aaaa";
+const DOC_B = "doc-bbbb";
+
+const SOURCE_A = [
+  "[Page 1]",
+  "The General Partner shall receive a management fee of 2% per annum.",
+  "[Page 2]",
+  "Carried interest equals 20% of profits above the preferred return.",
+].join("\n");
+
+const SOURCE_B = [
+  "## Sheet: Summary",
+  "| Row | A | B |",
+  "| 7 | Fee | 2% |",
+].join("\n");
+
+function sources(): TabularCellSources {
+  return {
+    combined: `${SOURCE_A}\n\n---\n\n${SOURCE_B}`,
+    byDocId: new Map([
+      [DOC_A, SOURCE_A],
+      [DOC_B, SOURCE_B],
+    ]),
+  };
+}
+
+describe("verifyInlineCitations", () => {
+  it("keeps an exact verified quote unchanged", () => {
+    const text = `2% [[document:${DOC_A}||page:1||quote:management fee of 2% per annum]]`;
+    expect(verifyInlineCitations(text, sources())).toBe(text);
+  });
+
+  it("marks a fabricated quote as unverified", () => {
+    const text = `3% [[document:${DOC_A}||page:1||quote:management fee of 3% per annum payable quarterly]]`;
+    expect(verifyInlineCitations(text, sources())).toBe(
+      `3% [[document:${DOC_A}||page:1||unverified:true||quote:management fee of 3% per annum payable quarterly]]`,
+    );
+  });
+
+  it("corrects a drifted quote to the exact source excerpt", () => {
+    // Case drift: verified via normalized matching, corrected to source text.
+    const text = `Fee [[document:${DOC_A}||page:1||quote:Management Fee of 2% per Annum]]`;
+    expect(verifyInlineCitations(text, sources())).toBe(
+      `Fee [[document:${DOC_A}||page:1||quote:management fee of 2% per annum]]`,
+    );
+  });
+
+  it("verifies against the cited document, not other row documents", () => {
+    // The quote exists only in DOC_A; citing DOC_B must fail verification.
+    const text = `X [[document:${DOC_B}||sheet:Summary||cell:B7||quote:management fee of 2% per annum]]`;
+    expect(verifyInlineCitations(text, sources())).toContain(
+      "unverified:true",
+    );
+  });
+
+  it("marks citations to unknown document ids as unverified", () => {
+    // Quote exists in the row, but the cited document id does not — the
+    // pinpoint target is unresolvable, so the citation must not pass.
+    const text =
+      "X [[document:doc-nonexistent||page:1||quote:management fee of 2% per annum]]";
+    expect(verifyInlineCitations(text, sources())).toContain(
+      "unverified:true",
+    );
+  });
+
+  it("verifies spreadsheet citations by cell value", () => {
+    const text = `2% [[document:${DOC_B}||sheet:Summary||cell:B7||quote:2%]]`;
+    expect(verifyInlineCitations(text, sources())).toBe(text);
+  });
+
+  it("falls back to combined text when the marker has no document id", () => {
+    const text = "Carry [[page:2||quote:Carried interest equals 20% of profits]]";
+    expect(verifyInlineCitations(text, sources())).toBe(
+      "Carry [[page:2||quote:Carried interest equals 20% of profits]]",
+    );
+  });
+
+  it("leaves Yes/No and tag pills untouched", () => {
+    const text = "[[Yes]] and [[Confidential]] and [[USD]]";
+    expect(verifyInlineCitations(text, sources())).toBe(text);
+  });
+
+  it("leaves unparseable markers untouched", () => {
+    const text = "[[document:x||nonsense]]";
+    expect(verifyInlineCitations(text, sources())).toBe(text);
+  });
+
+  it("is idempotent: re-verification does not stack unverified flags", () => {
+    const text = `X [[document:${DOC_A}||page:1||quote:no such text anywhere]]`;
+    const once = verifyInlineCitations(text, sources());
+    const twice = verifyInlineCitations(once, sources());
+    expect(twice).toBe(once);
+    expect(twice.match(/unverified:true/g)).toHaveLength(1);
+  });
+
+  it("clears a stale unverified flag when the quote now verifies", () => {
+    const text = `X [[document:${DOC_A}||page:1||unverified:true||quote:management fee of 2% per annum]]`;
+    expect(verifyInlineCitations(text, sources())).toBe(
+      `X [[document:${DOC_A}||page:1||quote:management fee of 2% per annum]]`,
+    );
+  });
+});
+
+describe("verifyTabularCellResult", () => {
+  it("verifies citations in both summary and reasoning", () => {
+    const result = {
+      summary: `2% [[document:${DOC_A}||page:1||quote:not in the source at all]]`,
+      flag: "green" as const,
+      reasoning: `Because [[document:${DOC_A}||page:2||quote:Carried interest equals 20% of profits]]`,
+    };
+    const verified = verifyTabularCellResult(result, sources());
+    expect(verified.summary).toContain("unverified:true");
+    expect(verified.reasoning).not.toContain("unverified:true");
+    expect(verified.flag).toBe("green");
+  });
+});

--- a/backend/src/lib/chat/verifyTabularCitations.ts
+++ b/backend/src/lib/chat/verifyTabularCitations.ts
@@ -1,0 +1,151 @@
+import { verifyQuoteAgainstSource } from "./verifyCitations";
+
+/**
+ * Server-side verification for tabular review cell citations.
+ *
+ * Tabular cells carry inline markers such as
+ *   [[document:<id>||page:3||quote:exact text]]
+ *   [[document:<id>||sheet:Summary||cell:B7||quote:42]]
+ * embedded directly in the cell's "summary" and "reasoning" text. Unlike chat
+ * citations (which flow through verifyDocumentCitations), these markers were
+ * previously persisted exactly as the model produced them. This module runs
+ * every marker through the same quote-location engine used for chat:
+ *   - a verified quote that drifted from the source is corrected to the exact
+ *     source excerpt, so highlights resolve and the UI never shows text as the
+ *     source's words when it is not;
+ *   - a quote that cannot be located gains an `unverified:true` field, which
+ *     the frontend renders as an explicit warning instead of a working
+ *     pinpoint citation.
+ *
+ * Non-citation double-bracket markers (Yes/No pills, tag pills such as
+ * [[Confidential]]) are left untouched: only markers with a page or
+ * sheet+cell locator and a quote are treated as citations, mirroring the
+ * frontend parser in frontend/src/app/components/tabular/citation-utils.ts.
+ */
+
+// Mirror of the frontend inline-marker pattern (citation-utils.ts).
+const INLINE_MARKER_RE = /\[\[((?:[^\[\]]|\[[^\]]*\])+)\]\]/g;
+
+// Legacy page form that may omit the explicit "quote:" prefix.
+const PAGE_CITATION_RE =
+  /^(?:document:([^|]+)\|\|)?page:(\d+)\|\|(?:quote:)?([\s\S]+)$/i;
+
+export type TabularCellSources = {
+  /** All row source documents concatenated, as sent to the model. */
+  combined: string;
+  /** Extracted text per source document id, for pinpoint verification. */
+  byDocId: Map<string, string>;
+};
+
+type ParsedMarker = {
+  documentId?: string;
+  /** Locator fields verbatim, without the trailing quote field. */
+  locator: string;
+  quote: string;
+};
+
+function parseMarker(rawMetadata: string): ParsedMarker | null {
+  const quoteSeparator = rawMetadata.search(/\|\|quote:/i);
+  if (quoteSeparator >= 0) {
+    const locatorParts = rawMetadata.slice(0, quoteSeparator).split("||");
+    const quote = rawMetadata
+      .slice(quoteSeparator)
+      .replace(/^\|\|quote:/i, "")
+      .trim();
+    if (!quote) return null;
+
+    const fields = new Map<string, string>();
+    for (const part of locatorParts) {
+      const separator = part.indexOf(":");
+      if (separator < 0) continue;
+      const key = part.slice(0, separator).trim().toLowerCase();
+      const value = part.slice(separator + 1).trim();
+      if (value) fields.set(key, value);
+    }
+
+    const hasPage = fields.has("page");
+    const hasSheetCell =
+      fields.has("sheet") &&
+      (fields.has("cell") ||
+        (fields.has("row") && (fields.has("col") || fields.has("column"))));
+    // Not a recognizable citation locator (e.g. a tag pill) — leave untouched.
+    if (!hasPage && !hasSheetCell) return null;
+
+    // Drop any pre-existing unverified flag so re-verification always
+    // reflects the current outcome rather than stacking or retaining stale
+    // annotations.
+    const locator = locatorParts
+      .filter((part) => !/^\s*unverified\s*:/i.test(part))
+      .join("||");
+
+    return { documentId: fields.get("document"), locator, quote };
+  }
+
+  const match = rawMetadata.match(PAGE_CITATION_RE);
+  if (!match) return null;
+  const documentId = match[1]?.trim() || undefined;
+  const locator = `${documentId ? `document:${documentId}||` : ""}page:${match[2]}`;
+  return { documentId, locator, quote: match[3].trim() };
+}
+
+/**
+ * Verify every inline citation marker in `text` against the row's source
+ * documents, correcting drifted quotes and flagging unlocatable ones.
+ */
+export function verifyInlineCitations(
+  text: string,
+  sources: TabularCellSources,
+): string {
+  if (!text || !text.includes("[[")) return text;
+  INLINE_MARKER_RE.lastIndex = 0;
+  return text.replace(INLINE_MARKER_RE, (fullMarker, rawMetadata: string) => {
+    const parsed = parseMarker(rawMetadata);
+    if (!parsed) return fullMarker;
+
+    // Verify strictly against the cited document when one is named: an
+    // unknown document id or an unreadable/empty extraction must fail
+    // verification rather than silently matching text from a different
+    // document in the same row. The combined text is only used for legacy
+    // markers that carry no document id.
+    let source: string;
+    if (parsed.documentId) {
+      const docText = sources.byDocId.get(parsed.documentId);
+      if (docText === undefined) {
+        return `[[${parsed.locator}||unverified:true||quote:${parsed.quote}]]`;
+      }
+      source = docText;
+    } else {
+      source = sources.combined;
+    }
+    const result = verifyQuoteAgainstSource(source, parsed.quote);
+
+    if (!result.verified) {
+      return `[[${parsed.locator}||unverified:true||quote:${parsed.quote}]]`;
+    }
+
+    // Swap the exact source text in when the quote drifted, unless the
+    // excerpt itself would corrupt the marker syntax.
+    const corrected =
+      result.needs_correction &&
+      result.source_excerpt &&
+      !result.source_excerpt.includes("[[") &&
+      !result.source_excerpt.includes("]]")
+        ? result.source_excerpt
+        : parsed.quote;
+    return `[[${parsed.locator}||quote:${corrected}]]`;
+  });
+}
+
+/**
+ * Verify the citations inside a generated tabular cell result before it is
+ * persisted or streamed to the client.
+ */
+export function verifyTabularCellResult<
+  T extends { summary: string; reasoning: string },
+>(result: T, sources: TabularCellSources): T {
+  return {
+    ...result,
+    summary: verifyInlineCitations(result.summary, sources),
+    reasoning: verifyInlineCitations(result.reasoning, sources),
+  };
+}

--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -36,6 +36,10 @@ import {
 } from "../lib/access";
 import { safeErrorLog, safeErrorMessage } from "../lib/safeError";
 import {
+    verifyTabularCellResult,
+    type TabularCellSources,
+} from "../lib/chat/verifyTabularCitations";
+import {
     findMissingUserEmails,
     loadProfileUsersByEmail,
 } from "../lib/userLookup";
@@ -431,14 +435,15 @@ async function loadReviewRows(
     }));
 }
 
-async function loadRowDocumentText(
+async function loadRowDocumentSources(
     db: SupabaseDb,
     row: ReviewRow,
-): Promise<string> {
+): Promise<TabularCellSources> {
     const sourceIds =
         row.source_document_ids ?? (row.document_id ? [row.document_id] : []);
     const docs = await fetchSourceDocuments(db, sourceIds);
     const sections: string[] = [];
+    const byDocId = new Map<string, string>();
     for (const doc of docs) {
         const storagePath = (doc as SourceDocument & { storage_path?: string })
             .storage_path;
@@ -459,11 +464,12 @@ async function loadRowDocumentText(
                 }
             }
         }
+        byDocId.set(String(doc.id), markdown);
         sections.push(
             `## Source document: ${doc.filename}\nSource document ID: ${doc.id}\n\n${markdown}`,
         );
     }
-    return sections.join("\n\n---\n\n");
+    return { combined: sections.join("\n\n---\n\n"), byDocId };
 }
 
 function providerLabel(provider: Provider): string {
@@ -1111,19 +1117,19 @@ tabularRouter.post(
             .eq("row_id", row.id)
             .eq("column_index", column_index);
 
-        const markdown = await loadRowDocumentText(db, row);
+        const sources = await loadRowDocumentSources(db, row);
 
-        const result = await queryTabularCell(
+        const rawResult = await queryTabularCell(
             tabular_model,
             row.label,
-            markdown,
+            sources.combined,
             column.prompt,
             column.format,
             column.tags,
             api_keys,
         );
 
-        if (!result) {
+        if (!rawResult) {
             await db
                 .from("tabular_cells")
                 .update({ status: "error" })
@@ -1132,6 +1138,8 @@ tabularRouter.post(
                 .eq("column_index", column_index);
             return void res.status(500).json({ detail: "Generation failed" });
         }
+
+        const result = verifyTabularCellResult(rawResult, sources);
 
         await db
             .from("tabular_cells")
@@ -1214,10 +1222,7 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
     try {
         await Promise.all(
             rows.map(async (row) => {
-                const markdown = await loadRowDocumentText(
-                    db,
-                    row,
-                );
+                const sources = await loadRowDocumentSources(db, row);
 
                 // Filter to only columns that need processing
                 const columnsToProcess = columns.filter((col) => {
@@ -1254,10 +1259,14 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
                     await queryTabularAllColumns(
                         tabular_model,
                         row.label,
-                        markdown,
+                        sources.combined,
                         columnsToProcess,
-                        async (columnIndex, result) => {
+                        async (columnIndex, rawResult) => {
                             receivedColumns.add(columnIndex);
+                            const result = verifyTabularCellResult(
+                                rawResult,
+                                sources,
+                            );
                             await db
                                 .from("tabular_cells")
                                 .update({

--- a/frontend/src/app/components/tabular/TRSidePanel.tsx
+++ b/frontend/src/app/components/tabular/TRSidePanel.tsx
@@ -758,7 +758,12 @@ function CitationBadge({
             data-cell={citation.cell}
             data-document-id={citation.documentId}
             data-quote={citation.quote}
-            title={`${formatCitationLocation(citation)}: "${citation.quote}"`}
+            data-unverified={citation.unverified ? "true" : undefined}
+            title={
+                citation.unverified
+                    ? `Could not verify quote — not found in the source. ${formatCitationLocation(citation)}: "${citation.quote}"`
+                    : `${formatCitationLocation(citation)}: "${citation.quote}"`
+            }
             onClick={() =>
                 onClick({
                     quote: citation.quote,
@@ -769,7 +774,11 @@ function CitationBadge({
                     citationRef: index + 1,
                 })
             }
-            className="inline-flex items-center justify-center rounded-full bg-gray-200 w-3.5 h-3.5 text-[9px] font-medium text-gray-700 align-super cursor-pointer hover:bg-gray-300 transition-colors"
+            className={`inline-flex items-center justify-center rounded-full w-3.5 h-3.5 text-[9px] font-medium align-super cursor-pointer transition-colors ${
+                citation.unverified
+                    ? "bg-red-100 text-red-700 hover:bg-red-200"
+                    : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+            }`}
         >
             {index + 1}
         </button>

--- a/frontend/src/app/components/tabular/TabularCell.tsx
+++ b/frontend/src/app/components/tabular/TabularCell.tsx
@@ -121,9 +121,12 @@ function CellMarkdown({
                         const idx = parseInt(citMatch[1]);
                         const citation = citations[idx];
                         if (citation) {
+                            const title = citation.unverified
+                                ? `Could not verify quote — not found in the source. ${formatCitationLocation(citation)}: "${citation.quote}"`
+                                : `${formatCitationLocation(citation)}: "${citation.quote}"`;
                             return (
                                 <span
-                                    title={`${formatCitationLocation(citation)}: "${citation.quote}"`}
+                                    title={title}
                                     onClick={(e) => {
                                         e.stopPropagation();
                                         if (onCitationClick) {
@@ -139,7 +142,11 @@ function CellMarkdown({
                                             onExpand();
                                         }
                                     }}
-                                    className="mx-0.5 inline-flex items-center justify-center rounded-full bg-gray-200 w-3.5 h-3.5 text-[9px] font-medium text-gray-700 align-super cursor-pointer hover:bg-gray-300 transition-colors"
+                                    className={`mx-0.5 inline-flex items-center justify-center rounded-full w-3.5 h-3.5 text-[9px] font-medium align-super cursor-pointer transition-colors ${
+                                        citation.unverified
+                                            ? "bg-red-100 text-red-700 hover:bg-red-200"
+                                            : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+                                    }`}
                                 >
                                     {idx + 1}
                                 </span>

--- a/frontend/src/app/components/tabular/citation-utils.test.ts
+++ b/frontend/src/app/components/tabular/citation-utils.test.ts
@@ -45,4 +45,36 @@ describe("preprocessCitations", () => {
             },
         ]);
     });
+
+    it("parses an unverified page citation", () => {
+        const result = preprocessCitations(
+            "Value [[document:doc-2||page:4||unverified:true||quote:Missing language]]",
+        );
+
+        expect(result.processed).toBe("Value §0§");
+        expect(result.citations).toEqual([
+            {
+                documentId: "doc-2",
+                page: 4,
+                quote: "Missing language",
+                unverified: true,
+            },
+        ]);
+    });
+
+    it("parses an unverified spreadsheet citation", () => {
+        const result = preprocessCitations(
+            "Value [[document:doc-sheet||sheet:Summary||cell:B7||unverified:true||quote:42]]",
+        );
+
+        expect(result.citations).toEqual([
+            {
+                documentId: "doc-sheet",
+                sheet: "Summary",
+                cell: "B7",
+                quote: "42",
+                unverified: true,
+            },
+        ]);
+    });
 });

--- a/frontend/src/app/components/tabular/citation-utils.ts
+++ b/frontend/src/app/components/tabular/citation-utils.ts
@@ -8,6 +8,12 @@ export interface ParsedCitation {
     sheet?: string;
     cell?: string;
     quote: string;
+    /**
+     * Set when server-side verification could not locate the quote in the
+     * source document. Unverified citations render as warnings, not as
+     * working pinpoint citations.
+     */
+    unverified?: boolean;
 }
 
 /**
@@ -38,13 +44,14 @@ export function preprocessCitations(text: string): {
 
 function parsePageCitation(metadata: string): ParsedCitation | null {
     const match = metadata.match(
-        /^(?:document:([^|]+)\|\|)?page:(\d+)\|\|(?:quote:)?([\s\S]+)$/i,
+        /^(?:document:([^|]+)\|\|)?page:(\d+)\|\|(?:unverified:(true)\|\|)?(?:quote:)?([\s\S]+)$/i,
     );
     if (!match) return null;
     return {
         documentId: match[1]?.trim() || undefined,
         page: parseInt(match[2], 10),
-        quote: match[3].trim(),
+        quote: match[4].trim(),
+        ...(match[3] ? { unverified: true } : {}),
     };
 }
 
@@ -79,5 +86,8 @@ function parseSpreadsheetCitation(metadata: string): ParsedCitation | null {
         sheet,
         cell,
         quote,
+        ...(fields.get("unverified")?.toLowerCase() === "true"
+            ? { unverified: true }
+            : {}),
     };
 }


### PR DESCRIPTION
Chat citations flow through `verifyDocumentCitations`, which locates every
quote in the extracted source, corrects drifted quotes to the exact source
excerpt, and flags unverifiable ones in the UI. Tabular review cells got none
of this: the inline `[[document:...||page:N||quote:...]]` markers in cell
`summary`/`reasoning` were persisted exactly as the model produced them, so
the review grid — the surface most likely to be exported into diligence work
product — carried weaker grounding than chat.

This PR runs every tabular cell citation through the same quote-location
engine at generation time, in both the full-review run and the single-cell
regenerate path:

- **Drifted quotes are corrected** to the exact source excerpt, so viewer
  highlights resolve and the UI never presents text as the source's words
  when it is not.
- **Unlocatable quotes gain an `unverified:true` field** in the marker; the
  grid cell and detail panel render those pills red with a "Could not verify
  quote — not found in the source" tooltip, mirroring chat's unverified
  treatment.
- **Verification is strict per cited document**: a citation naming an unknown
  document id, or a document whose extraction is empty/unreadable, fails
  verification rather than silently matching text from a different document
  in the same folder-grouped row. The combined row text is only used for
  legacy markers with no document id.
- **Non-citation markers pass through untouched**: Yes/No pills, currency and
  tag pills share the double-bracket syntax and are recognized by locator
  shape, mirroring the frontend parser.

Implementation notes:

- New `backend/src/lib/chat/verifyTabularCitations.ts` (verification +
  marker rewriting; idempotent under re-verification, stale flags cleared).
- `loadRowDocumentText` becomes `loadRowDocumentSources`, returning per-
  document extractions alongside the combined text so verification can
  pinpoint the cited file within multi-document rows.
- Frontend `citation-utils.ts` parses the new field; `TabularCell.tsx` and
  `TRSidePanel.tsx` style unverified pills. No changes to citation click
  handling or the document viewers.

**Testing:** adds `verifyTabularCitations.test.ts` (12 cases: exact, drifted,
fabricated, wrong-document, unknown-document, spreadsheet-cell, legacy,
pill passthrough, idempotence, stale-flag clearing) and extends
`citation-utils.test.ts` with unverified page/spreadsheet parsing cases.
Backend `tsc` + full vitest suite (507 passed) and frontend `next build` +
full vitest suite (238 passed) are green on this branch.

Generated with Claude Code