### PR TITLE
feat: formalize design system on existing shadcn/Tailwind foundation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,22 @@ Frontend:
 npm run build --prefix frontend
 ```
 
+## Frontend UI
+
+Before writing a new component from scratch, check
+`frontend/src/app/components/ui/` for a primitive that already covers it — most
+new UI should be composed from that shared layer rather than hand-rolled. If
+there's no primitive but the pattern is a standard one (dialog, tooltip,
+popover, select, tabs), take it from the [shadcn/ui](https://ui.shadcn.com)
+registry so we inherit Radix's keyboard and ARIA behaviour instead of
+reimplementing it. Hand-write a one-off only when it's used on a single screen
+and has no interaction semantics worth sharing, and keep it in the feature
+folder. When you find yourself copying the same markup into a third place —
+especially a `shadow-[...]` glass recipe — promote it to `components/ui/` with a
+test and migrate every call site in that PR. Tokens, the de facto spacing and
+type scales, and the accessibility rules for primitives are documented in
+[`docs/design-system.md`](docs/design-system.md).
+
 ## Testing
 
 ```bash

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,337 @@
+# Design System
+
+How Mike's frontend actually looks and how to build with it. This documents the
+existing system — it is not a proposal to change it. Everything below was read
+off `frontend/src/app/globals.css` and measured across
+`frontend/src/app/components/` (~120 component files), so where the de facto
+convention differs from the theoretical one, the de facto one is what's written
+down.
+
+Stack: Next.js App Router, Tailwind v4, shadcn/ui (`new-york`, see
+`frontend/components.json`), Lucide icons.
+
+---
+
+## 1. Colour
+
+There are three colour vocabularies in the codebase. Knowing which one you're
+in is most of the job.
+
+### 1.1 The Tailwind grey ramp — the working palette
+
+~930 usages of `text-gray-*` / `bg-gray-*` / `border-gray-*` across the feature
+components. This, not the semantic token set, is what the app is actually built
+out of.
+
+| Usage | Class |
+| --- | --- |
+| Primary text | `text-gray-900` (headings), `text-gray-700` (body) |
+| Secondary text | `text-gray-600` |
+| Muted / meta text | `text-gray-500` |
+| Placeholder, disabled-ish | `text-gray-400` |
+| Hairlines and borders | `border-gray-100`, `border-gray-300` |
+| Filled control (checkbox, pill) | `bg-gray-900` |
+| Inverted text on filled | `text-white` |
+
+Contrast floors worth remembering, all against a near-white background:
+`gray-400` is ~2.5:1 and **fails** WCAG AA for text; `gray-500` is ~4.8:1 and
+passes. Do not use `text-gray-400` for text a user has to read — it is fine for
+decorative icons and for genuinely disabled controls, which are exempt.
+
+### 1.2 The `app-*` surface tokens — layered chrome
+
+Defined in `globals.css` as plain hex, exposed as Tailwind colours via
+`@theme inline`:
+
+| Token | Value | Meaning |
+| --- | --- | --- |
+| `--app-background` | `#f9fafb` | The page behind everything |
+| `--app-surface` | `#fdfdfe` | A raised panel or table surface |
+| `--app-surface-hover` | `#f9fafb` | Row/item hover |
+| `--app-surface-active` | `#eff0f3` | Row/item selected |
+| `--app-floating` | `#fefefe` | Floating elements above a surface |
+
+Use these through the shared constants in
+`frontend/src/app/components/ui/liquid-surface.ts` rather than hand-writing the
+classes — `APP_SURFACE_HOVER_CLASS`, `APP_SURFACE_ACTIVE_CLASS`,
+`APP_SURFACE_PRESSED_CLASS`, `APP_SURFACE_GROUP_HOVER_CLASS`. That file also
+holds the two composite surface recipes, `LIQUID_TABLE_SURFACE_CLASS` and
+`LIQUID_PANEL_SURFACE_CLASS`.
+
+### 1.3 The shadcn semantic tokens — primitives only
+
+`--background`, `--foreground`, `--card`, `--popover`, `--primary`,
+`--secondary`, `--muted`, `--accent`, `--destructive`, `--border`, `--input`,
+`--ring`, plus `--sidebar-*` and `--chart-1..5`. All oklch, all in `:root` with
+a `.dark` counterpart.
+
+In practice these are used almost exclusively by the vendored shadcn
+primitives (`button.tsx`, `input.tsx`, `dropdown-menu.tsx`) — about 45 usages
+total against the grey ramp's 930. Keep using them inside anything derived from
+shadcn, so that the primitive stays swappable with upstream. Don't try to
+convert the feature layer to them as a drive-by; that's a separate, deliberate
+migration.
+
+`--muted-foreground` (`oklch(0.556 0 0)`, ≈`#767676`) is ~4.6:1 on the light
+background and clears AA for body text.
+
+### 1.4 Accent blue
+
+Declared once in `@theme inline` and used for links, focus rings, and the "on"
+state of controls:
+
+`--color-blue` / `--color-blue-600` = `rgb(0, 136, 255)`, with `blue-50`,
+`blue-100`, `blue-200` as translucent tints and `blue-700` as the pressed
+shade. `--color-azure` (`0, 136, 255` as a bare triple) exists so legal-content
+CSS can build `rgba()` from it — that's why the USC/CFR link styles use
+`rgb(var(--color-azure))`.
+
+### 1.5 Dark mode: defined, not wired up
+
+A full `.dark` token set exists and `@custom-variant dark` is declared, but
+**nothing in the app ever adds the `dark` class**, and `dark:` variants appear
+only in the three vendored shadcn primitives. Treat dark mode as unshipped: you
+don't need to design for it, and you shouldn't assume it works if you turn it
+on. Keeping the `dark:` arms that come with a shadcn component is fine and
+costs nothing.
+
+### 1.6 Raw hex
+
+Exactly five component files use raw 6-digit hex, all for a legitimate reason
+(third-party viewer chrome, an SVG logo, syntax-ish highlighting):
+`assistant/CaseLawPanel.tsx`, `assistant/AssistantSidePanel.tsx`,
+`chat/mike-icon.tsx`, `shared/DocumentSidePanel.tsx`,
+`shared/views/SpreadsheetView.tsx`. Adding a sixth needs a reason. Note this
+does **not** cover `rgba()` inside arbitrary `shadow-[...]` values, which is
+the normal way shadows are written here (see §4).
+
+---
+
+## 2. Typography
+
+Two fonts, both loaded via `next/font/google` in `frontend/src/app/layout.tsx`
+and bound to CSS variables:
+
+| Family | Variable | Tailwind | Role |
+| --- | --- | --- | --- |
+| Inter | `--font-inter` | `font-sans` (default) | All UI chrome |
+| EB Garamond | `--font-eb-garamond` | `font-serif`, `.font-eb-garamond` | Legal document content, and display headings |
+
+`font-sans` is applied to `<body>`, so UI text needs no font class. Reach for
+`font-serif` in two places, matching what the app already does:
+
+1. **Rendered legal text** — the `.usc-section`, `.cfr-section`, and
+   `.workflow-editor-content` blocks in `globals.css` set it wholesale, along
+   with a `1.6`–`1.65` line-height for long-form reading.
+2. **Display headings** — empty-state titles and panel titles, e.g.
+   `font-serif text-2xl font-medium text-gray-900`. Available via
+   `EmptyState` (§5) so you don't retype it.
+
+The de facto type scale, by frequency:
+
+| Class | Uses | Where |
+| --- | --- | --- |
+| `text-xs` | ~200 | The default for dense UI: rows, pills, menu items, meta |
+| `text-sm` | ~155 | Comfortable body text, inputs, buttons |
+| `text-2xl` | ~14 | Empty-state / display headings (with `font-serif`) |
+| `text-base`, `text-lg`, `text-xl` | <10 each | Occasional panel titles |
+
+`text-xs` being the workhorse is the single most surprising thing about this
+codebase's type scale — it is a dense, table-heavy application. There is also a
+tail of arbitrary sizes (`text-[11px]`, `text-[10px]`, `text-[9px]`, ~36 uses)
+for badge and annotation text below `text-xs`. Prefer `text-[10px]`/`text-[11px]`
+over inventing a new one.
+
+Weights: `font-medium` is the emphasis weight almost everywhere;
+`font-semibold` appears mainly in long-form legal headings. `font-bold` is
+essentially unused — don't start.
+
+---
+
+## 3. Spacing and radius
+
+Nothing is customised: this is Tailwind's default 0.25rem-step scale. What
+matters is which steps the codebase actually uses, because sticking to them is
+what keeps screens looking consistent.
+
+**Spacing**, by frequency:
+
+- Gaps: `gap-2` (82), `gap-1.5` (73), `gap-1` (67), then `gap-3` (26), `gap-4` (10).
+  `gap-1.5` is the idiomatic icon-to-label gap inside a control.
+- Horizontal padding: `px-3` (112), `px-2` (60), `px-4` (21), `px-2.5` (17).
+- Vertical padding: `py-2` (83), `py-1.5` (44), `py-1` (22), `py-0.5` (24).
+
+So a dense row is `px-2 py-2` or `px-3 py-1.5`; a comfortable control is
+`px-3 py-2`. Steps above `4` are rare and mostly page-level.
+
+**Radius.** `--radius: 0.625rem` (10px) feeds the shadcn `--radius-sm/md/lg/xl`
+ladder, but the feature layer mostly uses Tailwind's literal radii:
+
+| Class | Uses | Meaning |
+| --- | --- | --- |
+| `rounded-full` | 87 | Pills, toggles, circular icon buttons — the house style |
+| `rounded-lg` | 58 | Menu items, rows, small panels |
+| `rounded-md` | 46 | Inputs, buttons (shadcn default) |
+| `rounded-xl` | 28 | Dropdown/popover containers |
+| `rounded-2xl` | 13 | Large floating surfaces (the `liquid-*` recipes) |
+
+The rule of thumb: the bigger the surface, the bigger the radius. Interactive
+chips are always `rounded-full`.
+
+**Control heights.** `h-7` (28px) for compact controls (tab pills, icon
+buttons), `h-8`/`h-9` for standard (shadcn `sm`/`default`), `h-3.5` for the
+checkbox square. Icon sizes track the control: `h-2.5`, `h-3`, `h-3.5` inside
+compact chrome, `h-4` (`size-4`) for shadcn defaults.
+
+---
+
+## 4. The glass / "liquid" idiom
+
+Mike's distinctive surface treatment: a translucent white fill, a white
+hairline border, an inset highlight, and a blur. ~68 `backdrop-blur-*` usages,
+overwhelmingly `backdrop-blur-xl` (38) on controls and `backdrop-blur-2xl` (20)
+on large surfaces.
+
+Shadows in this idiom are written as arbitrary values with `rgba()` literals —
+`shadow-[0_3px_9px_rgba(15,23,42,0.05),inset_0_1px_0_rgba(255,255,255,0.86)]`
+and friends. That is deliberate and unavoidable (Tailwind's shadow scale can't
+express layered inset highlights), but it is also the main source of copy-paste
+drift in this codebase.
+
+**Never retype one of these shadow triples.** Every one that is used more than
+once already lives in a shared primitive or in `liquid-surface.ts`. If you need
+a glass surface, compose from: `PillButton`, `TabPillButton`, `SearchBar`,
+`GlassIconButton`, `LiquidDropdown*`, `LIQUID_TABLE_SURFACE_CLASS`,
+`LIQUID_PANEL_SURFACE_CLASS`, or the `.white-liquid-glass` utility in
+`globals.css`.
+
+---
+
+## 5. The primitive layer: `components/ui/`
+
+`frontend/src/app/components/ui/` is the shared layer. Two kinds of file live
+there: **vendored shadcn** components, which should stay close to upstream so
+they can be re-synced, and **Mike-native** primitives, which encode this app's
+own idioms.
+
+| Primitive | Origin | What it's for |
+| --- | --- | --- |
+| `button.tsx` | shadcn | The standard button; `cva` variants + `asChild` |
+| `input.tsx` | shadcn | The standard text input |
+| `dropdown-menu.tsx` | shadcn (Radix) | All menus, submenus, checkbox/radio items |
+| `pill-button.tsx` | Mike | Primary action pill. `tone` = `black` \| `white` \| `blue` \| `danger` |
+| `tab-pill-button.tsx` | Mike | Filter/tab chip. `active` tri-state: `true` \| `false` \| `undefined` (not a toggle) |
+| `search-bar.tsx` | Mike | Glass search field with clear button; `size` = `sm` \| `normal` |
+| `toggle-switch.tsx` | Mike | `role="switch"` with an optional inline label |
+| `cite-button.tsx` | Mike | Copy-quote-and-citation control |
+| `glass-icon-button.tsx` | Mike | Circular glass icon button (panel/modal close) |
+| `check-square.tsx` | Mike | The selection square; purely visual, ARIA-free by design |
+| `empty-state.tsx` | Mike | Icon + serif title + description + action body |
+| `liquid-dropdown.tsx` | Mike | The glass skin over `dropdown-menu` |
+| `liquid-surface.ts` | Mike | Surface class constants (not a component) |
+
+Two shared components live just outside this directory and are worth knowing
+about, because reimplementing either is a common mistake:
+`shared/TablePrimitive.tsx` (table shell, `TableEmptyState`, `SkeletonLine`,
+`SkeletonDot`, `TABLE_CHECKBOX_CLASS`) and `modals/Modal.tsx` (the modal shell,
+used by 18 files).
+
+### 5.1 Which layer do I reach for?
+
+In order. Stop at the first one that works.
+
+1. **A primitive in `components/ui/`** — if one covers it, use it, even if you
+   need to pass a `className` tweak. This is almost always the answer.
+2. **A shared constant** — `liquid-surface.ts` for surfaces,
+   `tabular/pillUtils.ts` (`getPillClass`, `TAG_COLORS`) for tag colours,
+   `TABLE_CHECKBOX_CLASS` for native table checkboxes.
+3. **The shadcn registry** — for a genuinely standard interaction pattern we
+   don't have yet (dialog, tooltip, popover, select, tabs, accordion…). Prefer
+   this over hand-rolling, because you inherit Radix's keyboard and ARIA
+   behaviour for free. Add it with the shadcn CLI so it lands in
+   `components/ui/` in `new-york` style with our token names, then adapt the
+   colours to §1 if it needs the glass treatment. Adding a Radix dependency for
+   this is expected and fine.
+4. **A one-off in the feature folder** — legitimate when the thing is used
+   once, is specific to one screen, and has no interaction semantics worth
+   sharing. Keep it in the feature directory, not in `ui/`.
+5. **A new primitive in `components/ui/`** — earn this. The bar is the same one
+   the existing Mike-native primitives cleared: **the same markup, with only
+   cosmetic variation, in three or more places.** Two occurrences is a
+   coincidence; three is a pattern. When you promote one, migrate every call
+   site in the same PR, and give it a `*.test.tsx`.
+
+### 5.2 Promoting a duplicated pattern
+
+The grep that finds candidates: pick a distinctive class string from the thing
+you're about to write and search for it.
+
+```bash
+grep -rn "rounded-full border border-white/70" --include='*.tsx' frontend/src/app/components/
+```
+
+Three or more hits with the same shape means the primitive already wants to
+exist. Some things look duplicated but aren't, and shouldn't be merged:
+inline `Loader2` spinners (real size/colour variation at every site, a wrapper
+would trade one line for one line), tag pills (already shared via
+`pillUtils.ts`), and one-line `<p>` "no results" messages (a paragraph with one
+class is not a component).
+
+---
+
+## 6. Accessibility baseline
+
+The primitives are where an a11y fix pays off everywhere at once, so the rules
+here are tighter than for feature code.
+
+**Focus must be visible.** The house focus indicator is
+`outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2`
+(drop the offset inside dense containers like menus). Two traps this codebase
+already fell into: a focus style that only changes a translucent background
+(`white/70` → `white/90` is imperceptible), and `outline-hidden` on a Radix
+menu item whose skin then overrides the highlight colour. A ring is independent
+of the background, so it survives both. Never remove an outline without
+replacing it.
+
+**Icon-only controls need a name.** An icon is not a label. `GlassIconButton`
+makes `aria-label` a required prop for exactly this reason. Where a visible
+label exists, let it be the accessible name — don't override it with an
+`aria-label` that says something different (WCAG 2.5.3). `CiteButton` therefore
+only sets `aria-label` when it's rendering icon-only.
+
+**Don't signal state with colour alone** (WCAG 1.4.1) and keep state
+indicators above 3:1 (WCAG 1.4.11). Both were violated here: a switch whose
+"off" track was `bg-gray-100` behind a white thumb (~1.07:1, fixed with a
+`ring-1 ring-gray-300`), and a selected menu radio item marked only by
+`bg-gray-100` on white (~1.03:1, fixed by adding `font-medium` as a second,
+non-colour channel).
+
+**Text contrast**: see §1.1. `text-gray-400` is not a text colour.
+
+**Interactive `<span>`s carry their own ARIA.** `CheckSquare` is deliberately
+role-free and ARIA-free because call sites disagree about whether the checkbox
+semantics belong on the square or on the row button wrapping it. When the
+square is the control, pass `role="checkbox"` + `aria-checked` (+
+`aria-disabled`, `aria-label`) to it; when the row is the control, put them
+there and leave the square as decoration.
+
+**Every button declares `type`.** Default is `type="submit"`, which submits any
+surrounding form. Every Mike-native primitive defaults to `type="button"`.
+
+---
+
+## 7. Testing a primitive
+
+Primitives are unit-tested with Vitest + Testing Library; see the `*.test.tsx`
+files alongside them for the house style. Query by role and accessible name
+(`getByRole("button", { name: "Close" })`) rather than by test id — it asserts
+the a11y contract and the behaviour at the same time. Assert the specific
+classes that carry meaning (state colours, focus rings), not the whole class
+string, which is churn.
+
+```bash
+npm test --prefix frontend -- src/app/components/ui
+```
+
+Some list and table screens accept `?emptyStates=1` to force their empty state,
+which is the quickest way to eyeball `EmptyState` changes in the running app.

