### PR TITLE
feat: add PRD template for scoping larger features

### DIFF
--- a/.github/ISSUE_TEMPLATE/prd.md
+++ b/.github/ISSUE_TEMPLATE/prd.md
@@ -1,0 +1,41 @@
+---
+name: New PRD
+about: Propose and scope a feature or change that touches multiple subsystems, the data model, or public API/behavior
+title: 'PRD: '
+labels: ''
+assignees: ''
+---
+
+<!-- Keep it short — 1-2 pages, not a process. For small, well-understood
+     fixes, just open a plain issue instead. See docs/templates/PRD.md. -->
+
+## Problem
+
+<!-- What's broken or missing, and for whom? If this section doesn't answer
+     "why are we building this," the rest doesn't matter. -->
+
+## Non-goals / out of scope
+
+<!-- Explicit. Prevents scope creep and sets reviewer expectations. -->
+
+## Proposed solution
+
+<!-- The approach, in enough detail for a contributor to start implementation
+     without re-deriving the design. -->
+
+## Alternatives considered
+
+<!-- Briefly, with why they were rejected. -->
+
+## Technical approach / affected areas
+
+<!-- Which parts of backend/, frontend/, or schema.sql this touches. -->
+
+## Success metrics
+
+<!-- How we'll know it worked, even informally (e.g. "eliminates issue
+     class X", "no perf regression on Y"). -->
+
+## Open questions
+
+<!-- Things the author knows they don't know yet. -->

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ e2e/.auth/
 /supabase/
 backend/supabase/*
 !backend/supabase/config.toml
+
+# dev-cycle scratch files
+.current-issue.md
+.implementation-plan.md
+.implement-config

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Thanks for helping improve Mike. Please keep contributions small, focused, and e
 
 ## Guidelines
 
+- For changes that touch multiple subsystems, the data model, or public API/behavior, open a PRD issue first using the "New PRD" template (`docs/templates/PRD.md`); for small, well-understood fixes, a plain issue is fine.
 - Prefer targeted edits over broad refactors.
 - Keep each PR focused on one bug, feature, or cleanup.
 - Update docs or env examples when changing setup, config, or user-facing behavior.

--- a/docs/templates/PRD.md
+++ b/docs/templates/PRD.md
@@ -1,0 +1,37 @@
+# PRD: <title>
+
+<!-- Copy this template into a new GitHub issue (or use the "New PRD" issue
+     form) when scoping a feature or change that touches multiple subsystems,
+     the data model, or public API/behavior. Keep it short — 1-2 pages, not a
+     process. For small, well-understood fixes, just open a plain issue. -->
+
+## Problem
+
+<!-- What's broken or missing, and for whom? If this section doesn't answer
+     "why are we building this," the rest doesn't matter. -->
+
+## Non-goals / out of scope
+
+<!-- Explicit. Prevents scope creep and sets reviewer expectations. -->
+
+## Proposed solution
+
+<!-- The approach, in enough detail for a contributor to start implementation
+     without re-deriving the design. -->
+
+## Alternatives considered
+
+<!-- Briefly, with why they were rejected. -->
+
+## Technical approach / affected areas
+
+<!-- Which parts of backend/, frontend/, or schema.sql this touches. -->
+
+## Success metrics
+
+<!-- How we'll know it worked, even informally (e.g. "eliminates issue
+     class X", "no perf regression on Y"). -->
+
+## Open questions
+
+<!-- Things the author knows they don't know yet. -->


### PR DESCRIPTION
## Summary

- Adds a lightweight PRD template (`docs/templates/PRD.md`) for scoping larger features/architecture changes, covering Problem, Non-goals/out of scope, Proposed solution, Alternatives considered, Technical approach/affected areas, Success metrics, and Open questions.
- Adds a matching GitHub issue form (`.github/ISSUE_TEMPLATE/prd.md`) so "New PRD" appears as an issue-creation option, using the same sections.
- Adds one sentence to `CONTRIBUTING.md` on when to use the PRD template vs. a plain issue.

Closes #324

## Changes

- `docs/templates/PRD.md` — new PRD template, copy-paste source for scoping issues.
- `.github/ISSUE_TEMPLATE/prd.md` — new issue form with YAML frontmatter (`name`, `about`, `title`) and the same section headers as the template.
- `CONTRIBUTING.md` — one-line guideline on when to reach for the PRD template vs. a plain issue.
- `.gitignore` — ignore dev-cycle scratch files (`.current-issue.md`, `.implementation-plan.md`, `.implement-config`).

## Test plan

- [x] No application code touched — docs/template-only change.
- [x] Verified `.github/ISSUE_TEMPLATE/prd.md` YAML frontmatter parses correctly (Python `yaml.safe_load`), since the repo has no existing pattern for validating issue-template YAML.
- [x] `npm run build --prefix backend` passes.
- [x] `npm run lint --prefix frontend` passes (0 errors).
- [x] `npm run build --prefix frontend` passes (includes typecheck), using CI's placeholder `NEXT_PUBLIC_*` env vars.
