### PR TITLE
Add Claude Opus 5 medium cost controls

### DIFF
--- a/backend/src/__tests__/integration/chat.routes.test.ts
+++ b/backend/src/__tests__/integration/chat.routes.test.ts
@@ -109,6 +109,21 @@ describe("POST /chat — streaming endpoint", () => {
         expect(res.headers["content-type"]).toContain("text/event-stream");
         expect(res.text).toContain('"type":"chat_id"');
         expect(runLLMStream).toHaveBeenCalledTimes(1);
+        expect(runLLMStream.mock.calls[0][0]).toMatchObject({
+            reasoningEffort: "medium",
+        });
+    });
+
+    it("passes an explicitly selected reasoning effort to the LLM stream", async () => {
+        const res = await request(app)
+            .post("/chat")
+            .set("Authorization", "Bearer test")
+            .send({ ...VALID_BODY, reasoning_effort: "low" });
+
+        expect(res.status).toBe(200);
+        expect(runLLMStream.mock.calls[0][0]).toMatchObject({
+            reasoningEffort: "low",
+        });
     });
 
     it("surfaces a stream failure as an in-stream error event, not an HTTP error", async () => {
@@ -166,6 +181,10 @@ describe("POST /chat — streaming endpoint", () => {
         [
             { ...VALID_BODY, ask_inputs_response: { responses: [] } },
             "ask_inputs_response.responses must be a non-empty array",
+        ],
+        [
+            { ...VALID_BODY, reasoning_effort: "xhigh" },
+            'reasoning_effort must be "low", "medium", or "high"',
         ],
     ])("shares strict request validation with project chat", async (body, detail) => {
         const res = await request(app)

--- a/backend/src/__tests__/integration/projectChat.routes.test.ts
+++ b/backend/src/__tests__/integration/projectChat.routes.test.ts
@@ -167,6 +167,7 @@ describe("POST /projects/:projectId/chat", () => {
                     },
                 ],
                 model: " custom-model ",
+                reasoning_effort: "low",
                 displayed_doc: {
                     filename: " displayed.pdf ",
                     document_id: " displayed-document ",
@@ -205,6 +206,7 @@ describe("POST /projects/:projectId/chat", () => {
         expect(systemPromptExtra).toContain("attached.pdf");
         expect(runLLMStream.mock.calls[0][0]).toMatchObject({
             model: "custom-model",
+            reasoningEffort: "low",
         });
     });
 
@@ -224,6 +226,10 @@ describe("POST /projects/:projectId/chat", () => {
         [
             { ...VALID_BODY, model: 42 },
             "model must be a non-empty string",
+        ],
+        [
+            { ...VALID_BODY, reasoning_effort: "max" },
+            'reasoning_effort must be "low", "medium", or "high"',
         ],
         [
             {

--- a/backend/src/__tests__/integration/tabular.routes.test.ts
+++ b/backend/src/__tests__/integration/tabular.routes.test.ts
@@ -874,6 +874,21 @@ describe("tabular.routes", () => {
 
     // ── POST /tabular-review/:reviewId/chat (streaming GUARDS only) ───────
     describe("POST /tabular-review/:reviewId/chat", () => {
+        it("returns 400 for an unsupported reasoning effort", async () => {
+            const res = await request(app)
+                .post("/tabular-review/r1/chat")
+                .set(...AUTH)
+                .send({
+                    messages: [{ role: "user", content: "hello" }],
+                    reasoning_effort: "max",
+                });
+
+            expect(res.status).toBe(400);
+            expect(res.body.detail).toBe(
+                'reasoning_effort must be "low", "medium", or "high"',
+            );
+        });
+
         it("returns 400 when no user message is present", async () => {
             const res = await request(app)
                 .post("/tabular-review/r1/chat")

--- a/backend/src/lib/__tests__/claude.test.ts
+++ b/backend/src/lib/__tests__/claude.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createMock, streamMock } = vi.hoisted(() => ({
+    createMock: vi.fn(),
+    streamMock: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+    default: class AnthropicMock {
+        messages = { create: createMock, stream: streamMock };
+    },
+}));
+
+import { completeClaudeText, streamClaude } from "../llm/claude";
+
+function finishedStream() {
+    const stream = {
+        abort: vi.fn(),
+        on: vi.fn(() => stream),
+        finalMessage: vi.fn(async () => ({
+            stop_reason: "end_turn",
+            content: [{ type: "text", text: "Done" }],
+            usage: {
+                input_tokens: 120,
+                cache_creation_input_tokens: 80,
+                cache_read_input_tokens: 40,
+                output_tokens: 12,
+            },
+        })),
+    };
+    return stream;
+}
+
+describe("Claude cost controls", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        streamMock.mockReturnValue(finishedStream());
+    });
+
+    it("sends Opus 5 medium reasoning with automatic and tool-prefix caching", async () => {
+        const usageLog = vi.spyOn(console, "info").mockImplementation(() => {});
+
+        await expect(
+            streamClaude({
+                model: "claude-opus-5",
+                systemPrompt: "You are Mike.",
+                messages: [{ role: "user", content: "Hello" }],
+                tools: [
+                    {
+                        type: "function",
+                        function: {
+                            name: "lookup",
+                            description: "Look something up",
+                            parameters: { type: "object", properties: {} },
+                        },
+                    },
+                ],
+                enableThinking: true,
+                reasoningEffort: "medium",
+                apiKeys: { claude: "sk-ant-test" },
+            }),
+        ).resolves.toEqual({ fullText: "Done" });
+
+        expect(streamMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                model: "claude-opus-5",
+                cache_control: { type: "ephemeral" },
+                thinking: { type: "adaptive", display: "summarized" },
+                output_config: { effort: "medium" },
+                tools: [
+                    expect.objectContaining({
+                        name: "lookup",
+                        cache_control: { type: "ephemeral" },
+                    }),
+                ],
+            }),
+        );
+        expect(usageLog).toHaveBeenCalledWith("[claude-usage]", {
+            model: "claude-opus-5",
+            iteration: 0,
+            reasoningEffort: "medium",
+            inputTokens: 120,
+            cacheCreationInputTokens: 80,
+            cacheReadInputTokens: 40,
+            outputTokens: 12,
+        });
+
+        usageLog.mockRestore();
+    });
+
+    it("caches the stable system prefix for repeated one-shot jobs", async () => {
+        createMock.mockResolvedValue({
+            content: [{ type: "text", text: "Result" }],
+        });
+
+        await expect(
+            completeClaudeText({
+                model: "claude-opus-5",
+                systemPrompt: "Extract the requested legal field.",
+                user: "Document text",
+                apiKeys: { claude: "sk-ant-test" },
+            }),
+        ).resolves.toBe("Result");
+
+        expect(createMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                system: [
+                    {
+                        type: "text",
+                        text: "Extract the requested legal field.",
+                        cache_control: { type: "ephemeral" },
+                    },
+                ],
+            }),
+        );
+    });
+});

--- a/backend/src/lib/__tests__/llmModels.test.ts
+++ b/backend/src/lib/__tests__/llmModels.test.ts
@@ -58,12 +58,22 @@ describe("providerForModel", () => {
 
 describe("resolveModel", () => {
     it("returns a known model id unchanged", () => {
+        expect(resolveModel("claude-opus-5", DEFAULT_MAIN_MODEL)).toBe(
+            "claude-opus-5",
+        );
         expect(resolveModel("claude-sonnet-4-6", DEFAULT_MAIN_MODEL)).toBe(
             "claude-sonnet-4-6",
         );
         expect(resolveModel("gpt-5.4-lite", DEFAULT_TITLE_MODEL)).toBe(
             "gpt-5.4-lite",
         );
+    });
+
+    it("migrates the retired Opus 4.7 selection to Opus 5", () => {
+        expect(resolveModel("claude-opus-4-7", DEFAULT_MAIN_MODEL)).toBe(
+            "claude-opus-5",
+        );
+        expect(CLAUDE_MAIN_MODELS).not.toContain("claude-opus-4-7");
     });
 
     it("falls back for unknown model ids", () => {

--- a/backend/src/lib/chat/__tests__/requestValidation.test.ts
+++ b/backend/src/lib/chat/__tests__/requestValidation.test.ts
@@ -7,6 +7,7 @@ import {
     parseOptionalDisplayedDoc,
     parseOptionalModel,
     parseOptionalProjectId,
+    parseReasoningEffort,
 } from "../requestValidation";
 
 describe("chat request validation", () => {
@@ -98,6 +99,26 @@ describe("chat request validation", () => {
             value: { provided: false, projectId: null },
         });
     });
+
+    it("defaults reasoning to medium and accepts the supported cost controls", () => {
+        expect(parseReasoningEffort(undefined)).toEqual({
+            ok: true,
+            value: "medium",
+        });
+        for (const value of ["low", "medium", "high"]) {
+            expect(parseReasoningEffort(value)).toEqual({ ok: true, value });
+        }
+    });
+
+    it.each([null, "xhigh", "max", " medium ", 1])(
+        "rejects unsupported reasoning effort %j",
+        (value) => {
+            expect(parseReasoningEffort(value)).toEqual({
+                ok: false,
+                detail: 'reasoning_effort must be "low", "medium", or "high"',
+            });
+        },
+    );
 
     it.each([
         [parseOptionalChatId, " ", "chat_id must be a non-empty string"],

--- a/backend/src/lib/chat/requestValidation.ts
+++ b/backend/src/lib/chat/requestValidation.ts
@@ -1,5 +1,10 @@
 import { parseAskInputsResponsePayload } from "./contextBuilders";
 import type { AskInputsResponseRequest, ChatMessage } from "./types";
+import {
+  DEFAULT_REASONING_EFFORT,
+  isReasoningEffort,
+  type ReasoningEffort,
+} from "../llm";
 
 type ValidationResult<T> =
   | { ok: true; value: T }
@@ -58,6 +63,21 @@ export function parseOptionalModel(
 ): ValidationResult<string | undefined> {
   if (value === undefined) return { ok: true, value: undefined };
   return parseNonEmptyString(value, "model must be a non-empty string");
+}
+
+export function parseReasoningEffort(
+  value: unknown,
+): ValidationResult<ReasoningEffort> {
+  if (value === undefined) {
+    return { ok: true, value: DEFAULT_REASONING_EFFORT };
+  }
+  if (!isReasoningEffort(value)) {
+    return {
+      ok: false,
+      detail: 'reasoning_effort must be "low", "medium", or "high"',
+    };
+  }
+  return { ok: true, value };
 }
 
 function parseMessageFiles(

--- a/backend/src/lib/chat/streaming.ts
+++ b/backend/src/lib/chat/streaming.ts
@@ -160,6 +160,7 @@ export async function runLLMStream(params: {
   buildCitations?: (fullText: string) => unknown[];
   model?: string;
   apiKeys?: import("../llm").UserApiKeys;
+  reasoningEffort?: import("../llm").ReasoningEffort;
   signal?: AbortSignal;
   /**
    * If set, generate_docx will attach created docs to this project so
@@ -190,6 +191,7 @@ export async function runLLMStream(params: {
     buildCitations,
     model,
     apiKeys,
+    reasoningEffort,
     signal,
     projectId,
     nonce,
@@ -349,6 +351,7 @@ export async function runLLMStream(params: {
       maxIterations: 10,
       apiKeys,
       enableThinking: true,
+      reasoningEffort,
       abortSignal: signal,
       callbacks: {
         onContentDelta: (delta) => {

--- a/backend/src/lib/llm/claude.ts
+++ b/backend/src/lib/llm/claude.ts
@@ -8,6 +8,7 @@ import type {
 } from "./types";
 import { toClaudeTools } from "./tools";
 import { createRawLlmStreamRecorder, logRawLlmStream } from "./rawStreamLog";
+import { DEFAULT_REASONING_EFFORT } from "./models";
 
 type ContentBlock =
   | { type: "text"; text: string }
@@ -20,6 +21,15 @@ type NativeMessage = {
 };
 
 const MAX_TOKENS = 16384;
+const CACHE_CONTROL = { type: "ephemeral" } as const;
+
+function cachedSystemPrompt(
+  value?: string,
+): Anthropic.TextBlockParam[] | undefined {
+  return value
+    ? [{ type: "text", text: value, cache_control: CACHE_CONTROL }]
+    : undefined;
+}
 
 function apiKey(override?: string | null): string {
   const key = override?.trim() || process.env.ANTHROPIC_API_KEY?.trim() || "";
@@ -112,10 +122,20 @@ export async function streamClaude(
     runTools,
     apiKeys,
     enableThinking,
+    reasoningEffort,
   } = params;
   const maxIter = params.maxIterations ?? 10;
   const anthropic = client(apiKeys?.claude);
   const claudeTools = toClaudeTools(tools);
+  const cachedClaudeTools = claudeTools.map((tool, index) =>
+    index === claudeTools.length - 1
+      ? { ...tool, cache_control: CACHE_CONTROL }
+      : tool,
+  );
+  const effectiveReasoningEffort =
+    model === "claude-opus-5"
+      ? (reasoningEffort ?? DEFAULT_REASONING_EFFORT)
+      : "high";
 
   const messages: NativeMessage[] = toNativeMessages(params.messages);
   let fullText = "";
@@ -131,18 +151,23 @@ export async function streamClaude(
         model,
         system: systemPrompt,
         messages: messages as Anthropic.MessageParam[],
-        tools: claudeTools.length
-          ? (claudeTools as unknown as Tool[])
+        tools: cachedClaudeTools.length
+          ? (cachedClaudeTools as unknown as Tool[])
           : undefined,
+        // Automatic caching advances with the conversation. The explicit
+        // marker on the last tool preserves the large stable tool prefix even
+        // when Mike's per-request prompt-injection nonce changes the system.
+        cache_control: CACHE_CONTROL,
         max_tokens: MAX_TOKENS,
-        // Claude 4.x models require `thinking.type: "adaptive"` and
-        // drive effort via `output_config.effort` rather than a fixed
-        // token budget. We only opt in when the caller requested it.
+        // Adaptive-thinking models drive effort via `output_config.effort`
+        // rather than a fixed token budget. We only opt in when requested.
         ...(enableThinking
           ? ({
-              thinking: { type: "adaptive" },
-              output_config: { effort: "high" },
-            } as unknown as Record<string, unknown>)
+              thinking: { type: "adaptive", display: "summarized" },
+              output_config: {
+                effort: effectiveReasoningEffort,
+              },
+            } as const)
           : {}),
         // Extended thinking requires temperature to be default (omitted).
       });
@@ -208,6 +233,16 @@ export async function streamClaude(
       } finally {
         params.abortSignal?.removeEventListener("abort", abortStream);
       }
+      console.info("[claude-usage]", {
+        model,
+        iteration: iter,
+        reasoningEffort: effectiveReasoningEffort,
+        inputTokens: final.usage.input_tokens,
+        cacheCreationInputTokens:
+          final.usage.cache_creation_input_tokens ?? 0,
+        cacheReadInputTokens: final.usage.cache_read_input_tokens ?? 0,
+        outputTokens: final.usage.output_tokens,
+      });
       if (sawThinking) callbacks.onReasoningBlockEnd?.();
       throwIfAborted(params.abortSignal);
       const stopReason = final.stop_reason;
@@ -278,7 +313,10 @@ export async function completeClaudeText(params: {
     resp = await anthropic.messages.create({
       model: params.model,
       max_tokens: params.maxTokens ?? 512,
-      system: params.systemPrompt,
+      // One-shot tabular jobs reuse a stable system prompt with changing
+      // document inputs, so cache that prefix without paying to cache every
+      // unique user payload.
+      system: cachedSystemPrompt(params.systemPrompt),
       messages: [{ role: "user", content: params.user }],
     });
   } catch (error) {

--- a/backend/src/lib/llm/models.ts
+++ b/backend/src/lib/llm/models.ts
@@ -1,4 +1,4 @@
-import type { Provider } from "./types";
+import type { Provider, ReasoningEffort } from "./types";
 
 // ---------------------------------------------------------------------------
 // Canonical model IDs
@@ -6,8 +6,8 @@ import type { Provider } from "./types";
 // Main-chat tier (top-end) — user picks one of these per message.
 export const CLAUDE_MAIN_MODELS = [
     "claude-fable-5",
+    "claude-opus-5",
     "claude-opus-4-8",
-    "claude-opus-4-7",
     "claude-sonnet-4-6",
 ] as const;
 export const GEMINI_MAIN_MODELS = [
@@ -33,6 +33,8 @@ export const OPENAI_LOW_MODELS = ["gpt-5.4-lite"] as const;
 export const DEFAULT_MAIN_MODEL = "gemini-3-flash-preview";
 export const DEFAULT_TITLE_MODEL = "gemini-3.1-flash-lite-preview";
 export const DEFAULT_TABULAR_MODEL = "gemini-3-flash-preview";
+export const DEFAULT_REASONING_EFFORT: ReasoningEffort = "medium";
+export const REASONING_EFFORTS = ["low", "medium", "high"] as const;
 
 const ALL_MODELS = new Set<string>([
     ...CLAUDE_MAIN_MODELS,
@@ -59,6 +61,14 @@ export function providerForModel(model: string): Provider {
 }
 
 export function resolveModel(id: string | null | undefined, fallback: string): string {
+    if (id === "claude-opus-4-7") return "claude-opus-5";
     if (id && (ALL_MODELS.has(id) || id.startsWith("ollama/"))) return id;
     return fallback;
+}
+
+export function isReasoningEffort(value: unknown): value is ReasoningEffort {
+    return (
+        typeof value === "string" &&
+        (REASONING_EFFORTS as readonly string[]).includes(value)
+    );
 }

--- a/backend/src/lib/llm/types.ts
+++ b/backend/src/lib/llm/types.ts
@@ -3,6 +3,7 @@
 // provider translates internally.
 
 export type Provider = "claude" | "gemini" | "openai" | "ollama";
+export type ReasoningEffort = "low" | "medium" | "high";
 
 export type OpenAIToolSchema = {
     type: "function";
@@ -60,6 +61,7 @@ export type StreamChatParams = {
      * one-shot completions should leave this off to save tokens and latency.
      */
     enableThinking?: boolean;
+    reasoningEffort?: ReasoningEffort;
     abortSignal?: AbortSignal;
 };
 

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -19,6 +19,7 @@ import {
     parseOptionalAskInputsResponse,
     parseOptionalChatId,
     parseOptionalModel,
+    parseReasoningEffort,
     parseOptionalProjectId,
     parseOptionalDocumentContext,
     buildWordDocumentContextPrompt,
@@ -383,6 +384,12 @@ chatRouter.post("/", requireAuth, async (req, res) => {
     if (!parsedModel.ok) {
         return void res.status(400).json({ detail: parsedModel.detail });
     }
+    const parsedReasoningEffort = parseReasoningEffort(body.reasoning_effort);
+    if (!parsedReasoningEffort.ok) {
+        return void res
+            .status(400)
+            .json({ detail: parsedReasoningEffort.detail });
+    }
     // Optional plain-text document context supplied by the Word add-in (the
     // active document body, read via Word.run() — no upload, no stored
     // document record). Injected into the LLM system prompt below.
@@ -407,6 +414,7 @@ chatRouter.post("/", requireAuth, async (req, res) => {
     const chat_id = parsedChatId.value;
     const project_id = parsedProjectId.value.projectId;
     const model = parsedModel.value;
+    const reasoningEffort = parsedReasoningEffort.value;
     const askInputsResponse = parsedAskInputsResponse.value;
 
     devLog("[chat/stream] incoming request", {
@@ -567,6 +575,7 @@ chatRouter.post("/", requireAuth, async (req, res) => {
             includeResearchTools: legalResearchUs,
             model,
             apiKeys,
+            reasoningEffort,
             signal: streamAbort.signal,
             projectId: resolvedProjectId,
             nonce,

--- a/backend/src/routes/projectChat.ts
+++ b/backend/src/routes/projectChat.ts
@@ -23,6 +23,7 @@ import {
     parseOptionalChatId,
     parseOptionalDisplayedDoc,
     parseOptionalModel,
+    parseReasoningEffort,
     type ChatMessage,
 } from "../lib/chat";
 import {
@@ -62,6 +63,12 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
     if (!parsedModel.ok) {
         return void res.status(400).json({ detail: parsedModel.detail });
     }
+    const parsedReasoningEffort = parseReasoningEffort(body.reasoning_effort);
+    if (!parsedReasoningEffort.ok) {
+        return void res
+            .status(400)
+            .json({ detail: parsedReasoningEffort.detail });
+    }
     const parsedDisplayedDoc = parseOptionalDisplayedDoc(body.displayed_doc);
     if (!parsedDisplayedDoc.ok) {
         return void res.status(400).json({ detail: parsedDisplayedDoc.detail });
@@ -86,6 +93,7 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
     const messages = parsedMessages.value;
     const chat_id = parsedChatId.value;
     const model = parsedModel.value;
+    const reasoningEffort = parsedReasoningEffort.value;
     const displayed_doc = parsedDisplayedDoc.value;
     const attached_documents = parsedAttachedDocuments.value;
     const askInputsResponse = parsedAskInputsResponse.value;
@@ -261,6 +269,7 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
             includeResearchTools: legalResearchUs,
             model,
             apiKeys,
+            reasoningEffort,
             signal: streamAbort.signal,
             projectId,
             nonce,

--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -16,6 +16,7 @@ import {
     buildCancelledAssistantMessage,
     isAbortError,
     runLLMStream,
+    parseReasoningEffort,
     stripTransientAssistantEvents,
     TABULAR_TOOLS,
     type ChatMessage,
@@ -1533,12 +1534,20 @@ tabularRouter.post("/:reviewId/chat", requireAuth, async (req, res) => {
         chat_id: existingChatId,
         review_title: clientReviewTitle,
         project_name: clientProjectName,
+        reasoning_effort: rawReasoningEffort,
     } = req.body as {
         messages: ChatMessage[];
         chat_id?: string;
         review_title?: string;
         project_name?: string;
+        reasoning_effort?: unknown;
     };
+    const parsedReasoningEffort = parseReasoningEffort(rawReasoningEffort);
+    if (!parsedReasoningEffort.ok) {
+        return void res
+            .status(400)
+            .json({ detail: parsedReasoningEffort.detail });
+    }
 
     const lastUser = [...(messages ?? [])]
         .reverse()
@@ -1679,6 +1688,7 @@ tabularRouter.post("/:reviewId/chat", requireAuth, async (req, res) => {
                 extractTabularAnnotations(text, tabularStore),
             model: tabular_model,
             apiKeys: api_keys,
+            reasoningEffort: parsedReasoningEffort.value,
             signal: streamAbort.signal,
         });
 

--- a/frontend/src/app/components/assistant/ChatInput.slashCommands.test.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.slashCommands.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/app/lib/mikeApi", () => ({
 
 vi.mock("@/app/hooks/useSelectedModel", () => ({
     useSelectedModel: () => ["claude-sonnet-4-6", vi.fn()],
+    useReasoningEffort: () => ["medium", vi.fn()],
 }));
 
 vi.mock("@/app/contexts/UserProfileContext", () => ({

--- a/frontend/src/app/components/assistant/ChatInput.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.tsx
@@ -34,7 +34,10 @@ import {
 } from "./workflowSlashCommands";
 import { ApiKeyMissingPopup } from "../popups/ApiKeyMissingPopup";
 import { ModelToggle } from "./ModelToggle";
-import { useSelectedModel } from "@/app/hooks/useSelectedModel";
+import {
+    useReasoningEffort,
+    useSelectedModel,
+} from "@/app/hooks/useSelectedModel";
 import { useUserProfile } from "@/app/contexts/UserProfileContext";
 import {
     getModelProvider,
@@ -96,6 +99,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
         title: string;
     } | null>(null);
     const [model, setModel] = useSelectedModel();
+    const [reasoningEffort, setReasoningEffort] = useReasoningEffort();
     const { profile } = useUserProfile();
     const apiKeys = profile?.apiKeys;
     const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -328,6 +332,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
             files: files.length > 0 ? files : undefined,
             workflow: workflow ?? undefined,
             model,
+            reasoningEffort,
         });
     };
 
@@ -558,6 +563,8 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                             <ModelToggle
                                 value={model}
                                 onChange={setModel}
+                                reasoningEffort={reasoningEffort}
+                                onReasoningEffortChange={setReasoningEffort}
                                 apiKeys={apiKeys}
                             />
                             <button

--- a/frontend/src/app/components/assistant/ModelToggle.test.tsx
+++ b/frontend/src/app/components/assistant/ModelToggle.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ModelToggle } from "./ModelToggle";
+
+describe("ModelToggle", () => {
+    it("keeps Opus 5 reasoning inside the existing model selector", async () => {
+        const user = userEvent.setup();
+        const onReasoningEffortChange = vi.fn();
+
+        render(
+            <ModelToggle
+                value="claude-opus-5"
+                onChange={vi.fn()}
+                reasoningEffort="medium"
+                onReasoningEffortChange={onReasoningEffortChange}
+            />,
+        );
+
+        await user.click(
+            screen.getByRole("button", { name: /Opus 5 · Medium/i }),
+        );
+
+        expect(screen.getByText("Claude Opus 5")).toBeInTheDocument();
+        expect(screen.getByText("Reasoning")).toBeInTheDocument();
+        await user.click(screen.getByRole("menuitemradio", { name: "Low" }));
+        expect(onReasoningEffortChange).toHaveBeenCalledWith("low");
+    });
+});

--- a/frontend/src/app/components/assistant/ModelToggle.tsx
+++ b/frontend/src/app/components/assistant/ModelToggle.tsx
@@ -5,16 +5,19 @@ import { ChevronDown, Check, AlertCircle } from "lucide-react";
 import {
     DropdownMenu,
     DropdownMenuLabel,
+    DropdownMenuRadioGroup,
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from "@/app/components/ui/dropdown-menu";
 import {
     LiquidDropdownContent,
     LiquidDropdownItem,
+    LiquidDropdownRadioItem,
 } from "@/app/components/ui/liquid-dropdown";
 import { isModelAvailable } from "@/app/lib/modelAvailability";
 import type { ApiKeyState } from "@/app/lib/mikeApi";
 import { useOllamaModels } from "@/app/hooks/useOllamaModels";
+import type { ReasoningEffort } from "../shared/types";
 
 export interface ModelOption {
     id: string;
@@ -24,8 +27,8 @@ export interface ModelOption {
 
 export const MODELS: ModelOption[] = [
     { id: "claude-fable-5", label: "Claude Fable 5", group: "Anthropic" },
+    { id: "claude-opus-5", label: "Claude Opus 5", group: "Anthropic" },
     { id: "claude-opus-4-8", label: "Claude Opus 4.8", group: "Anthropic" },
-    { id: "claude-opus-4-7", label: "Claude Opus 4.7", group: "Anthropic" },
     { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", group: "Anthropic" },
     { id: "gemini-3.5-flash", label: "Gemini 3.5 Flash", group: "Google" },
     { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro", group: "Google" },
@@ -49,6 +52,13 @@ export const SETTINGS_MODELS: ModelOption[] = [
 export const DEFAULT_MODEL_ID = "gemini-3-flash-preview";
 
 export const ALLOWED_MODEL_IDS = new Set(MODELS.map((m) => m.id));
+export const DEFAULT_REASONING_EFFORT: ReasoningEffort = "medium";
+
+const REASONING_OPTIONS: { id: ReasoningEffort; label: string }[] = [
+    { id: "low", label: "Low" },
+    { id: "medium", label: "Medium" },
+    { id: "high", label: "High" },
+];
 
 const GROUP_ORDER: ModelOption["group"][] = ["Anthropic", "Google", "OpenAI", "Local"];
 const itemClassName =
@@ -57,15 +67,29 @@ const itemClassName =
 interface Props {
     value: string;
     onChange: (id: string) => void;
+    reasoningEffort?: ReasoningEffort;
+    onReasoningEffortChange?: (effort: ReasoningEffort) => void;
     apiKeys?: ApiKeyState;
 }
 
-export function ModelToggle({ value, onChange, apiKeys }: Props) {
+export function ModelToggle({
+    value,
+    onChange,
+    reasoningEffort,
+    onReasoningEffortChange,
+    apiKeys,
+}: Props) {
     const [isOpen, setIsOpen] = useState(false);
     const ollamaModels = useOllamaModels();
     const models = [...MODELS, ...ollamaModels];
     const selected = models.find((m) => m.id === value);
-    const selectedLabel = selected?.label ?? "Model";
+    const showReasoning =
+        value === "claude-opus-5" &&
+        reasoningEffort !== undefined &&
+        onReasoningEffortChange !== undefined;
+    const selectedLabel = showReasoning
+        ? `${selected?.label.replace("Claude ", "") ?? "Opus 5"} · ${reasoningEffort[0].toUpperCase()}${reasoningEffort.slice(1)}`
+        : (selected?.label ?? "Model");
     const selectedAvailable = apiKeys
         ? isModelAvailable(value, apiKeys)
         : true;
@@ -137,6 +161,40 @@ export function ModelToggle({ value, onChange, apiKeys }: Props) {
                         </div>
                     );
                 })}
+                {showReasoning && (
+                    <>
+                        <DropdownMenuSeparator className="-mx-1 my-1 bg-white/70" />
+                        <DropdownMenuLabel className="text-[10px] uppercase tracking-wider text-gray-400">
+                            Reasoning
+                        </DropdownMenuLabel>
+                        <DropdownMenuRadioGroup
+                            value={reasoningEffort}
+                            onValueChange={(next) => {
+                                const option = REASONING_OPTIONS.find(
+                                    ({ id }) => id === next,
+                                );
+                                if (option) {
+                                    onReasoningEffortChange(option.id);
+                                }
+                            }}
+                        >
+                            {REASONING_OPTIONS.map((option) => (
+                                <LiquidDropdownRadioItem
+                                    key={option.id}
+                                    value={option.id}
+                                    className={itemClassName}
+                                >
+                                    <span className="flex-1">
+                                        {option.label}
+                                    </span>
+                                    {option.id === reasoningEffort && (
+                                        <Check className="ml-1 h-3.5 w-3.5 text-gray-600" />
+                                    )}
+                                </LiquidDropdownRadioItem>
+                            ))}
+                        </DropdownMenuRadioGroup>
+                    </>
+                )}
             </LiquidDropdownContent>
         </DropdownMenu>
     );

--- a/frontend/src/app/components/shared/types.ts
+++ b/frontend/src/app/components/shared/types.ts
@@ -314,12 +314,15 @@ export interface Message {
   files?: { filename: string; document_id?: string }[];
   workflow?: { id: string; title: string };
   model?: string;
+  reasoningEffort?: ReasoningEffort;
   citations?: Citation[];
   citationStatus?: "started" | "partial" | "final";
   events?: AssistantEvent[];
   /** Set when streaming failed; rendered as a red error block. */
   error?: string;
 }
+
+export type ReasoningEffort = "low" | "medium" | "high";
 
 export interface CitationQuote {
   page?: number;

--- a/frontend/src/app/components/tabular/TRChatPanel.tsx
+++ b/frontend/src/app/components/tabular/TRChatPanel.tsx
@@ -26,7 +26,7 @@ import {
     type TRChat,
     type TRCitationAnnotation,
 } from "@/app/lib/mikeApi";
-import type { AssistantEvent } from "../shared/types";
+import type { AssistantEvent, ReasoningEffort } from "../shared/types";
 import { ModelToggle } from "../assistant/ModelToggle";
 import { ApiKeyMissingPopup } from "../popups/ApiKeyMissingPopup";
 import { PreResponseWrapper } from "../assistant/PreResponseWrapper";
@@ -52,6 +52,7 @@ import {
     LiquidDropdownSurface,
 } from "@/app/components/ui/liquid-dropdown";
 import { cn } from "@/app/lib/utils";
+import { useReasoningEffort } from "@/app/hooks/useSelectedModel";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -439,6 +440,8 @@ function TRChatInput({
     onCancel,
     model,
     onModelChange,
+    reasoningEffort,
+    onReasoningEffortChange,
     apiKeys,
     onHeightChange,
 }: {
@@ -447,6 +450,8 @@ function TRChatInput({
     onCancel: () => void;
     model: string;
     onModelChange: (id: string) => void;
+    reasoningEffort: ReasoningEffort;
+    onReasoningEffortChange: (effort: ReasoningEffort) => void;
     apiKeys?: ApiKeyState;
     onHeightChange: (height: number) => void;
 }) {
@@ -531,6 +536,8 @@ function TRChatInput({
                     <ModelToggle
                         value={model}
                         onChange={onModelChange}
+                        reasoningEffort={reasoningEffort}
+                        onReasoningEffortChange={onReasoningEffortChange}
                         apiKeys={apiKeys}
                     />
                     <button
@@ -762,6 +769,7 @@ export function TRChatPanel({
     const { profile, updateModelPreference } = useUserProfile();
     const apiKeys = profile?.apiKeys;
     const currentModel = profile?.tabularModel ?? "gemini-3-flash-preview";
+    const [reasoningEffort, setReasoningEffort] = useReasoningEffort();
     const [apiKeyModalProvider, setApiKeyModalProvider] =
         useState<ModelProvider | null>(null);
     const [chats, setChats] = useState<TRChat[]>([]);
@@ -1179,7 +1187,7 @@ export function TRChatPanel({
                 allMessages,
                 currentChatId,
                 controller.signal,
-                { reviewTitle, projectName },
+                { reviewTitle, projectName, reasoningEffort },
             );
             if (!response.body) throw new Error("No response body");
 
@@ -1913,6 +1921,8 @@ export function TRChatPanel({
                 onModelChange={(id) =>
                     updateModelPreference("tabularModel", id)
                 }
+                reasoningEffort={reasoningEffort}
+                onReasoningEffortChange={setReasoningEffort}
                 apiKeys={apiKeys}
                 onHeightChange={setInputHeight}
             />

--- a/frontend/src/app/hooks/useAssistantChat.ts
+++ b/frontend/src/app/hooks/useAssistantChat.ts
@@ -327,6 +327,7 @@ export function useAssistantChat({
       }));
 
       const model = message.model;
+      const reasoningEffort = message.reasoningEffort;
 
       const displayedDoc = opts?.displayedDoc ?? null;
 
@@ -348,6 +349,7 @@ export function useAssistantChat({
             messages: apiMessages,
             chat_id: chatId,
             model,
+            reasoning_effort: reasoningEffort,
             displayed_doc: displayedDoc
               ? {
                   filename: displayedDoc.filename,
@@ -363,6 +365,7 @@ export function useAssistantChat({
             messages: apiMessages,
             chat_id: chatId,
             model,
+            reasoning_effort: reasoningEffort,
             ask_inputs_response: opts?.askInputsResponse,
             signal: controller.signal,
           }));

--- a/frontend/src/app/hooks/useSelectedModel.test.tsx
+++ b/frontend/src/app/hooks/useSelectedModel.test.tsx
@@ -1,0 +1,30 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+    useReasoningEffort,
+    useSelectedModel,
+} from "./useSelectedModel";
+
+describe("saved Claude controls", () => {
+    beforeEach(() => window.localStorage.clear());
+
+    it("migrates a saved Opus 4.7 selection to Opus 5", async () => {
+        window.localStorage.setItem("mike.selectedModel", "claude-opus-4-7");
+
+        const { result } = renderHook(() => useSelectedModel());
+
+        await waitFor(() => expect(result.current[0]).toBe("claude-opus-5"));
+        expect(window.localStorage.getItem("mike.selectedModel")).toBe(
+            "claude-opus-5",
+        );
+    });
+
+    it("defaults reasoning to medium and persists changes", () => {
+        const { result } = renderHook(() => useReasoningEffort());
+
+        expect(result.current[0]).toBe("medium");
+        act(() => result.current[1]("low"));
+        expect(result.current[0]).toBe("low");
+        expect(window.localStorage.getItem("mike.reasoningEffort")).toBe("low");
+    });
+});

--- a/frontend/src/app/hooks/useSelectedModel.ts
+++ b/frontend/src/app/hooks/useSelectedModel.ts
@@ -1,9 +1,15 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { ALLOWED_MODEL_IDS, DEFAULT_MODEL_ID } from "../components/assistant/ModelToggle";
+import {
+    ALLOWED_MODEL_IDS,
+    DEFAULT_MODEL_ID,
+    DEFAULT_REASONING_EFFORT,
+} from "../components/assistant/ModelToggle";
+import type { ReasoningEffort } from "../components/shared/types";
 
 const STORAGE_KEY = "mike.selectedModel";
+const REASONING_STORAGE_KEY = "mike.reasoningEffort";
 
 function isAllowed(id: string): boolean {
     return ALLOWED_MODEL_IDS.has(id) || id.startsWith("ollama/");
@@ -12,8 +18,22 @@ function isAllowed(id: string): boolean {
 function readStored(): string {
     if (typeof window === "undefined") return DEFAULT_MODEL_ID;
     const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === "claude-opus-4-7") {
+        window.localStorage.setItem(STORAGE_KEY, "claude-opus-5");
+        return "claude-opus-5";
+    }
     if (raw && isAllowed(raw)) return raw;
     return DEFAULT_MODEL_ID;
+}
+
+function isReasoningEffort(value: string | null): value is ReasoningEffort {
+    return value === "low" || value === "medium" || value === "high";
+}
+
+function readStoredReasoningEffort(): ReasoningEffort {
+    if (typeof window === "undefined") return DEFAULT_REASONING_EFFORT;
+    const raw = window.localStorage.getItem(REASONING_STORAGE_KEY);
+    return isReasoningEffort(raw) ? raw : DEFAULT_REASONING_EFFORT;
 }
 
 export function useSelectedModel(): [string, (id: string) => void] {
@@ -33,4 +53,27 @@ export function useSelectedModel(): [string, (id: string) => void] {
     }, []);
 
     return [model, setModel];
+}
+
+export function useReasoningEffort(): [
+    ReasoningEffort,
+    (effort: ReasoningEffort) => void,
+] {
+    const [effort, setEffortState] = useState<ReasoningEffort>(
+        DEFAULT_REASONING_EFFORT,
+    );
+
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration-safe localStorage read; SSR must render the default effort
+        setEffortState(readStoredReasoningEffort());
+    }, []);
+
+    const setEffort = useCallback((next: ReasoningEffort) => {
+        setEffortState(next);
+        if (typeof window !== "undefined") {
+            window.localStorage.setItem(REASONING_STORAGE_KEY, next);
+        }
+    }, []);
+
+    return [effort, setEffort];
 }

--- a/frontend/src/app/lib/mikeApi.test.ts
+++ b/frontend/src/app/lib/mikeApi.test.ts
@@ -597,6 +597,7 @@ describe("streamChat", () => {
             messages: [{ role: "user", content: "hi" }],
             chat_id: "c1",
             model: "gemini-3-flash-preview",
+            reasoning_effort: "medium",
             signal: controller.signal,
         });
 
@@ -614,6 +615,7 @@ describe("streamChat", () => {
             messages: [{ role: "user", content: "hi" }],
             chat_id: "c1",
             model: "gemini-3-flash-preview",
+            reasoning_effort: "medium",
         });
     });
 
@@ -642,6 +644,7 @@ describe("streamProjectChat", () => {
             projectId: "p1",
             messages: [{ role: "user", content: "hi" }],
             displayed_doc: { filename: "a.pdf", document_id: "d1" },
+            reasoning_effort: "high",
             signal: controller.signal,
         });
 
@@ -651,6 +654,7 @@ describe("streamProjectChat", () => {
         expect(JSON.parse(init.body as string)).toEqual({
             messages: [{ role: "user", content: "hi" }],
             displayed_doc: { filename: "a.pdf", document_id: "d1" },
+            reasoning_effort: "high",
         });
     });
 });
@@ -664,7 +668,11 @@ describe("streamTabularChat", () => {
             [{ role: "user", content: "summarize" }],
             null,
             undefined,
-            { reviewTitle: "Leases", projectName: null },
+            {
+                reviewTitle: "Leases",
+                projectName: null,
+                reasoningEffort: "low",
+            },
         );
 
         const { url, init } = lastFetchCall();
@@ -672,6 +680,7 @@ describe("streamTabularChat", () => {
         expect(JSON.parse(init.body as string)).toEqual({
             messages: [{ role: "user", content: "summarize" }],
             review_title: "Leases",
+            reasoning_effort: "low",
         });
     });
 });

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -16,6 +16,7 @@ import type {
     OpenSourceWorkflowContributorMode,
     OpenSourceWorkflowResponse,
     Project,
+    ReasoningEffort,
     Workflow,
     WorkflowContributor,
     TabularReview,
@@ -974,6 +975,7 @@ export async function streamChat(payload: {
     chat_id?: string;
     project_id?: string;
     model?: string;
+    reasoning_effort?: ReasoningEffort;
     ask_inputs_response?: {
         responses: (
             | {
@@ -1019,6 +1021,7 @@ export async function streamProjectChat(payload: {
     messages: StreamChatMessage[];
     chat_id?: string;
     model?: string;
+    reasoning_effort?: ReasoningEffort;
     displayed_doc?: { filename: string; document_id: string };
     attached_documents?: { filename: string; document_id: string }[];
     ask_inputs_response?: {
@@ -1211,7 +1214,11 @@ export async function streamTabularChat(
     messages: { role: string; content: string }[],
     chat_id?: string | null,
     signal?: AbortSignal,
-    context?: { reviewTitle?: string | null; projectName?: string | null },
+    context?: {
+        reviewTitle?: string | null;
+        projectName?: string | null;
+        reasoningEffort?: ReasoningEffort;
+    },
 ): Promise<Response> {
     const authHeaders = await getAuthHeader();
     return fetch(`${API_BASE}/tabular-review/${reviewId}/chat`, {
@@ -1222,6 +1229,7 @@ export async function streamTabularChat(
             chat_id: chat_id ?? undefined,
             review_title: context?.reviewTitle ?? undefined,
             project_name: context?.projectName ?? undefined,
+            reasoning_effort: context?.reasoningEffort,
         }),
         signal: signal ?? undefined,
     });


### PR DESCRIPTION
## Summary
- replace the retired Opus 4.7 picker entry with Claude Opus 5 and migrate saved 4.7 selections
- add Low, Medium, and High reasoning inside the existing selector, defaulting Opus 5 to Medium
- enable Anthropic automatic caching, cache stable tool and one-shot system prefixes, and log cache usage counters
- validate reasoning inputs across standard, project, and tabular chat routes

## Verification
- backend tests on Node 22: 508 passed, 14 skipped
- frontend tests on Node 22: 239 passed
- frontend coverage: 99.69% statements, 98.53% branches, 100% functions and lines
- backend TypeScript build passed
- frontend lint passed with 0 errors
- optimized Next.js production build passed