--- a/frontend/src/app/components/assistant/QuickActionsModal.tsx
+++ b/frontend/src/app/components/assistant/QuickActionsModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check } from "lucide-react";
+import { CheckSquare } from "@/app/components/ui/check-square";
 import { Modal } from "../modals/Modal";
 import { QUICK_ACTIONS, type QuickActionId } from "./quickActionsPreferences";
 
@@ -61,17 +61,10 @@ export function QuickActionsModal({
                                 <span className="min-w-0 truncate">
                                     {action.label}
                                 </span>
-                                <span
-                                    className={`ml-auto flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border ${
-                                        checked
-                                            ? "bg-gray-900 border-gray-900"
-                                            : "border-gray-300"
-                                    }`}
-                                >
-                                    {checked && (
-                                        <Check className="h-2.5 w-2.5 text-white" />
-                                    )}
-                                </span>
+                                <CheckSquare
+                                    checked={checked}
+                                    className="ml-auto"
+                                />
                             </button>
                         );
                     })}

--- a/frontend/src/app/components/modals/AddProjectDocsModal.tsx
+++ b/frontend/src/app/components/modals/AddProjectDocsModal.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Check, Loader2, Upload, X } from "lucide-react";
+import { Loader2, Upload, X } from "lucide-react";
+import { CheckSquare } from "@/app/components/ui/check-square";
 import { SearchBar } from "@/app/components/ui/search-bar";
 import { getProject, uploadProjectDocument } from "@/app/lib/mikeApi";
 import type { Document } from "../shared/types";
