### PR TITLE
Add secure conflicts check workflow

### DIFF
--- a/backend/migrations/20260812_02_conflicts_check.sql
+++ b/backend/migrations/20260812_02_conflicts_check.sql
@@ -1,0 +1,57 @@
+-- Restricted conflicts-check records and review history.
+--
+-- These tables are deliberately backend-only. The service-role API scopes
+-- every query by owner_user_id; browser roles have no direct privileges and
+-- RLS has no permissive policies as a second line of defence.
+create table if not exists public.conflict_records (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null,
+  client_name text not null,
+  matter_name text,
+  parties jsonb not null default '[]'::jsonb check (jsonb_typeof(parties) = 'array'),
+  affiliates jsonb not null default '[]'::jsonb check (jsonb_typeof(affiliates) = 'array'),
+  search_text text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists conflict_records_owner_created
+  on public.conflict_records (owner_user_id, created_at desc);
+
+create table if not exists public.conflict_searches (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null,
+  search_input jsonb not null check (jsonb_typeof(search_input) = 'object'),
+  matched_record_ids uuid[] not null default '{}',
+  result_count integer not null default 0 check (result_count >= 0),
+  status text not null default 'pending_review'
+    check (status in ('pending_review', 'cleared', 'conflict_found')),
+  reviewer_notes text,
+  reviewed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists conflict_searches_owner_created
+  on public.conflict_searches (owner_user_id, created_at desc);
+
+create table if not exists public.conflict_audit_events (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null,
+  actor_user_id uuid not null,
+  action text not null check (action in ('record.created', 'search.performed', 'review.decided')),
+  record_id uuid,
+  search_id uuid,
+  detail jsonb,
+  created_at timestamptz not null default now()
+);
+create index if not exists conflict_audit_owner_created
+  on public.conflict_audit_events (owner_user_id, created_at desc);
+
+revoke all on public.conflict_records from anon, authenticated;
+revoke all on public.conflict_searches from anon, authenticated;
+revoke all on public.conflict_audit_events from anon, authenticated;
+alter table public.conflict_records enable row level security;
+alter table public.conflict_searches enable row level security;
+alter table public.conflict_audit_events enable row level security;
+grant select, insert, update, delete on public.conflict_records to service_role;
+grant select, insert, update, delete on public.conflict_searches to service_role;
+grant select, insert, update, delete on public.conflict_audit_events to service_role;

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1852,6 +1852,49 @@ create index if not exists audit_events_user_created on public.audit_events (use
 create index if not exists audit_events_project_created on public.audit_events (project_id, created_at desc);
 alter table public.audit_events enable row level security;
 
+-- Restricted conflicts-check data. These records are intentionally absent
+-- from broad project/library endpoints and are available only through the
+-- owner-scoped, MFA-aware /conflicts API.
+create table if not exists public.conflict_records (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null,
+  client_name text not null,
+  matter_name text,
+  parties jsonb not null default '[]'::jsonb check (jsonb_typeof(parties) = 'array'),
+  affiliates jsonb not null default '[]'::jsonb check (jsonb_typeof(affiliates) = 'array'),
+  search_text text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists conflict_records_owner_created on public.conflict_records (owner_user_id, created_at desc);
+create table if not exists public.conflict_searches (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null,
+  search_input jsonb not null check (jsonb_typeof(search_input) = 'object'),
+  matched_record_ids uuid[] not null default '{}',
+  result_count integer not null default 0 check (result_count >= 0),
+  status text not null default 'pending_review' check (status in ('pending_review', 'cleared', 'conflict_found')),
+  reviewer_notes text,
+  reviewed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists conflict_searches_owner_created on public.conflict_searches (owner_user_id, created_at desc);
+create table if not exists public.conflict_audit_events (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null,
+  actor_user_id uuid not null,
+  action text not null check (action in ('record.created', 'search.performed', 'review.decided')),
+  record_id uuid,
+  search_id uuid,
+  detail jsonb,
+  created_at timestamptz not null default now()
+);
+create index if not exists conflict_audit_owner_created on public.conflict_audit_events (owner_user_id, created_at desc);
+alter table public.conflict_records enable row level security;
+alter table public.conflict_searches enable row level security;
+alter table public.conflict_audit_events enable row level security;
+
 revoke all on public.user_profiles from anon, authenticated;
 revoke all on public.projects from anon, authenticated;
 revoke all on public.project_subfolders from anon, authenticated;
@@ -1879,6 +1922,9 @@ revoke all on public.user_mcp_tool_audit_logs from anon, authenticated;
 revoke all on public.courtlistener_citation_index from anon, authenticated;
 revoke all on public.courtlistener_opinion_cluster_index from anon, authenticated;
 revoke all on public.audit_events from anon, authenticated;
+revoke all on public.conflict_records from anon, authenticated;
+revoke all on public.conflict_searches from anon, authenticated;
+revoke all on public.conflict_audit_events from anon, authenticated;
 
 -- Tables created by this file are owned by the database bootstrap role. The
 -- backend connects as service_role, so grant it only the data privileges that

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -15,6 +15,7 @@ import { modelsRouter } from "./routes/models";
 import { downloadsRouter } from "./routes/downloads";
 import { caseLawRouter } from "./routes/caseLaw";
 import { auditRouter } from "./routes/audit";
+import { conflictsRouter } from "./routes/conflicts";
 import { manifestPublicKey } from "./lib/manifestSigning";
 import { safeErrorLog } from "./lib/safeError";
 
@@ -178,6 +179,7 @@ app.use("/users", userRouter);
 app.use("/download", downloadsRouter);
 app.use("/case-law", caseLawRouter);
 app.use("/audit", auditRouter);
+app.use("/conflicts", conflictsRouter);
 
 app.get("/health", (_req, res) => res.json({ ok: true }));
 

--- a/backend/src/lib/__tests__/conflicts.test.ts
+++ b/backend/src/lib/__tests__/conflicts.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  conflictRecordInput,
+  conflictReviewInput,
+  conflictSearchInput,
+  escapeLike,
+  matchedFields,
+  normalizedSearchText,
+  searchTerms,
+} from "../conflicts";
+
+describe("conflicts input validation", () => {
+  it("requires a client, party, or affiliate for a search", () => {
+    expect(
+      conflictSearchInput.safeParse({
+        matterName: "New engagement",
+        parties: [],
+        affiliates: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("trims structured names and enforces input limits", () => {
+    const parsed = conflictRecordInput.parse({
+      clientName: "  Acme Corp  ",
+      matterName: "  Acquisition  ",
+      parties: ["  Seller LLC "],
+      affiliates: [],
+    });
+    expect(parsed.clientName).toBe("Acme Corp");
+    expect(parsed.parties).toEqual(["Seller LLC"]);
+    expect(
+      conflictSearchInput.safeParse({
+        prospectiveClient: "x".repeat(201),
+        parties: [],
+        affiliates: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("does not allow pending_review to be submitted as a human decision", () => {
+    expect(
+      conflictReviewInput.safeParse({ status: "pending_review", notes: "No" })
+        .success,
+    ).toBe(false);
+    expect(
+      conflictReviewInput.safeParse({ status: "cleared", notes: "" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("conflicts matching helpers", () => {
+  const input = conflictSearchInput.parse({
+    prospectiveClient: "Acme",
+    matterName: "purchase",
+    parties: ["Jones"],
+    affiliates: ["Roadrunner"],
+  });
+
+  it("builds normalized search text and terms", () => {
+    expect(
+      normalizedSearchText({
+        clientName: "ACME",
+        matterName: "Purchase",
+        parties: ["Jones"],
+        affiliates: [],
+      }),
+    ).toBe("acme\npurchase\njones");
+    expect(searchTerms(input)).toEqual([
+      "acme",
+      "purchase",
+      "jones",
+      "roadrunner",
+    ]);
+  });
+
+  it("reports which relationship fields produced potential matches", () => {
+    expect(
+      matchedFields(
+        {
+          client_name: "Acme Holdings",
+          matter_name: "Asset purchase",
+          parties: ["Sam Jones"],
+          affiliates: ["Other Co"],
+        },
+        input,
+      ),
+    ).toEqual(["client", "matter", "party"]);
+  });
+
+  it("escapes PostgREST LIKE metacharacters", () => {
+    expect(escapeLike("100%_safe\\name")).toBe("100\\%\\_safe\\\\name");
+  });
+});

--- a/backend/src/lib/conflicts.ts
+++ b/backend/src/lib/conflicts.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+const name = z.string().trim().min(1).max(200);
+const optionalName = z
+  .string()
+  .trim()
+  .max(200)
+  .optional()
+  .transform((value) => value || undefined);
+const names = z.array(name).max(25).default([]);
+
+export const conflictRecordInput = z.object({
+  clientName: name,
+  matterName: optionalName,
+  parties: names,
+  affiliates: names,
+});
+
+export const conflictSearchInput = z
+  .object({
+    prospectiveClient: optionalName,
+    matterName: optionalName,
+    parties: names,
+    affiliates: names,
+  })
+  .refine(
+    (value) =>
+      Boolean(value.prospectiveClient) ||
+      value.parties.length > 0 ||
+      value.affiliates.length > 0,
+    { message: "Enter a prospective client, party, or affiliate" },
+  );
+
+export const conflictReviewInput = z.object({
+  status: z.enum(["cleared", "conflict_found"]),
+  notes: z.string().trim().min(1).max(2000),
+});
+
+export type ConflictRecordInput = z.infer<typeof conflictRecordInput>;
+export type ConflictSearchInput = z.infer<typeof conflictSearchInput>;
+
+export function normalizedSearchText(input: ConflictRecordInput): string {
+  return [
+    input.clientName,
+    input.matterName,
+    ...input.parties,
+    ...input.affiliates,
+  ]
+    .filter(Boolean)
+    .join("\n")
+    .toLocaleLowerCase();
+}
+
+export function searchTerms(input: ConflictSearchInput): string[] {
+  return [
+    input.prospectiveClient,
+    input.matterName,
+    ...input.parties,
+    ...input.affiliates,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .map((value) => value.toLocaleLowerCase());
+}
+
+export function escapeLike(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
+type StoredRecord = {
+  client_name: string;
+  matter_name: string | null;
+  parties: unknown;
+  affiliates: unknown;
+};
+
+export function matchedFields(
+  record: StoredRecord,
+  input: ConflictSearchInput,
+): string[] {
+  const candidateSets = {
+    client: [record.client_name],
+    matter: record.matter_name ? [record.matter_name] : [],
+    party: Array.isArray(record.parties) ? record.parties : [],
+    affiliate: Array.isArray(record.affiliates) ? record.affiliates : [],
+  } as const;
+  const terms = searchTerms(input);
+  return Object.entries(candidateSets)
+    .filter(([, values]) =>
+      values.some(
+        (value) =>
+          typeof value === "string" &&
+          terms.some((term) => value.toLocaleLowerCase().includes(term)),
+      ),
+    )
+    .map(([field]) => field);
+}

--- a/backend/src/routes/conflicts.ts
+++ b/backend/src/routes/conflicts.ts
@@ -1,0 +1,214 @@
+import { Router } from "express";
+import { requireAuth, requireMfaIfEnrolled } from "../middleware/auth";
+import { createServerSupabase } from "../lib/supabase";
+import {
+  conflictRecordInput,
+  conflictReviewInput,
+  conflictSearchInput,
+  escapeLike,
+  matchedFields,
+  normalizedSearchText,
+  searchTerms,
+} from "../lib/conflicts";
+
+export const conflictsRouter = Router();
+conflictsRouter.use(requireAuth, requireMfaIfEnrolled);
+
+const RECORD_COLUMNS =
+  "id, client_name, matter_name, parties, affiliates, created_at, updated_at";
+
+function validationError(error: { issues: { message: string }[] }) {
+  return error.issues[0]?.message ?? "Invalid conflicts-check input";
+}
+
+async function audit(
+  db: ReturnType<typeof createServerSupabase>,
+  ownerUserId: string,
+  action: "record.created" | "search.performed" | "review.decided",
+  links: { record_id?: string; search_id?: string; detail?: object },
+) {
+  const { error } = await db.from("conflict_audit_events").insert({
+    owner_user_id: ownerUserId,
+    actor_user_id: ownerUserId,
+    action,
+    record_id: links.record_id ?? null,
+    search_id: links.search_id ?? null,
+    detail: links.detail ?? null,
+  });
+  if (error) console.error("[conflicts/audit] insert failed:", error.message);
+}
+
+conflictsRouter.get("/records", async (_req, res) => {
+  const userId = res.locals.userId as string;
+  const db = createServerSupabase();
+  const { data, error } = await db
+    .from("conflict_records")
+    .select(RECORD_COLUMNS)
+    .eq("owner_user_id", userId)
+    .order("created_at", { ascending: false })
+    .limit(100);
+  if (error)
+    return void res
+      .status(500)
+      .json({ detail: "Unable to load conflict records" });
+  res.json({ records: data ?? [] });
+});
+
+conflictsRouter.post("/records", async (req, res) => {
+  const parsed = conflictRecordInput.safeParse(req.body);
+  if (!parsed.success)
+    return void res.status(400).json({ detail: validationError(parsed.error) });
+  const userId = res.locals.userId as string;
+  const db = createServerSupabase();
+  const input = parsed.data;
+  const { data, error } = await db
+    .from("conflict_records")
+    .insert({
+      owner_user_id: userId,
+      client_name: input.clientName,
+      matter_name: input.matterName ?? null,
+      parties: input.parties,
+      affiliates: input.affiliates,
+      search_text: normalizedSearchText(input),
+    })
+    .select(RECORD_COLUMNS)
+    .single();
+  if (error || !data)
+    return void res
+      .status(500)
+      .json({ detail: "Unable to create conflict record" });
+  await audit(db, userId, "record.created", { record_id: data.id });
+  res.status(201).json({ record: data });
+});
+
+conflictsRouter.post("/searches", async (req, res) => {
+  const parsed = conflictSearchInput.safeParse(req.body);
+  if (!parsed.success)
+    return void res.status(400).json({ detail: validationError(parsed.error) });
+  const userId = res.locals.userId as string;
+  const db = createServerSupabase();
+  const terms = searchTerms(parsed.data);
+  // Keep user input in parameter values instead of interpolating it into a
+  // PostgREST `.or(...)` expression. Besides escaping LIKE wildcards, this
+  // prevents punctuation in a name from changing the filter grammar.
+  const termResults = await Promise.all(
+    terms.map((term) =>
+      db
+        .from("conflict_records")
+        .select(RECORD_COLUMNS)
+        .eq("owner_user_id", userId)
+        .ilike("search_text", `%${escapeLike(term)}%`)
+        .order("created_at", { ascending: false })
+        .limit(50),
+    ),
+  );
+  if (termResults.some((result) => result.error))
+    return void res
+      .status(500)
+      .json({ detail: "Unable to search conflict records" });
+  const byId = new Map<string, any>();
+  for (const result of termResults) {
+    for (const row of result.data ?? []) byId.set(row.id, row);
+  }
+  const rows = [...byId.values()]
+    .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)))
+    .slice(0, 50);
+  const records = (rows ?? []).map((row) => ({
+    ...row,
+    matched_fields: matchedFields(row, parsed.data),
+  }));
+  const { data: search, error: insertError } = await db
+    .from("conflict_searches")
+    .insert({
+      owner_user_id: userId,
+      search_input: parsed.data,
+      matched_record_ids: records.map((record) => record.id),
+      result_count: records.length,
+      status: "pending_review",
+    })
+    .select(
+      "id, search_input, result_count, status, reviewer_notes, reviewed_at, created_at",
+    )
+    .single();
+  if (insertError || !search)
+    return void res
+      .status(500)
+      .json({ detail: "Unable to record conflict search" });
+  await audit(db, userId, "search.performed", {
+    search_id: search.id,
+    detail: { result_count: records.length },
+  });
+  res.status(201).json({
+    search,
+    records,
+    disclaimer:
+      "Potential matches are search aids only. A qualified human reviewer must decide whether a conflict exists and whether the matter may proceed.",
+  });
+});
+
+conflictsRouter.get("/searches", async (_req, res) => {
+  const userId = res.locals.userId as string;
+  const db = createServerSupabase();
+  const { data, error } = await db
+    .from("conflict_searches")
+    .select(
+      "id, search_input, result_count, status, reviewer_notes, reviewed_at, created_at",
+    )
+    .eq("owner_user_id", userId)
+    .order("created_at", { ascending: false })
+    .limit(50);
+  if (error)
+    return void res
+      .status(500)
+      .json({ detail: "Unable to load conflict searches" });
+  res.json({ searches: data ?? [] });
+});
+
+conflictsRouter.patch("/searches/:searchId/review", async (req, res) => {
+  const parsed = conflictReviewInput.safeParse(req.body);
+  if (!parsed.success)
+    return void res.status(400).json({ detail: validationError(parsed.error) });
+  const userId = res.locals.userId as string;
+  const db = createServerSupabase();
+  const { data, error } = await db
+    .from("conflict_searches")
+    .update({
+      status: parsed.data.status,
+      reviewer_notes: parsed.data.notes,
+      reviewed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", req.params.searchId)
+    .eq("owner_user_id", userId)
+    .select(
+      "id, search_input, result_count, status, reviewer_notes, reviewed_at, created_at",
+    )
+    .maybeSingle();
+  if (error)
+    return void res
+      .status(500)
+      .json({ detail: "Unable to record review decision" });
+  if (!data)
+    return void res.status(404).json({ detail: "Conflict search not found" });
+  await audit(db, userId, "review.decided", {
+    search_id: data.id,
+    detail: { status: parsed.data.status },
+  });
+  res.json({ search: data });
+});
+
+conflictsRouter.get("/audit", async (_req, res) => {
+  const userId = res.locals.userId as string;
+  const db = createServerSupabase();
+  const { data, error } = await db
+    .from("conflict_audit_events")
+    .select("id, action, record_id, search_id, detail, created_at")
+    .eq("owner_user_id", userId)
+    .order("created_at", { ascending: false })
+    .limit(100);
+  if (error)
+    return void res
+      .status(500)
+      .json({ detail: "Unable to load conflicts audit history" });
+  res.json({ events: data ?? [] });
+});

--- a/frontend/src/app/(pages)/conflicts/page.tsx
+++ b/frontend/src/app/(pages)/conflicts/page.tsx
@@ -1,0 +1,507 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  History,
+  Loader2,
+  Plus,
+  Search,
+  ShieldCheck,
+} from "lucide-react";
+import { PageHeader } from "@/app/components/shared/PageHeader";
+import { Button } from "@/app/components/ui/button";
+import {
+  createConflictRecord,
+  listConflictAuditEvents,
+  listConflictRecords,
+  listConflictSearches,
+  reviewConflictSearch,
+  runConflictSearch,
+  type ConflictAuditEvent,
+  type ConflictRecord,
+  type ConflictSearch,
+} from "@/app/lib/mikeApi";
+
+function lines(value: string): string[] {
+  return value
+    .split(/[\n,]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+const fieldClass =
+  "w-full rounded-xl border border-gray-200 bg-white/80 px-3 py-2 text-sm outline-none focus:border-gray-400";
+const cardClass =
+  "rounded-2xl border border-white/80 bg-app-surface p-5 shadow-[0_8px_24px_rgba(15,23,42,0.06)]";
+
+export default function ConflictsPage() {
+  const [records, setRecords] = useState<ConflictRecord[]>([]);
+  const [searches, setSearches] = useState<ConflictSearch[]>([]);
+  const [events, setEvents] = useState<ConflictAuditEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [showRecordForm, setShowRecordForm] = useState(false);
+  const [recordForm, setRecordForm] = useState({
+    clientName: "",
+    matterName: "",
+    parties: "",
+    affiliates: "",
+  });
+  const [searchForm, setSearchForm] = useState({
+    prospectiveClient: "",
+    matterName: "",
+    parties: "",
+    affiliates: "",
+  });
+  const [result, setResult] = useState<{
+    search: ConflictSearch;
+    records: ConflictRecord[];
+    disclaimer: string;
+  } | null>(null);
+  const [decision, setDecision] = useState<"cleared" | "conflict_found">(
+    "cleared",
+  );
+  const [notes, setNotes] = useState("");
+
+  const refresh = useCallback(async () => {
+    try {
+      const [nextRecords, nextSearches, nextEvents] = await Promise.all([
+        listConflictRecords(),
+        listConflictSearches(),
+        listConflictAuditEvents(),
+      ]);
+      setRecords(nextRecords);
+      setSearches(nextSearches);
+      setEvents(nextEvents);
+      setError("");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Unable to load conflicts data",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => void refresh(), 0);
+    return () => window.clearTimeout(timer);
+  }, [refresh]);
+
+  const addRecord = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setBusy(true);
+    setError("");
+    try {
+      await createConflictRecord({
+        clientName: recordForm.clientName,
+        matterName: recordForm.matterName || undefined,
+        parties: lines(recordForm.parties),
+        affiliates: lines(recordForm.affiliates),
+      });
+      setRecordForm({
+        clientName: "",
+        matterName: "",
+        parties: "",
+        affiliates: "",
+      });
+      setShowRecordForm(false);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to add record");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const performSearch = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setBusy(true);
+    setError("");
+    setResult(null);
+    setNotes("");
+    try {
+      const next = await runConflictSearch({
+        prospectiveClient: searchForm.prospectiveClient || undefined,
+        matterName: searchForm.matterName || undefined,
+        parties: lines(searchForm.parties),
+        affiliates: lines(searchForm.affiliates),
+      });
+      setResult(next);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to run search");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveDecision = async () => {
+    if (!result) return;
+    setBusy(true);
+    setError("");
+    try {
+      const updated = await reviewConflictSearch(result.search.id, {
+        status: decision,
+        notes,
+      });
+      setResult({ ...result, search: updated });
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to save decision");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <PageHeader shrink>
+        <div className="flex items-center gap-2 text-xl font-semibold">
+          <ShieldCheck className="h-5 w-5" /> Conflicts
+        </div>
+      </PageHeader>
+      <div className="flex-1 overflow-y-auto px-4 pb-10 md:px-6">
+        <div className="mx-auto max-w-6xl space-y-5">
+          <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950">
+            <strong>Human review required.</strong> Search results are potential
+            matches only. Mike does not determine that a conflict is cleared or
+            that a matter may proceed.
+          </div>
+          {error && (
+            <div
+              role="alert"
+              className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"
+            >
+              {error}
+            </div>
+          )}
+          <div className="grid gap-5 lg:grid-cols-[1.25fr_.75fr]">
+            <section className={cardClass}>
+              <div className="mb-4 flex items-center gap-2">
+                <Search className="h-4 w-4" />
+                <h2 className="font-semibold">New conflicts check</h2>
+              </div>
+              <form
+                onSubmit={performSearch}
+                className="grid gap-3 sm:grid-cols-2"
+              >
+                <label className="text-sm">
+                  Prospective client
+                  <input
+                    aria-label="Prospective client"
+                    className={`${fieldClass} mt-1`}
+                    value={searchForm.prospectiveClient}
+                    onChange={(e) =>
+                      setSearchForm({
+                        ...searchForm,
+                        prospectiveClient: e.target.value,
+                      })
+                    }
+                    maxLength={200}
+                  />
+                </label>
+                <label className="text-sm">
+                  Matter name
+                  <input
+                    aria-label="Matter name"
+                    className={`${fieldClass} mt-1`}
+                    value={searchForm.matterName}
+                    onChange={(e) =>
+                      setSearchForm({
+                        ...searchForm,
+                        matterName: e.target.value,
+                      })
+                    }
+                    maxLength={200}
+                  />
+                </label>
+                <label className="text-sm">
+                  Parties <span className="text-gray-500">(one per line)</span>
+                  <textarea
+                    aria-label="Parties"
+                    className={`${fieldClass} mt-1 min-h-24`}
+                    value={searchForm.parties}
+                    onChange={(e) =>
+                      setSearchForm({ ...searchForm, parties: e.target.value })
+                    }
+                  />
+                </label>
+                <label className="text-sm">
+                  Affiliates{" "}
+                  <span className="text-gray-500">(one per line)</span>
+                  <textarea
+                    aria-label="Affiliates"
+                    className={`${fieldClass} mt-1 min-h-24`}
+                    value={searchForm.affiliates}
+                    onChange={(e) =>
+                      setSearchForm({
+                        ...searchForm,
+                        affiliates: e.target.value,
+                      })
+                    }
+                  />
+                </label>
+                <div className="sm:col-span-2">
+                  <Button disabled={busy} type="submit">
+                    {busy ? <Loader2 className="animate-spin" /> : <Search />}{" "}
+                    Search restricted records
+                  </Button>
+                </div>
+              </form>
+            </section>
+            <section className={cardClass}>
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="font-semibold">Restricted records</h2>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setShowRecordForm((value) => !value)}
+                >
+                  <Plus /> Add
+                </Button>
+              </div>
+              {showRecordForm && (
+                <form onSubmit={addRecord} className="mb-4 space-y-2">
+                  <input
+                    required
+                    aria-label="Record client"
+                    placeholder="Client name"
+                    className={fieldClass}
+                    value={recordForm.clientName}
+                    onChange={(e) =>
+                      setRecordForm({
+                        ...recordForm,
+                        clientName: e.target.value,
+                      })
+                    }
+                    maxLength={200}
+                  />
+                  <input
+                    aria-label="Record matter"
+                    placeholder="Matter name"
+                    className={fieldClass}
+                    value={recordForm.matterName}
+                    onChange={(e) =>
+                      setRecordForm({
+                        ...recordForm,
+                        matterName: e.target.value,
+                      })
+                    }
+                    maxLength={200}
+                  />
+                  <textarea
+                    aria-label="Record parties"
+                    placeholder="Parties, one per line"
+                    className={fieldClass}
+                    value={recordForm.parties}
+                    onChange={(e) =>
+                      setRecordForm({ ...recordForm, parties: e.target.value })
+                    }
+                  />
+                  <textarea
+                    aria-label="Record affiliates"
+                    placeholder="Affiliates, one per line"
+                    className={fieldClass}
+                    value={recordForm.affiliates}
+                    onChange={(e) =>
+                      setRecordForm({
+                        ...recordForm,
+                        affiliates: e.target.value,
+                      })
+                    }
+                  />
+                  <Button size="sm" disabled={busy} type="submit">
+                    Save restricted record
+                  </Button>
+                </form>
+              )}
+              {loading ? (
+                <Loader2 className="animate-spin text-gray-400" />
+              ) : records.length === 0 ? (
+                <p className="text-sm text-gray-500">
+                  No restricted records yet.
+                </p>
+              ) : (
+                <div className="max-h-72 space-y-2 overflow-y-auto">
+                  {records.map((record) => (
+                    <div
+                      key={record.id}
+                      className="rounded-xl border border-gray-100 bg-white/60 p-3 text-sm"
+                    >
+                      <div className="font-medium">{record.client_name}</div>
+                      <div className="text-gray-500">
+                        {record.matter_name || "No matter name"}
+                      </div>
+                      <div className="mt-1 text-xs text-gray-500">
+                        {record.parties.length} parties ·{" "}
+                        {record.affiliates.length} affiliates
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+          </div>
+
+          {result && (
+            <section className={cardClass} aria-label="Search results">
+              <div className="mb-3 flex items-center justify-between">
+                <h2 className="font-semibold">
+                  Potential matches ({result.records.length})
+                </h2>
+                <span className="rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800">
+                  Pending human review
+                </span>
+              </div>
+              <p className="mb-4 text-sm text-gray-600">{result.disclaimer}</p>
+              {result.records.length === 0 ? (
+                <p className="rounded-xl bg-gray-50 p-3 text-sm text-gray-600">
+                  No matches were found in the current restricted records. This
+                  is not an automatic clearance.
+                </p>
+              ) : (
+                <div className="mb-4 grid gap-2 sm:grid-cols-2">
+                  {result.records.map((record) => (
+                    <div
+                      key={record.id}
+                      className="rounded-xl border border-amber-100 bg-amber-50/60 p-3 text-sm"
+                    >
+                      <div className="font-medium">{record.client_name}</div>
+                      <div>{record.matter_name || "No matter name"}</div>
+                      <div className="mt-1 text-xs text-amber-800">
+                        Matched: {record.matched_fields?.join(", ")}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {result.search.status === "pending_review" ? (
+                <div className="rounded-xl border border-gray-200 p-4">
+                  <h3 className="mb-3 text-sm font-semibold">
+                    Reviewer decision
+                  </h3>
+                  <div className="mb-3 flex gap-4 text-sm">
+                    <label>
+                      <input
+                        type="radio"
+                        checked={decision === "cleared"}
+                        onChange={() => setDecision("cleared")}
+                      />{" "}
+                      Cleared by reviewer
+                    </label>
+                    <label>
+                      <input
+                        type="radio"
+                        checked={decision === "conflict_found"}
+                        onChange={() => setDecision("conflict_found")}
+                      />{" "}
+                      Conflict found
+                    </label>
+                  </div>
+                  <textarea
+                    aria-label="Review rationale"
+                    required
+                    placeholder="Document the reviewer’s rationale"
+                    className={`${fieldClass} mb-3`}
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                    maxLength={2000}
+                  />
+                  <Button
+                    onClick={saveDecision}
+                    disabled={busy || !notes.trim()}
+                  >
+                    Record human decision
+                  </Button>
+                </div>
+              ) : (
+                <div
+                  className={`flex items-start gap-2 rounded-xl p-3 text-sm ${result.search.status === "cleared" ? "bg-green-50 text-green-800" : "bg-red-50 text-red-800"}`}
+                >
+                  {result.search.status === "cleared" ? (
+                    <CheckCircle2 />
+                  ) : (
+                    <AlertTriangle />
+                  )}
+                  <div>
+                    <strong>
+                      {result.search.status === "cleared"
+                        ? "Cleared by reviewer"
+                        : "Conflict found by reviewer"}
+                    </strong>
+                    <p>{result.search.reviewer_notes}</p>
+                  </div>
+                </div>
+              )}
+            </section>
+          )}
+
+          <div className="grid gap-5 lg:grid-cols-2">
+            <section className={cardClass}>
+              <div className="mb-3 flex items-center gap-2">
+                <History className="h-4 w-4" />
+                <h2 className="font-semibold">Review history</h2>
+              </div>
+              {searches.length === 0 ? (
+                <p className="text-sm text-gray-500">No searches yet.</p>
+              ) : (
+                <div className="space-y-2">
+                  {searches.slice(0, 10).map((search) => (
+                    <div
+                      key={search.id}
+                      className="rounded-xl border border-gray-100 p-3 text-sm"
+                    >
+                      <div className="flex justify-between gap-2">
+                        <span className="font-medium">
+                          {search.search_input.prospectiveClient ||
+                            search.search_input.parties[0] ||
+                            "Structured search"}
+                        </span>
+                        <span>{search.status.replaceAll("_", " ")}</span>
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        {search.result_count} potential matches ·{" "}
+                        {formatDate(search.created_at)}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+            <section className={cardClass}>
+              <h2 className="mb-3 font-semibold">Conflicts audit trail</h2>
+              {events.length === 0 ? (
+                <p className="text-sm text-gray-500">No audit events yet.</p>
+              ) : (
+                <div className="space-y-2">
+                  {events.slice(0, 10).map((event) => (
+                    <div
+                      key={event.id}
+                      className="flex justify-between rounded-xl border border-gray-100 p-3 text-sm"
+                    >
+                      <span>{event.action.replaceAll(".", " ")}</span>
+                      <span className="text-xs text-gray-500">
+                        {formatDate(event.created_at)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/components/shared/AppSidebar.tsx
+++ b/frontend/src/app/components/shared/AppSidebar.tsx
@@ -14,6 +14,7 @@ import {
     ChevronsUpDown,
     ChevronDown,
   Loader2,
+  ShieldCheck,
 } from "lucide-react";
 import { useAuth } from "@/app/contexts/AuthContext";
 import { useUserProfile } from "@/app/contexts/UserProfileContext";
@@ -49,6 +50,7 @@ const NAV_ITEMS = [
     icon: TabularReviewSkeuoIcon,
   },
     { href: "/workflows", label: "Workflows", icon: WorkflowSkeuoIcon },
+    { href: "/conflicts", label: "Conflicts", icon: ShieldCheck },
 ];
 
 const RECENT_PROJECT_PAGE_SIZE = 10;

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -444,6 +444,116 @@ export async function exportAuditHistory(params: {
     return apiBlobRequest(`/audit/export?${qs.toString()}`);
 }
 
+// ---------------------------------------------------------------------------
+// Restricted conflicts checks
+// ---------------------------------------------------------------------------
+
+export interface ConflictRecord {
+  id: string;
+  client_name: string;
+  matter_name: string | null;
+  parties: string[];
+  affiliates: string[];
+  created_at: string;
+  matched_fields?: string[];
+}
+
+export interface ConflictSearch {
+  id: string;
+  search_input: {
+    prospectiveClient?: string;
+    matterName?: string;
+    parties: string[];
+    affiliates: string[];
+  };
+  result_count: number;
+  status: "pending_review" | "cleared" | "conflict_found";
+  reviewer_notes: string | null;
+  reviewed_at: string | null;
+  created_at: string;
+}
+
+export interface ConflictAuditEvent {
+  id: string;
+  action: "record.created" | "search.performed" | "review.decided";
+  record_id: string | null;
+  search_id: string | null;
+  detail: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export type ConflictNamesInput = {
+  prospectiveClient?: string;
+  matterName?: string;
+  parties: string[];
+  affiliates: string[];
+};
+
+export async function listConflictRecords(): Promise<ConflictRecord[]> {
+  const out = await apiRequest<{ records: ConflictRecord[] }>(
+    "/conflicts/records",
+  );
+  return out.records;
+}
+
+export async function createConflictRecord(input: {
+  clientName: string;
+  matterName?: string;
+  parties: string[];
+  affiliates: string[];
+}): Promise<ConflictRecord> {
+  const out = await apiRequest<{ record: ConflictRecord }>(
+    "/conflicts/records",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    },
+  );
+  return out.record;
+}
+
+export async function runConflictSearch(input: ConflictNamesInput): Promise<{
+  search: ConflictSearch;
+  records: ConflictRecord[];
+  disclaimer: string;
+}> {
+  return apiRequest("/conflicts/searches", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+}
+
+export async function listConflictSearches(): Promise<ConflictSearch[]> {
+  const out = await apiRequest<{ searches: ConflictSearch[] }>(
+    "/conflicts/searches",
+  );
+  return out.searches;
+}
+
+export async function reviewConflictSearch(
+  searchId: string,
+  input: { status: "cleared" | "conflict_found"; notes: string },
+): Promise<ConflictSearch> {
+  const out = await apiRequest<{ search: ConflictSearch }>(
+    `/conflicts/searches/${encodeURIComponent(searchId)}/review`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    },
+  );
+  return out.search;
+}
+
+export async function listConflictAuditEvents(): Promise<ConflictAuditEvent[]> {
+  const out = await apiRequest<{ events: ConflictAuditEvent[] }>(
+    "/conflicts/audit",
+  );
+  return out.events;
+}
+
 export async function getUserProfile(): Promise<UserProfile> {
     return apiRequest<UserProfile>("/user/profile");
 }


### PR DESCRIPTION
## What changed

- add backend-only conflict records for client, matter, party, and affiliate relationships
- add owner-scoped, MFA-aware APIs for structured search, reviewer decisions, and conflicts audit history
- add a dedicated Conflicts page and sidebar entry
- require a human reviewer to record either `cleared` or `conflict_found` with rationale
- add database migration, schema updates, validation helpers, and unit tests

## Why

Conflicts data is sensitive and should not be exposed through broad project, library, search, or general-history endpoints. This creates a small end-to-end workflow with dedicated storage and access controls while treating search results only as potential matches.

## Security and user impact

Browser roles have no direct access to the conflicts tables, RLS is enabled without permissive policies, and every API query is scoped to the authenticated owner. Searches remain `pending_review` until a human records a decision; the application never automatically clears a conflict.

## Validation

- backend tests: 556 passed, 23 skipped
- backend TypeScript check: passed
- frontend TypeScript check: passed
- targeted frontend lint: passed
- frontend tests: 276 passed; 4 existing `Blob.text()` export assertions failed under the available local runtime/dependency combination and are unrelated to this change
- `git diff --check`: passed