@@ -202,17 +203,7 @@ export function AddProjectDocsModal({
                                           : "hover:bg-gray-100/70"
                                 }`}
                             >
-                                <span
-                                    className={`shrink-0 h-3.5 w-3.5 rounded border flex items-center justify-center ${
-                                        checked
-                                            ? "bg-gray-900 border-gray-900"
-                                            : "border-gray-300"
-                                    }`}
-                                >
-                                    {checked && (
-                                        <Check className="h-2.5 w-2.5 text-white" />
-                                    )}
-                                </span>
+                                <CheckSquare checked={checked} />
                                 <DocFileIcon fileType={doc.file_type} />
                                 <span
                                     className={`flex-1 truncate ${

--- a/frontend/src/app/components/modals/Modal.tsx
+++ b/frontend/src/app/components/modals/Modal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 import { X } from "lucide-react";
+import { GlassIconButton } from "@/app/components/ui/glass-icon-button";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { cn } from "@/app/lib/utils";
 
@@ -116,13 +117,9 @@ export function Modal({
                             </div>
                             {headerAction}
                         </div>
-                        <button
-                            onClick={onClose}
-                            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/70 bg-white/55 text-gray-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),inset_0_-1px_0_rgba(255,255,255,0.55),0_6px_18px_rgba(15,23,42,0.08)] backdrop-blur-xl transition-colors hover:bg-white/75 hover:text-gray-700"
-                            aria-label="Close"
-                        >
+                        <GlassIconButton onClick={onClose} aria-label="Close">
                             <X className="h-3.5 w-3.5" />
-                        </button>
+                        </GlassIconButton>
                     </div>
                 )}
                 {/* Body never scrolls itself (so children's edge shadows are

--- a/frontend/src/app/components/projects/ProjectAssistantTable.tsx
+++ b/frontend/src/app/components/projects/ProjectAssistantTable.tsx
@@ -23,6 +23,7 @@ import {
     type TableSortDirection,
     TableStickyCell,
 } from "@/app/components/shared/TablePrimitive";
+import { EmptyState } from "@/app/components/ui/empty-state";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { ChatSkeuoIcon } from "@/app/components/shared/AppSidebarSkeuoIcons";
 import type { Chat } from "@/app/components/shared/types";
@@ -225,23 +226,21 @@ export function ProjectAssistantTable({
                 <ProjectAssistantLoadingRows />
             ) : chats.length === 0 ? (
                 <TableEmptyState>
-                    <ChatSkeuoIcon className="mb-4 h-8 w-8" />
-                    <p className="text-2xl font-medium font-serif text-gray-900">
-                        Assistant
-                    </p>
-                    <p className="mt-1 text-xs text-gray-400 max-w-xs">
-                        Ask questions and get answers grounded in the documents
-                        in this project.
-                    </p>
-                    <PillButton
-                        tone="black"
-                        size="sm"
-                        onClick={onCreateChat}
-                        className="mt-4 px-3"
+                    <EmptyState
+                        icon={ChatSkeuoIcon}
+                        title="Assistant"
+                        description="Ask questions and get answers grounded in the documents in this project."
                     >
-                        <Plus className="h-3.5 w-3.5" />
-                        Create
-                    </PillButton>
+                        <PillButton
+                            tone="black"
+                            size="sm"
+                            onClick={onCreateChat}
+                            className="mt-4 px-3"
+                        >
+                            <Plus className="h-3.5 w-3.5" />
+                            Create
+                        </PillButton>
+                    </EmptyState>
                 </TableEmptyState>
             ) : (
                 <TableBody>

--- a/frontend/src/app/components/projects/ProjectReviewsTable.tsx
+++ b/frontend/src/app/components/projects/ProjectReviewsTable.tsx
@@ -24,6 +24,7 @@ import {
     type TableSortDirection,
     TableStickyCell,
 } from "@/app/components/shared/TablePrimitive";
+import { EmptyState } from "@/app/components/ui/empty-state";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { TabularReviewSkeuoIcon } from "@/app/components/shared/AppSidebarSkeuoIcons";
 import type { Document, TabularReview } from "@/app/components/shared/types";
@@ -247,15 +248,11 @@ export function ProjectReviewsTable({
                             No reviews found
                         </p>
                     ) : (
-                        <>
-                            <TabularReviewSkeuoIcon className="mb-4 h-8 w-8" />
-                            <p className="text-2xl font-medium font-serif text-gray-900">
-                                Tabular Reviews
-                            </p>
-                            <p className="mt-1 text-xs text-gray-400 max-w-xs">
-                                Extract data from project documents into tables
-                                using AI.
-                            </p>
+                        <EmptyState
+                            icon={TabularReviewSkeuoIcon}
+                            title="Tabular Reviews"
+                            description="Extract data from project documents into tables using AI."
+                        >
                             <PillButton
                                 tone="black"
                                 size="sm"
@@ -266,7 +263,7 @@ export function ProjectReviewsTable({
                                 <Plus className="h-3.5 w-3.5" />
                                 Create
                             </PillButton>
-                        </>
+                        </EmptyState>
                     )}
                 </TableEmptyState>
             ) : (

--- a/frontend/src/app/components/projects/ProjectsOverview.tsx
+++ b/frontend/src/app/components/projects/ProjectsOverview.tsx
@@ -46,6 +46,7 @@ import {
     type TableSortDirection,
     TableStickyCell,
 } from "@/app/components/shared/TablePrimitive";
+import { EmptyState } from "@/app/components/ui/empty-state";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { TabPillButton } from "@/app/components/ui/tab-pill-button";
 
@@ -554,35 +555,30 @@ export function ProjectsOverview() {
                     </TableBody>
                 ) : loadError ? (
                     <TableEmptyState>
-                        <OpenProjectSvgIcon className="mb-4 h-8 w-8" />
-                        <p className="text-2xl font-medium font-serif text-gray-900">
-                            Projects
-                        </p>
-                        <p className="mt-1 text-xs text-red-500 max-w-xs">
-                            {loadError}
-                        </p>
-                        <PillButton
-                            tone="black"
-                            size="sm"
-                            onClick={retry}
-                            className="mt-4 px-3"
+                        <EmptyState
+                            icon={OpenProjectSvgIcon}
+                            title="Projects"
+                            description={loadError}
+                            descriptionClassName="text-red-500"
                         >
-                            Try again
-                        </PillButton>
+                            <PillButton
+                                tone="black"
+                                size="sm"
+                                onClick={retry}
+                                className="mt-4 px-3"
+                            >
+                                Try again
+                            </PillButton>
+                        </EmptyState>
                     </TableEmptyState>
                 ) : visibleProjects.length === 0 ? (
                     <TableEmptyState>
                         {activeFilter === "all" || activeFilter === "mine" ? (
-                            <>
-                                <OpenProjectSvgIcon className="mb-4 h-8 w-8" />
-                                <p className="text-2xl font-medium font-serif text-gray-900">
-                                    Projects
-                                </p>
-                                <p className="mt-1 text-xs text-gray-400 max-w-xs">
-                                    Upload documents into projects and to
-                                    commence chats and tabular reviews with
-                                    them.
-                                </p>
+                            <EmptyState
+                                icon={OpenProjectSvgIcon}
+                                title="Projects"
+                                description="Upload documents into projects and to commence chats and tabular reviews with them."
+                            >
                                 <PillButton
                                     tone="black"
                                     size="sm"
@@ -592,7 +588,7 @@ export function ProjectsOverview() {
                                     <Plus className="h-3.5 w-3.5" />
                                     Create
                                 </PillButton>
-                            </>
+                            </EmptyState>
                         ) : (
                             <p className="text-sm text-gray-400">
                                 No {activeFilter} projects

--- a/frontend/src/app/components/shared/DocumentSidePanel.tsx
+++ b/frontend/src/app/components/shared/DocumentSidePanel.tsx
@@ -18,6 +18,7 @@ import { FileTypeIcon } from "@/app/components/shared/FileTypeIcon";
 import { PdfView } from "@/app/components/shared/views/PdfView";
 import { DocxView } from "@/app/components/shared/views/DocxView";
 import { SpreadsheetView } from "@/app/components/shared/views/SpreadsheetView";
+import { GlassIconButton } from "@/app/components/ui/glass-icon-button";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { WarningPopup } from "@/app/components/popups/WarningPopup";
 import type { Document } from "@/app/components/shared/types";
@@ -507,14 +508,9 @@ export function DocumentSidePanel({
                             Details
                         </button>
                     </div>
-                    <button
-                        type="button"
-                        onClick={onClose}
-                        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/70 bg-white/55 text-gray-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),inset_0_-1px_0_rgba(255,255,255,0.55),0_6px_18px_rgba(15,23,42,0.08)] backdrop-blur-xl transition-colors hover:bg-white/75 hover:text-gray-700"
-                        aria-label="Close"
-                    >
+                    <GlassIconButton onClick={onClose} aria-label="Close">
                         <X className="h-3.5 w-3.5" />
-                    </button>
+                    </GlassIconButton>
                 </div>
             </div>
 

--- a/frontend/src/app/components/shared/FileDirectory.tsx
+++ b/frontend/src/app/components/shared/FileDirectory.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { type ReactNode, useEffect, useMemo, useState } from "react";
-import { Check, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import type { Document, LibraryFolder, Project } from "./types";
 import { FileTypeIcon } from "./FileTypeIcon";
 import { ProjectSvgIcon, SubfolderSvgIcon } from "./FolderSvgIcon";
+import { CheckSquare } from "@/app/components/ui/check-square";
 import { SearchBar } from "@/app/components/ui/search-bar";
 import { TabPillButton } from "@/app/components/ui/tab-pill-button";
 import { SkeletonLine } from "./TablePrimitive";
@@ -495,13 +496,7 @@ export function FileDirectory({
           selected ? APP_SURFACE_ACTIVE_CLASS : APP_SURFACE_HOVER_CLASS
                 }`}
             >
-                <span
-                    className={`shrink-0 h-3.5 w-3.5 rounded border flex items-center justify-center ${
-            selected ? "bg-gray-900 border-gray-900" : "border-gray-300"
-                    }`}
-                >
-                    {selected && <Check className="h-2.5 w-2.5 text-white" />}
-                </span>
+                <CheckSquare checked={selected} />
                 <DocFileIcon fileType={doc.file_type} />
                 <span
           className={`min-w-0 truncate ${selected ? "text-gray-900" : "text-gray-700"}`}
@@ -549,7 +544,7 @@ export function FileDirectory({
                         style={{ paddingLeft: indentedRowPadding(depth) }}
                         className={`w-full rounded-md ${DIRECTORY_GRID_CLASS} py-2 pr-2 text-xs transition-all text-left ${APP_SURFACE_HOVER_CLASS}`}
                     >
-                        <span
+                        <CheckSquare
                             role="checkbox"
                             aria-checked={someSelected ? "mixed" : allSelected}
               aria-disabled={!folderSelectionReady}
@@ -564,17 +559,12 @@ export function FileDirectory({
                                 toggleDocuments(docsInFolder);
                 }
                             }}
-                            className={`shrink-0 h-3.5 w-3.5 rounded border flex items-center justify-center ${
-                                allSelected || someSelected
-                                    ? "bg-gray-900 border-gray-900"
-                  : !folderSelectionReady || docsInFolder.length === 0
-                                      ? "border-gray-200 bg-gray-50"
-                                      : "border-gray-300"
-                            }`}
-                        >
-              {allSelected && <Check className="h-2.5 w-2.5 text-white" />}
-                            {someSelected && <span className="h-px w-2 bg-white" />}
-                        </span>
+                            checked={someSelected ? "mixed" : allSelected}
+                            muted={
+                                !folderSelectionReady ||
+                                docsInFolder.length === 0
+                            }
+                        />
             {(libraryTab && loadingFolderIds[libraryTab].has(folder.id)) ||
             (projectId &&
               loadingProjectLevels.has(`${projectId}:${folder.id}`)) ||
@@ -955,7 +945,7 @@ export function FileDirectory({
                       onClick={() => toggleFolder(project.id)}
                                         className={`w-full rounded-md ${DIRECTORY_GRID_CLASS} px-2 py-2 text-xs transition-all text-left ${APP_SURFACE_HOVER_CLASS}`}
                                     >
-                                        <span
+                                        <CheckSquare
                                             role="checkbox"
                                             aria-checked={
                                                 someProjectDocsSelected
@@ -974,21 +964,16 @@ export function FileDirectory({
                                                 toggleDocuments(docs);
                           }
                                             }}
-                                            className={`shrink-0 h-3.5 w-3.5 rounded border flex items-center justify-center ${
-                          allProjectDocsSelected || someProjectDocsSelected
-                                                    ? "bg-gray-900 border-gray-900"
-                            : !projectSelectionReady || docs.length === 0
-                                                      ? "border-gray-200 bg-gray-50"
-                                                      : "border-gray-300"
-                                            }`}
-                                        >
-                                            {allProjectDocsSelected && (
-                                                <Check className="h-2.5 w-2.5 text-white" />
-                                            )}
-                                            {someProjectDocsSelected && (
-                                                <span className="h-px w-2 bg-white" />
-                                            )}
-                                        </span>
+                                            checked={
+                                                someProjectDocsSelected
+                                                    ? "mixed"
+                                                    : allProjectDocsSelected
+                                            }
+                                            muted={
+                                                !projectSelectionReady ||
+                                                docs.length === 0
+                                            }
+                                        />
                                         <ProjectSvgIcon
                                             open={isExpanded}
                                             className="h-3.5 w-3.5 shrink-0"

--- a/frontend/src/app/components/tabular/TREditColumnMenu.tsx
+++ b/frontend/src/app/components/tabular/TREditColumnMenu.tsx
@@ -16,6 +16,7 @@ import {
     LiquidDropdownContent,
     LiquidDropdownRadioItem,
 } from "@/app/components/ui/liquid-dropdown";
+import { GlassIconButton } from "@/app/components/ui/glass-icon-button";
 import { PillButton } from "@/app/components/ui/pill-button";
 
 // Liquid-glass field styling shared by the menu's inputs/controls, matching the
@@ -248,14 +249,12 @@ export function TREditColumnMenu({
                         <p className="font-serif text-lg font-medium text-gray-900">
                             Edit Column
                         </p>
-                        <button
-                            type="button"
+                        <GlassIconButton
                             onClick={() => setOpen(false)}
                             aria-label="Close"
-                            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/70 bg-white/55 text-gray-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),inset_0_-1px_0_rgba(255,255,255,0.55),0_6px_18px_rgba(15,23,42,0.08)] backdrop-blur-xl transition-colors hover:bg-white/75 hover:text-gray-700"
                         >
                             <X className="h-3.5 w-3.5" />
-                        </button>
+                        </GlassIconButton>
                     </div>
                     <label className="text-xs font-medium text-gray-800">
                         Label

--- a/frontend/src/app/components/tabular/TRSidePanel.tsx
+++ b/frontend/src/app/components/tabular/TRSidePanel.tsx
@@ -41,6 +41,7 @@ import {
     APP_SURFACE_PRESSED_CLASS,
     LIQUID_PANEL_SURFACE_CLASS,
 } from "@/app/components/ui/liquid-surface";
+import { GlassIconButton } from "@/app/components/ui/glass-icon-button";
 
 function isDocxDocument(d: {
     file_type?: string | null;
@@ -460,14 +461,9 @@ export function TRSidePanel({
                             )}
                         </button>
                     )}
-                    <button
-                        type="button"
-                        onClick={onClose}
-                        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/70 bg-white/55 text-gray-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),inset_0_-1px_0_rgba(255,255,255,0.55),0_6px_18px_rgba(15,23,42,0.08)] backdrop-blur-xl transition-colors hover:bg-white/75 hover:text-gray-700"
-                        aria-label="Close"
-                    >
+                    <GlassIconButton onClick={onClose} aria-label="Close">
                         <X className="h-3.5 w-3.5" />
-                    </button>
+                    </GlassIconButton>
                 </div>
 
                 {/* Analysis panel */}

--- a/frontend/src/app/components/ui/check-square.test.tsx
+++ b/frontend/src/app/components/ui/check-square.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CheckSquare } from "./check-square";
+
+describe("CheckSquare", () => {
+    it("renders the unchecked box with no indicator", () => {
+        const { container } = render(<CheckSquare checked={false} />);
+        const box = container.firstElementChild as HTMLElement;
+
+        expect(box).toHaveClass("h-3.5", "w-3.5", "rounded", "border");
+        expect(box).toHaveClass("border-gray-300");
+        expect(box.textContent).toBe("");
+        expect(box.querySelector("svg")).toBeNull();
+    });
+
+    it("renders a check icon when checked", () => {
+        const { container } = render(<CheckSquare checked />);
+        const box = container.firstElementChild as HTMLElement;
+
+        expect(box).toHaveClass("bg-gray-900", "border-gray-900");
+        expect(box.querySelector("svg")).not.toBeNull();
+    });
+
+    it("renders a dash instead of a check for the mixed state", () => {
+        const { container } = render(<CheckSquare checked="mixed" />);
+        const box = container.firstElementChild as HTMLElement;
+
+        expect(box).toHaveClass("bg-gray-900", "border-gray-900");
+        expect(box.querySelector("svg")).toBeNull();
+        expect(box.querySelector("span")).toHaveClass("h-px", "w-2", "bg-white");
+    });
+
+    it("renders the muted look when muted and unchecked", () => {
+        const { container } = render(<CheckSquare checked={false} muted />);
+        const box = container.firstElementChild as HTMLElement;
+
+        expect(box).toHaveClass("border-gray-200", "bg-gray-50");
+    });
+
+    it("stays purely visual and forwards ARIA supplied by the caller", () => {
+        render(
+            <CheckSquare
+                checked="mixed"
+                role="checkbox"
+                aria-checked="mixed"
+                aria-label="Select all files in Contracts"
+            />,
+        );
+
+        const box = screen.getByRole("checkbox", {
+            name: "Select all files in Contracts",
+        });
+        expect(box).toHaveAttribute("aria-checked", "mixed");
+    });
+
+    it("adds no implicit role of its own", () => {
+        render(<CheckSquare checked={false} />);
+
+        expect(screen.queryByRole("checkbox")).toBeNull();
+    });
+});

--- a/frontend/src/app/components/ui/check-square.tsx
+++ b/frontend/src/app/components/ui/check-square.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import * as React from "react";
+import { Check } from "lucide-react";
+
+import { cn } from "@/app/lib/utils";
+
+type CheckSquareProps = Omit<React.ComponentProps<"span">, "children"> & {
+    checked: boolean | "mixed";
+    /**
+     * The dimmed look used when a row's selection isn't available yet. Purely
+     * visual — set `aria-disabled` on whatever element owns the interaction.
+     */
+    muted?: boolean;
+};
+
+/**
+ * The selection square used by document and action pickers.
+ *
+ * Deliberately has no role or ARIA of its own: call sites disagree about
+ * whether the checkbox semantics belong on this element or on the row button
+ * that wraps it, and adding a role here would double up on the ones that
+ * already declare it. Pass `role`/`aria-checked` through when this element is
+ * the control.
+ */
+export function CheckSquare({
+    checked,
+    muted = false,
+    className,
+    ...props
+}: CheckSquareProps) {
+    return (
+        <span
+            className={cn(
+                "flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border",
+                checked
+                    ? "border-gray-900 bg-gray-900"
+                    : muted
+                      ? "border-gray-200 bg-gray-50"
+                      : "border-gray-300",
+                className,
+            )}
+            {...props}
+        >
+            {checked === "mixed" ? (
+                <span className="h-px w-2 bg-white" />
+            ) : checked ? (
+                <Check className="h-2.5 w-2.5 text-white" />
+            ) : null}
+        </span>
+    );
+}

--- a/frontend/src/app/components/ui/cite-button.test.tsx
+++ b/frontend/src/app/components/ui/cite-button.test.tsx
@@ -37,4 +37,48 @@ describe("CiteButton", () => {
         expect(writeText).toHaveBeenCalledWith(`"he said 'hi'" Doe 2020`);
         expect(await screen.findByText("Copied")).toBeInTheDocument();
     });
+
+    it("defaults to type=button so it never submits a surrounding form", () => {
+        render(<CiteButton quoteText="hello" citationText="Doe 2020" />);
+
+        expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+    });
+
+    it("keeps an accessible name when rendered icon-only", () => {
+        render(
+            <CiteButton
+                quoteText="hello"
+                citationText="Doe 2020"
+                showText={false}
+            />,
+        );
+
+        expect(screen.getByRole("button")).toHaveAccessibleName(
+            "Copy quote and citation",
+        );
+    });
+
+    it("announces the copied state through its accessible name", async () => {
+        const user = userEvent.setup();
+        vi.spyOn(navigator.clipboard, "writeText");
+        render(
+            <CiteButton
+                quoteText="hello"
+                citationText="Doe 2020"
+                showText={false}
+            />,
+        );
+
+        await user.click(screen.getByRole("button"));
+
+        expect(
+            await screen.findByRole("button", { name: "Citation copied" }),
+        ).toBeInTheDocument();
+    });
+
+    it("renders a visible keyboard focus ring", () => {
+        render(<CiteButton quoteText="hello" citationText="Doe 2020" />);
+
+        expect(screen.getByRole("button")).toHaveClass("focus-visible:ring-2");
+    });
 });

--- a/frontend/src/app/components/ui/cite-button.tsx
+++ b/frontend/src/app/components/ui/cite-button.tsx
@@ -39,9 +39,20 @@ export function CiteButton({
 
     return (
         <button
+            type="button"
             onClick={handleClick}
-            className={`transition-colors flex items-center gap-1 ${className}`}
+            className={`transition-colors flex items-center gap-1 outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2 ${className}`}
             title="Copy Quote and Citation"
+            // Only label it when there is no visible text: an icon-only button
+            // would otherwise have no accessible name (WCAG 4.1.2), while
+            // overriding the visible "Cite" would break label-in-name (2.5.3).
+            aria-label={
+                showText
+                    ? undefined
+                    : isCopied
+                      ? "Citation copied"
+                      : "Copy quote and citation"
+            }
         >
             {isCopied ? (
                 <Check

--- a/frontend/src/app/components/ui/dropdown-menu.test.tsx
+++ b/frontend/src/app/components/ui/dropdown-menu.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
+    DropdownMenuTrigger,
+} from "./dropdown-menu";
+
+function renderMenu() {
+    return render(
+        <DropdownMenu>
+            <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+            <DropdownMenuContent>
+                <DropdownMenuItem>Rename</DropdownMenuItem>
+                <DropdownMenuRadioGroup value="text">
+                    <DropdownMenuRadioItem value="text">
+                        Text
+                    </DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="number">
+                        Number
+                    </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+        </DropdownMenu>,
+    );
+}
+
+describe("DropdownMenu", () => {
+    it("wires the trigger up to the menu it controls", async () => {
+        const user = userEvent.setup();
+        renderMenu();
+
+        const trigger = screen.getByRole("button", { name: "Open" });
+        expect(trigger).toHaveAttribute("aria-haspopup", "menu");
+        expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+        await user.click(trigger);
+
+        expect(trigger).toHaveAttribute("aria-expanded", "true");
+        expect(await screen.findByRole("menu")).toBeInTheDocument();
+    });
+
+    it("gives menu items a visible keyboard focus ring", async () => {
+        const user = userEvent.setup();
+        renderMenu();
+
+        await user.click(screen.getByRole("button", { name: "Open" }));
+
+        // The liquid dropdown skin overrides focus:bg-* with a near-white
+        // hover colour, so the highlight alone is not a usable focus
+        // indicator — items need their own ring.
+        expect(
+            await screen.findByRole("menuitem", { name: "Rename" }),
+        ).toHaveClass("focus-visible:ring-2");
+    });
+
+    it("marks the selected radio item for assistive tech", async () => {
+        const user = userEvent.setup();
+        renderMenu();
+
+        await user.click(screen.getByRole("button", { name: "Open" }));
+
+        const selected = await screen.findByRole("menuitemradio", {
+            name: "Text",
+        });
+        const unselected = screen.getByRole("menuitemradio", {
+            name: "Number",
+        });
+
+        expect(selected).toHaveAttribute("aria-checked", "true");
+        expect(unselected).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("does not signal radio selection with colour alone", async () => {
+        const user = userEvent.setup();
+        renderMenu();
+
+        await user.click(screen.getByRole("button", { name: "Open" }));
+
+        // A gray-100 background on a white popover is ~1.03:1. Weight is a
+        // second, non-colour channel for the same information (WCAG 1.4.1).
+        expect(
+            await screen.findByRole("menuitemradio", { name: "Text" }),
+        ).toHaveClass("data-[state=checked]:font-medium");
+    });
+});

--- a/frontend/src/app/components/ui/dropdown-menu.tsx
+++ b/frontend/src/app/components/ui/dropdown-menu.tsx
@@ -6,6 +6,16 @@ import { CheckIcon, ChevronRightIcon } from "lucide-react";
 
 import { cn } from "@/app/lib/utils";
 
+/**
+ * Items set `outline-hidden` and lean on `focus:bg-accent` for the highlight,
+ * but skins that override that background — `liquid-dropdown` swaps it for a
+ * near-white hover colour at ~1.02:1 — leave keyboard users with no visible
+ * focus indicator (WCAG 2.4.7). The ring is independent of the background, so
+ * it survives those overrides.
+ */
+const MENU_ITEM_FOCUS_RING =
+    "focus-visible:ring-2 focus-visible:ring-blue-500/40";
+
 function DropdownMenu({
     ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
@@ -81,6 +91,7 @@ function DropdownMenuItem({
             data-variant={variant}
             className={cn(
                 "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-lg px-3 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+                MENU_ITEM_FOCUS_RING,
                 className
             )}
             {...props}
@@ -99,6 +110,7 @@ function DropdownMenuCheckboxItem({
             data-slot="dropdown-menu-checkbox-item"
             className={cn(
                 "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-lg py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+                MENU_ITEM_FOCUS_RING,
                 className
             )}
             checked={checked}
@@ -134,7 +146,11 @@ function DropdownMenuRadioItem({
         <DropdownMenuPrimitive.RadioItem
             data-slot="dropdown-menu-radio-item"
             className={cn(
-                "focus:bg-accent focus:text-accent-foreground data-[state=checked]:bg-gray-100 relative flex cursor-default items-center gap-2 rounded-lg py-1.5 px-3 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+                // gray-100 on a white popover is ~1.03:1, so the checked
+                // background is not on its own a usable selection cue. The
+                // weight is a second, non-colour channel (WCAG 1.4.1).
+                "focus:bg-accent focus:text-accent-foreground data-[state=checked]:bg-gray-100 data-[state=checked]:font-medium relative flex cursor-default items-center gap-2 rounded-lg py-1.5 px-3 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+                MENU_ITEM_FOCUS_RING,
                 className
             )}
             {...props}
@@ -215,6 +231,7 @@ function DropdownMenuSubTrigger({
             data-inset={inset}
             className={cn(
                 "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+                MENU_ITEM_FOCUS_RING,
                 className
             )}
             {...props}

--- a/frontend/src/app/components/ui/empty-state.test.tsx
+++ b/frontend/src/app/components/ui/empty-state.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { EmptyState } from "./empty-state";
+
+function StubIcon({ className }: { className?: string }) {
+    return <svg data-testid="stub-icon" className={className} />;
+}
+
+describe("EmptyState", () => {
+    it("renders the title with the shared serif heading treatment", () => {
+        render(<EmptyState title="Projects" />);
+
+        const title = screen.getByText("Projects");
+        expect(title).toHaveClass(
+            "font-serif",
+            "text-2xl",
+            "font-medium",
+            "text-gray-900",
+        );
+    });
+
+    it("owns the icon sizing so call sites do not repeat it", () => {
+        render(<EmptyState icon={StubIcon} title="Projects" />);
+
+        expect(screen.getByTestId("stub-icon")).toHaveClass(
+            "mb-4",
+            "h-8",
+            "w-8",
+        );
+    });
+
+    it("renders the description with the shared muted treatment", () => {
+        render(<EmptyState title="Projects" description="Upload documents." />);
+
+        expect(screen.getByText("Upload documents.")).toHaveClass(
+            "mt-1",
+            "text-xs",
+            "text-gray-400",
+        );
+    });
+
+    it("omits the description paragraph entirely when there is none", () => {
+        const { container } = render(<EmptyState title="Projects" />);
+
+        expect(container.querySelectorAll("p")).toHaveLength(1);
+    });
+
+    it("lets a call site override the description treatment", () => {
+        render(
+            <EmptyState
+                title="Projects"
+                description="Something went wrong"
+                descriptionClassName="text-red-500"
+            />,
+        );
+
+        const description = screen.getByText("Something went wrong");
+        // tailwind-merge drops the conflicting default colour.
+        expect(description).toHaveClass("text-red-500");
+        expect(description).not.toHaveClass("text-gray-400");
+    });
+
+    it("renders an action passed as children", () => {
+        render(
+            <EmptyState title="Projects">
+                <button type="button">Create</button>
+            </EmptyState>,
+        );
+
+        expect(
+            screen.getByRole("button", { name: "Create" }),
+        ).toBeInTheDocument();
+    });
+});

--- a/frontend/src/app/components/ui/empty-state.tsx
+++ b/frontend/src/app/components/ui/empty-state.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+
+import { cn } from "@/app/lib/utils";
+
+type EmptyStateProps = {
+    /**
+     * Rendered at the shared size. Pass the component itself
+     * (`icon={ChatSkeuoIcon}`), not an element, so call sites stop repeating
+     * the sizing classes.
+     */
+    icon?: React.ComponentType<{ className?: string }>;
+    title: React.ReactNode;
+    description?: React.ReactNode;
+    /**
+     * For the two legitimate deviations: `text-left` where the copy reads
+     * better ragged-right, and `text-red-500` for load failures.
+     */
+    descriptionClassName?: string;
+    /** The call-to-action, if the state has one. */
+    children?: React.ReactNode;
+};
+
+/**
+ * The icon + title + description + action body shared by every table empty
+ * state. Renders no wrapper of its own so it drops straight into the existing
+ * `TableEmptyState` container (and anything else that centres its children).
+ */
+export function EmptyState({
+    icon: Icon,
+    title,
+    description,
+    descriptionClassName,
+    children,
+}: EmptyStateProps) {
+    return (
+        <>
+            {Icon ? <Icon className="mb-4 h-8 w-8" /> : null}
+            <p className="font-serif text-2xl font-medium text-gray-900">
+                {title}
+            </p>
+            {description ? (
+                <p
+                    className={cn(
+                        "mt-1 text-xs text-gray-400",
+                        descriptionClassName,
+                    )}
+                >
+                    {description}
+                </p>
+            ) : null}
+            {children}
+        </>
+    );
+}

--- a/frontend/src/app/components/ui/glass-icon-button.test.tsx
+++ b/frontend/src/app/components/ui/glass-icon-button.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { X } from "lucide-react";
+
+import { GlassIconButton } from "./glass-icon-button";
+
+describe("GlassIconButton", () => {
+    it("exposes the accessible name it was given", () => {
+        render(
+            <GlassIconButton aria-label="Close">
+                <X className="h-3.5 w-3.5" />
+            </GlassIconButton>,
+        );
+
+        expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+    });
+
+    it("defaults to type=button so it never submits a surrounding form", () => {
+        render(<GlassIconButton aria-label="Close" />);
+
+        expect(screen.getByRole("button", { name: "Close" })).toHaveAttribute(
+            "type",
+            "button",
+        );
+    });
+
+    it("carries the glass surface classes the panels used inline", () => {
+        render(<GlassIconButton aria-label="Close" />);
+
+        expect(screen.getByRole("button", { name: "Close" })).toHaveClass(
+            "h-7",
+            "w-7",
+            "rounded-full",
+            "border-white/70",
+            "bg-white/55",
+            "backdrop-blur-xl",
+        );
+    });
+
+    it("renders a visible keyboard focus ring", () => {
+        render(<GlassIconButton aria-label="Close" />);
+
+        expect(screen.getByRole("button", { name: "Close" })).toHaveClass(
+            "focus-visible:ring-2",
+        );
+    });
+
+    it("fires onClick when activated", async () => {
+        const onClick = vi.fn();
+        const user = userEvent.setup();
+        render(<GlassIconButton aria-label="Close" onClick={onClick} />);
+
+        await user.click(screen.getByRole("button", { name: "Close" }));
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/src/app/components/ui/glass-icon-button.tsx
+++ b/frontend/src/app/components/ui/glass-icon-button.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/app/lib/utils";
+
+/**
+ * The circular glass affordance used for panel and modal close buttons. The
+ * shadow triple is a bespoke literal that predates `liquid-surface.ts`; it
+ * lives here so the four panels that used to inline it stay in step.
+ */
+const GLASS_ICON_BUTTON_CLASS =
+    "flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/70 bg-white/55 text-gray-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),inset_0_-1px_0_rgba(255,255,255,0.55),0_6px_18px_rgba(15,23,42,0.08)] backdrop-blur-xl transition-colors hover:bg-white/75 hover:text-gray-700";
+
+type GlassIconButtonProps = React.ComponentProps<"button"> & {
+    /**
+     * Required: the button renders an icon only, so without this it has no
+     * accessible name at all (WCAG 4.1.2).
+     */
+    "aria-label": string;
+};
+
+export function GlassIconButton({
+    className,
+    type = "button",
+    ...props
+}: GlassIconButtonProps) {
+    return (
+        <button
+            type={type}
+            className={cn(
+                GLASS_ICON_BUTTON_CLASS,
+                "outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2",
+                className,
+            )}
+            {...props}
+        />
+    );
+}

--- a/frontend/src/app/components/ui/pill-button.test.tsx
+++ b/frontend/src/app/components/ui/pill-button.test.tsx
@@ -73,6 +73,14 @@ describe("PillButton", () => {
         expect(onClick).not.toHaveBeenCalled();
     });
 
+    it("renders a visible keyboard focus ring", () => {
+        render(<PillButton tone="black">Save</PillButton>);
+
+        expect(screen.getByRole("button", { name: "Save" })).toHaveClass(
+            "focus-visible:ring-2",
+        );
+    });
+
     it("renders as its child element via asChild", () => {
         render(
             <PillButton tone="blue" asChild>

--- a/frontend/src/app/components/ui/pill-button.tsx
+++ b/frontend/src/app/components/ui/pill-button.tsx
@@ -40,6 +40,7 @@ export function PillButton({
             type={asChild ? undefined : type}
             className={cn(
                 "inline-flex items-center justify-center gap-1.5 rounded-full border font-medium transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40 disabled:active:scale-100",
+                "outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2",
                 toneClasses[tone],
                 sizeClasses[size],
                 className,

--- a/frontend/src/app/components/ui/search-bar.test.tsx
+++ b/frontend/src/app/components/ui/search-bar.test.tsx
@@ -13,12 +13,12 @@ describe("SearchBar", () => {
         ).toBeInTheDocument();
     });
 
-    it("falls back to a generic label when no placeholder is given", () => {
-        render(
-            <SearchBar value="" onValueChange={vi.fn()} placeholder={undefined} />,
-        );
+    it("falls back to the default placeholder when none is given", () => {
+        render(<SearchBar value="" onValueChange={vi.fn()} />);
 
-        expect(screen.getByRole("searchbox")).toHaveAccessibleName("Search");
+        expect(screen.getByRole("searchbox")).toHaveAccessibleName(
+            "Search...",
+        );
     });
 
     it("lets an explicit aria-label win over the placeholder", () => {

--- a/frontend/src/app/components/ui/search-bar.test.tsx
+++ b/frontend/src/app/components/ui/search-bar.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { SearchBar } from "./search-bar";
+
+describe("SearchBar", () => {
+    it("names the input from its placeholder so it is never unlabelled", () => {
+        render(<SearchBar value="" onValueChange={vi.fn()} placeholder="Search documents" />);
+
+        expect(
+            screen.getByRole("searchbox", { name: "Search documents" }),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to a generic label when no placeholder is given", () => {
+        render(
+            <SearchBar value="" onValueChange={vi.fn()} placeholder={undefined} />,
+        );
+
+        expect(screen.getByRole("searchbox")).toHaveAccessibleName("Search");
+    });
+
+    it("lets an explicit aria-label win over the placeholder", () => {
+        render(
+            <SearchBar
+                value=""
+                onValueChange={vi.fn()}
+                placeholder="Search documents"
+                aria-label="Filter results"
+            />,
+        );
+
+        expect(
+            screen.getByRole("searchbox", { name: "Filter results" }),
+        ).toBeInTheDocument();
+    });
+
+    it("renders a visible focus indicator on the wrapper", () => {
+        const { container } = render(
+            <SearchBar value="" onValueChange={vi.fn()} />,
+        );
+
+        expect(container.firstElementChild).toHaveClass(
+            "focus-within:ring-2",
+        );
+    });
+
+    it("emits typed values", async () => {
+        const onValueChange = vi.fn();
+        const user = userEvent.setup();
+        render(<SearchBar value="" onValueChange={onValueChange} />);
+
+        await user.type(screen.getByRole("searchbox"), "a");
+
+        expect(onValueChange).toHaveBeenCalledWith("a");
+    });
+
+    it("exposes a labelled clear button only when there is a value", async () => {
+        const onValueChange = vi.fn();
+        const user = userEvent.setup();
+        const { rerender } = render(
+            <SearchBar value="" onValueChange={onValueChange} />,
+        );
+
+        expect(screen.queryByRole("button", { name: "Clear search" })).toBeNull();
+
+        rerender(<SearchBar value="tax" onValueChange={onValueChange} />);
+        await user.click(screen.getByRole("button", { name: "Clear search" }));
+
+        expect(onValueChange).toHaveBeenCalledWith("");
+    });
+});

--- a/frontend/src/app/components/ui/search-bar.tsx
+++ b/frontend/src/app/components/ui/search-bar.tsx
@@ -52,11 +52,18 @@ export const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
         ref,
     ) => {
         const classes = sizeClasses[size];
+        // A placeholder is not an accessible name, so without this the input
+        // is announced only as "search" (WCAG 4.1.2). An explicit aria-label
+        // from the call site still wins.
+        const label = props["aria-label"] ?? placeholder;
 
         return (
             <div
                 className={cn(
                     "flex items-center border border-white/70 bg-white/55 text-gray-700 shadow-[0_3px_9px_rgba(15,23,42,0.06),inset_0_1px_0_rgba(255,255,255,0.86),inset_0_-1px_0_rgba(255,255,255,0.58)] backdrop-blur-xl transition-colors focus-within:border-white/90 focus-within:bg-white/70",
+                    // The white/70 → white/90 shift alone is imperceptible, so
+                    // the field had no usable focus indicator (WCAG 2.4.7).
+                    "focus-within:ring-2 focus-within:ring-blue-500/40",
                     classes.wrapper,
                     className,
                     wrapperClassName,
@@ -73,6 +80,7 @@ export const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
                     type="search"
                     value={value}
                     placeholder={placeholder}
+                    aria-label={label}
                     onChange={(event) => onValueChange(event.target.value)}
                     className={cn(
                         "min-w-0 flex-1 bg-transparent text-gray-700 outline-none placeholder:text-gray-400 [&::-webkit-search-cancel-button]:hidden",

--- a/frontend/src/app/components/ui/tab-pill-button.test.tsx
+++ b/frontend/src/app/components/ui/tab-pill-button.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TabPillButton } from "./tab-pill-button";
+
+describe("TabPillButton", () => {
+    it("defaults to type=button", () => {
+        render(<TabPillButton>All</TabPillButton>);
+
+        expect(screen.getByRole("button", { name: "All" })).toHaveAttribute(
+            "type",
+            "button",
+        );
+    });
+
+    it("reports its pressed state when used as a toggle", () => {
+        render(<TabPillButton active>All</TabPillButton>);
+
+        expect(screen.getByRole("button", { name: "All" })).toHaveAttribute(
+            "aria-pressed",
+            "true",
+        );
+    });
+
+    it("omits aria-pressed when it is not a toggle", () => {
+        render(<TabPillButton>Actions</TabPillButton>);
+
+        expect(
+            screen.getByRole("button", { name: "Actions" }),
+        ).not.toHaveAttribute("aria-pressed");
+    });
+
+    it("uses a WCAG AA contrast text colour for the inactive state", () => {
+        render(<TabPillButton active={false}>Mine</TabPillButton>);
+
+        const button = screen.getByRole("button", { name: "Mine" });
+        // gray-400 on the translucent white pill is ~2.5:1 and fails 1.4.3.
+        expect(button).not.toHaveClass("text-gray-400");
+        expect(button).toHaveClass("text-gray-500");
+    });
+
+    it("renders a visible keyboard focus ring", () => {
+        render(<TabPillButton>All</TabPillButton>);
+
+        expect(screen.getByRole("button", { name: "All" })).toHaveClass(
+            "focus-visible:ring-2",
+        );
+    });
+});

--- a/frontend/src/app/components/ui/tab-pill-button.tsx
+++ b/frontend/src/app/components/ui/tab-pill-button.tsx
@@ -17,7 +17,9 @@ export function TabPillButton({
         active === true
             ? "border-white/80 bg-white text-gray-900"
             : active === false
-              ? "border-white/60 bg-white/45 text-gray-400 hover:bg-white/65 hover:text-gray-700"
+              ? // gray-400 on the translucent white pill is ~2.5:1 and fails
+                // WCAG 1.4.3; gray-500 clears AA at ~4.8:1.
+                "border-white/60 bg-white/45 text-gray-500 hover:bg-white/65 hover:text-gray-700"
               : "border-white/70 bg-white/65 text-gray-700 hover:bg-white hover:text-gray-900";
 
     return (
@@ -26,6 +28,7 @@ export function TabPillButton({
             aria-pressed={active}
             className={cn(
                 "inline-flex h-7 items-center justify-center gap-1.5 rounded-full border px-3 text-xs font-medium shadow-[0_3px_9px_rgba(15,23,42,0.05),inset_0_1px_0_rgba(255,255,255,0.86),inset_0_-1px_0_rgba(255,255,255,0.58)] backdrop-blur-xl transition-all active:scale-[0.98] disabled:cursor-default disabled:opacity-40 disabled:active:scale-100",
+                "outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2",
                 stateClass,
                 className,
             )}

--- a/frontend/src/app/components/ui/toggle-switch.test.tsx
+++ b/frontend/src/app/components/ui/toggle-switch.test.tsx
@@ -28,4 +28,35 @@ describe("ToggleSwitch", () => {
         fireEvent.click(toggle);
         expect(onCheckedChange).toHaveBeenCalledWith(false);
     });
+
+    it("keeps the off state discernible against the page", () => {
+        const { container } = render(
+            <ToggleSwitch checked={false} onCheckedChange={vi.fn()}>
+                Group documents
+            </ToggleSwitch>,
+        );
+
+        const track = container.querySelector(
+            '[data-slot="toggle-switch-track"]',
+        );
+
+        // The white thumb on a gray-100 track is ~1.07:1, so without a border
+        // the off state is effectively invisible (WCAG 1.4.11).
+        expect(track).toHaveClass("bg-gray-100", "border", "border-gray-300");
+    });
+
+    it("does not border the track once it is filled in", () => {
+        const { container } = render(
+            <ToggleSwitch checked onCheckedChange={vi.fn()}>
+                Group documents
+            </ToggleSwitch>,
+        );
+
+        const track = container.querySelector(
+            '[data-slot="toggle-switch-track"]',
+        );
+
+        expect(track).toHaveClass("bg-blue-600");
+        expect(track).not.toHaveClass("border-gray-300");
+    });
 });

--- a/frontend/src/app/components/ui/toggle-switch.test.tsx
+++ b/frontend/src/app/components/ui/toggle-switch.test.tsx
@@ -40,12 +40,12 @@ describe("ToggleSwitch", () => {
             '[data-slot="toggle-switch-track"]',
         );
 
-        // The white thumb on a gray-100 track is ~1.07:1, so without a border
+        // The white thumb on a gray-100 track is ~1.07:1, so without a ring
         // the off state is effectively invisible (WCAG 1.4.11).
-        expect(track).toHaveClass("bg-gray-100", "border", "border-gray-300");
+        expect(track).toHaveClass("bg-gray-100", "ring-1", "ring-gray-300");
     });
 
-    it("does not border the track once it is filled in", () => {
+    it("drops the ring once the track is filled in", () => {
         const { container } = render(
             <ToggleSwitch checked onCheckedChange={vi.fn()}>
                 Group documents
@@ -57,6 +57,6 @@ describe("ToggleSwitch", () => {
         );
 
         expect(track).toHaveClass("bg-blue-600");
-        expect(track).not.toHaveClass("border-gray-300");
+        expect(track).not.toHaveClass("ring-gray-300");
     });
 });

--- a/frontend/src/app/components/ui/toggle-switch.tsx
+++ b/frontend/src/app/components/ui/toggle-switch.tsx
@@ -37,7 +37,11 @@ export function ToggleSwitch({
                 aria-hidden="true"
                 className={cn(
                     "relative inline-flex h-5 w-9 shrink-0 rounded-full transition-colors duration-200",
-                    checked ? "bg-blue-600" : "bg-gray-100",
+                    // The white thumb on a gray-100 track is ~1.07:1, which
+                    // leaves the off state effectively invisible. A ring gives
+                    // the control a discernible boundary (WCAG 1.4.11) without
+                    // the 1px thumb shift a border would cause.
+                    checked ? "bg-blue-600" : "bg-gray-100 ring-1 ring-gray-300",
                 )}
             >
                 <span

--- a/frontend/src/app/components/workflows/WorkflowDetailPage.tsx
+++ b/frontend/src/app/components/workflows/WorkflowDetailPage.tsx
@@ -46,6 +46,7 @@ import {
 import { PeopleModal } from "@/app/components/modals/PeopleModal";
 import { OpenSourceWorkflowModal } from "@/app/components/workflows/OpenSourceWorkflowModal";
 import { PageHeader } from "@/app/components/shared/PageHeader";
+import { EmptyState } from "@/app/components/ui/empty-state";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { TabPillButton } from "@/app/components/ui/tab-pill-button";
 import { LIQUID_TABLE_SURFACE_CLASS } from "@/app/components/ui/liquid-surface";
@@ -693,24 +694,26 @@ export function WorkflowDetailPage({ id, workflowType }: Props) {
                         >
                             {visibleColumns.length === 0 ? (
                                 <TableEmptyState>
-                                    <TabularReviewSkeuoIcon className="mb-4 h-8 w-8" />
-                                    <p className="text-2xl font-medium font-serif text-gray-900">
-                                        Columns
-                                    </p>
-                                    <p className="mt-1 text-xs text-gray-400 text-left">
-                                        Add columns to define what this tabular review workflow extracts from each document.
-                                    </p>
-                                    {!readOnly && (
-                                        <PillButton
-                                            tone="black"
-                                            size="sm"
-                                            onClick={() => setAddColumnOpen(true)}
-                                            className="mt-4 px-3"
-                                        >
-                                            <Plus className="h-3.5 w-3.5" />
-                                            Add Column
-                                        </PillButton>
-                                    )}
+                                    <EmptyState
+                                        icon={TabularReviewSkeuoIcon}
+                                        title="Columns"
+                                        description="Add columns to define what this tabular review workflow extracts from each document."
+                                        descriptionClassName="text-left"
+                                    >
+                                        {!readOnly && (
+                                            <PillButton
+                                                tone="black"
+                                                size="sm"
+                                                onClick={() =>
+                                                    setAddColumnOpen(true)
+                                                }
+                                                className="mt-4 px-3"
+                                            >
+                                                <Plus className="h-3.5 w-3.5" />
+                                                Add Column
+                                            </PillButton>
+                                        )}
+                                    </EmptyState>
                                 </TableEmptyState>
                             ) : (
                                 <TableBody>

--- a/frontend/src/app/components/workflows/WorkflowList.tsx
+++ b/frontend/src/app/components/workflows/WorkflowList.tsx
@@ -24,6 +24,7 @@ import { OwnerOnlyPopup } from "@/app/components/popups/OwnerOnlyPopup";
 import { ConfirmPopup } from "@/app/components/popups/ConfirmPopup";
 import { MikeIcon } from "@/app/components/chat/mike-icon";
 import { PageHeader } from "@/app/components/shared/PageHeader";
+import { EmptyState } from "@/app/components/ui/empty-state";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { TabPillButton } from "@/app/components/ui/tab-pill-button";
 import { TableLoadMoreRow } from "@/app/components/shared/TableLoadMoreRow";
@@ -593,12 +594,12 @@ export function WorkflowList() {
                 ) : filtered.length === 0 ? (
                     <TableEmptyState>
                         {sourceFilter === "user" ? (
-                            <>
-                                <WorkflowSkeuoIcon className="mb-4 h-8 w-8" />
-                                <p className="text-2xl font-medium font-serif text-gray-900">User Workflows</p>
-                                <p className="mt-1 text-xs text-gray-400 text-left">
-                                    Build reusable prompts and tabular review templates tailored to your practice.
-                                </p>
+                            <EmptyState
+                                icon={WorkflowSkeuoIcon}
+                                title="User Workflows"
+                                description="Build reusable prompts and tabular review templates tailored to your practice."
+                                descriptionClassName="text-left"
+                            >
                                 <PillButton
                                     tone="black"
                                     size="sm"
@@ -608,23 +609,21 @@ export function WorkflowList() {
                                     <Plus className="h-3.5 w-3.5" />
                                     Create
                                 </PillButton>
-                            </>
+                            </EmptyState>
                         ) : sourceFilter === "shared" ? (
-                            <>
-                                <WorkflowSkeuoIcon className="mb-4 h-8 w-8" />
-                                <p className="text-2xl font-medium font-serif text-gray-900">Shared Workflows</p>
-                                <p className="mt-1 text-xs text-gray-400 text-left">
-                                    Workflows shared with you by other users will appear here.
-                                </p>
-                            </>
+                            <EmptyState
+                                icon={WorkflowSkeuoIcon}
+                                title="Shared Workflows"
+                                description="Workflows shared with you by other users will appear here."
+                                descriptionClassName="text-left"
+                            />
                         ) : (
-                            <>
-                                <WorkflowSkeuoIcon className="mb-4 h-8 w-8" />
-                                <p className="text-2xl font-medium font-serif text-gray-900">Workflows</p>
-                                <p className="mt-1 text-xs text-gray-400 text-left">
-                                    Automate document analysis with reusable prompts and tabular review templates.
-                                </p>
-                            </>
+                            <EmptyState
+                                icon={WorkflowSkeuoIcon}
+                                title="Workflows"
+                                description="Automate document analysis with reusable prompts and tabular review templates."
+                                descriptionClassName="text-left"
+                            />
                         )}
                     </TableEmptyState>
                 ) : (


### PR DESCRIPTION
## Summary

Formalizes the design system that already exists rather than changing it: documents the current tokens and primitives, promotes three duplicated patterns into the shared layer, and fixes the accessibility gaps in the primitives. No visual redesign — the only pixel-level changes are the accessibility fixes listed below.

Closes #316

## Scope note: catalog tool deferred

The component catalog (acceptance-criteria item 2, Storybook or Ladle) was **intentionally deferred to a follow-up issue** and is not in this PR. As a result this PR adds **no new dependencies** — `frontend/package.json` and `package-lock.json` are untouched.

## 1. `docs/design-system.md`

Documents the existing foundations, measured off `globals.css` and all ~120 component files rather than assumed:

- **Colour** — the three vocabularies actually in use, and when each applies: the Tailwind grey ramp (~930 usages, the real working palette), the `app-*` surface tokens, and the shadcn semantic tokens (~45 usages, effectively primitives-only). Plus the accent blue, and the five files that legitimately use raw hex.
- **Dark mode is documented as unshipped** — a full `.dark` token set exists but nothing ever adds the class, and `dark:` variants appear only in the three vendored shadcn primitives. Worth writing down so nobody assumes it works.
- **Typography** — Inter/EB Garamond split, when to reach for `font-serif`, and the de facto type scale (`text-xs` at ~200 uses is the workhorse; this is a dense, table-heavy app).
- **Spacing/radius** — the de facto scale by measured frequency, plus the "bigger surface, bigger radius" convention.
- **The glass/"liquid" idiom** — and the rule that layered `shadow-[...]` recipes are never retyped, since that is this codebase's main source of copy-paste drift.
- **Which layer to reach for** — a 5-step ladder from existing primitive → shared constant → shadcn registry → feature-local one-off → new primitive, with an explicit promotion bar (same markup in 3+ places).

## 2. Consolidated primitives

Chosen from a grep-and-read pass over the feature components, not invented. Each was verified as genuinely the same markup before promoting it:

| New primitive | Replaces | Call sites migrated |
| --- | --- | --- |
| `ui/glass-icon-button.tsx` | A character-for-character identical 300-char glass close button | 4 — `Modal`, `DocumentSidePanel`, `TRSidePanel`, `TREditColumnMenu` |
| `ui/empty-state.tsx` | The icon + serif title + description + action body repeated inside `TableEmptyState` | 8 across 5 files — `ProjectAssistantTable`, `ProjectReviewsTable`, `ProjectsOverview` (×2), `WorkflowList` (×3), `WorkflowDetailPage` |
| `ui/check-square.tsx` | The selection square, including its mixed and muted states | 5 — `AddProjectDocsModal`, `QuickActionsModal`, `FileDirectory` (×3) |

Deliberately **not** consolidated, to keep this honest:

- Inline `Loader2` spinners — 43 sites with real size/colour variation at each; a wrapper would trade one line for one line.
- Tag pills — already shared via `tabular/pillUtils.ts`.
- The hand-rolled "Actions" dropdown (5 copies of an outside-click effect + panel). Real duplication and the biggest win, but migrating it to Radix changes focus/Escape/portal behaviour, so it belongs in its own PR rather than riding along with a docs change.
- `ProjectReviewsTable`'s load-error state and the short "no results found" variants — superficially similar but a different heading size and a deliberately smaller state.

Two design decisions worth flagging: `EmptyState` renders no wrapper, so it drops straight into the existing `TableEmptyState` container; and `CheckSquare` is deliberately role-free and ARIA-free, because call sites disagree about whether the checkbox semantics belong on the square or on the row button wrapping it, and adding a role would double up on the three that already declare one.

## 3. Accessibility fixes

All applied, not just reported, and each covered by a test:

- **`cite-button`** — was missing `type="button"` (so it submitted any surrounding form) and had **no accessible name at all** when rendered icon-only. Now labelled only when there is no visible text, so the visible "Cite" stays the accessible name (WCAG 2.5.3).
- **`search-bar`** — the input had no accessible name (a placeholder is not a name, WCAG 4.1.2), and its only focus indicator was a `white/70` → `white/90` shift, which is imperceptible (WCAG 2.4.7).
- **`tab-pill-button`** — the inactive state used `text-gray-400` on a translucent white pill, ~2.5:1, failing WCAG 1.4.3. Now `text-gray-500` at ~4.8:1.
- **`toggle-switch`** — the off state was a white thumb on a `gray-100` track, ~1.07:1, effectively invisible (WCAG 1.4.11). Fixed with `ring-1 ring-gray-300` rather than a border, so the absolutely-positioned thumb doesn't shift by 1px.
- **`dropdown-menu`** — menu items set `outline-hidden` and relied on `focus:bg-accent`, but the `liquid-dropdown` skin overrides that with a near-white hover colour (~1.02:1), leaving keyboard users no focus indicator. Added a background-independent ring. Also, a selected radio item was marked by `bg-gray-100` on white (~1.03:1) and by colour alone — now also carries `font-medium` as a second, non-colour channel (WCAG 1.4.1).
- **`pill-button`** — had no focus-visible ring.
- Verified as already passing: the oklch token palette (`--muted-foreground` is ~4.6:1 on the light background) and `button`/`input`, which already ship upstream shadcn focus and `aria-invalid` handling.

## 4. `CONTRIBUTING.md`

One additive `## Frontend UI` section on checking `components/ui/` and the shadcn registry before hand-rolling a component. Placed in its own section and does not restructure the file, so it should not conflict with #315's separate addition.

## Test plan

- [x] 39 new tests across 9 files in `frontend/src/app/components/ui/` (new primitives + the ARIA/focus/contrast assertions), matching the existing house style: queried by role and accessible name, asserting only the classes that carry meaning.
- [x] Written first and confirmed failing for the right reasons before implementing.
- [x] Full frontend suite: 315 passed. The 4 failures in `src/app/lib/mikeApi.test.ts` (`blob.text is not a function`) are pre-existing and reproduce on an unmodified tree — a local Node 24 `Response.blob()` difference. `CI` and `Code Quality` are green on `main` at this branch's base commit (`1af9231`), and CI runs Node 22, so no issue was filed.
- [x] `npm run test:coverage` (the CI gate) — the `src/app/lib/**` ratchet floor is untouched by this change.
- [x] `npm run lint` with the cache cleared — 0 errors, and no warnings in any file this PR touches.
- [x] `npm run build` — passes with the same placeholder env vars CI uses.
- [x] `tsc --noEmit` clean.
