### PR TITLE
fix(db): enforce auth user foreign keys

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -124,39 +124,18 @@ jobs:
         uses: supabase/setup-cli@v1
         with:
           version: latest
-      - name: Init + start Supabase, load schema + migrations
+      - name: Init + start Supabase, load fresh schema
         run: |
           supabase init --force --with-vscode-settings=false || supabase init --force
           supabase start
           DB_URL=$(supabase status -o json | jq -r '.DB_URL')
-          # 1) Base schema. README: "For a new Supabase database ... run
-          # backend/schema.sql". It is meant to be the latest shape but in practice
-          # lags the migrations (e.g. it is missing workflow_open_source_submissions,
-          # which GET /workflows/:id queries — a 500 that breaks the workflow specs).
+          # A fresh database runs the current schema exactly once. Historical
+          # migrations only upgrade older deployments; replaying them on top of
+          # schema.sql can overwrite current functions with obsolete definitions.
+          # The schema-drift workflow separately proves that the real upgrade path
+          # (pinned baseline + migrations) converges with this fresh-install path.
           psql "$DB_URL" -v ON_ERROR_STOP=1 -f backend/schema.sql
-          # 2) Apply every dated migration on top. They are written to be safe to
-          # re-run (IF NOT EXISTS / ADD COLUMN IF NOT EXISTS), so the ones already
-          # in schema.sql are no-ops and the newer ones fill the gaps. Verified on a
-          # fresh CLI DB: all migrations apply with zero errors. Kept fail-tolerant
-          # so one non-idempotent migration can't wedge the whole gate — mismatches
-          # surface as a spec failure downstream, not an opaque CI abort.
-          for m in $(ls backend/migrations/*.sql | sort); do
-            psql "$DB_URL" -v ON_ERROR_STOP=1 -f "$m" >/dev/null 2>&1 \
-              || echo "::warning::migration returned a non-zero status (already applied?): $m"
-          done
-          # 3) schema.sql now grants service_role its narrowed data privileges
-          # itself, but those GRANT ... ON ALL statements only cover tables that
-          # exist when schema.sql runs — tables created by the migrations above
-          # are not covered, and the backend (which queries exclusively as
-          # service_role, lib/supabase.ts) 500s with "permission denied" on them.
-          # Re-grant AFTER migrations with the SAME privilege set as schema.sql —
-          # deliberately not ALL, so e2e cannot pass on a privilege prod lacks.
-          psql "$DB_URL" -v ON_ERROR_STOP=1 <<'SQL'
-          GRANT USAGE ON SCHEMA public TO service_role;
-          GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO service_role;
-          GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO service_role;
-          SQL
-          # 4) PostgREST cached its schema when `supabase start` booted it (before
+          # PostgREST cached its schema when `supabase start` booted it (before
           # the DDL above). Tell it to reload so the new tables/grants are visible.
           psql "$DB_URL" -v ON_ERROR_STOP=1 -c "NOTIFY pgrst, 'reload schema';"
 

--- a/backend/migrations/20260813_01_user_id_foreign_keys.sql
+++ b/backend/migrations/20260813_01_user_id_foreign_keys.sql
@@ -1,0 +1,1087 @@
+-- Migration date: 2026-08-13
+--
+-- Enforce issue #104's missing auth.users referential integrity across every
+-- application-owned user identifier. RPC parameters and return columns remain
+-- text for API compatibility; their SQL bodies cast at the database boundary.
+
+begin;
+
+-- Refuse to reinterpret malformed identifiers. Orphaned, well-formed UUIDs are
+-- rejected below when the foreign keys are validated.
+do $$
+declare
+  target record;
+  invalid_count bigint;
+begin
+  for target in
+    select *
+    from (values
+      ('projects', 'user_id'),
+      ('project_subfolders', 'user_id'),
+      ('library_folders', 'user_id'),
+      ('documents', 'user_id'),
+      ('workflows', 'user_id'),
+      ('hidden_workflows', 'user_id'),
+      ('workflow_shares', 'shared_by_user_id'),
+      ('default_workflow_installations', 'user_id'),
+      ('quick_actions', 'user_id'),
+      ('workflow_reference_documents', 'user_id'),
+      ('workflow_open_source_submissions', 'submitted_by_user_id'),
+      ('chats', 'user_id'),
+      ('word_documents', 'user_id'),
+      ('word_chats', 'user_id'),
+      ('tabular_reviews', 'user_id'),
+      ('tabular_review_chats', 'user_id')
+    ) as columns_to_convert(table_name, column_name)
+  loop
+    execute format(
+      'select count(*) from public.%I where %I is not null and %I !~* %L',
+      target.table_name,
+      target.column_name,
+      target.column_name,
+      '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    ) into invalid_count;
+
+    if invalid_count > 0 then
+      raise exception
+        'Cannot convert %.% to uuid: % malformed value(s)',
+        target.table_name,
+        target.column_name,
+        invalid_count;
+    end if;
+  end loop;
+end
+$$;
+
+alter table public.projects
+  alter column user_id type uuid using user_id::uuid;
+alter table public.project_subfolders
+  alter column user_id type uuid using user_id::uuid;
+alter table public.library_folders
+  alter column user_id type uuid using user_id::uuid;
+alter table public.documents
+  alter column user_id type uuid using user_id::uuid;
+alter table public.workflows
+  alter column user_id type uuid using user_id::uuid;
+alter table public.hidden_workflows
+  alter column user_id type uuid using user_id::uuid;
+alter table public.workflow_shares
+  alter column shared_by_user_id type uuid using shared_by_user_id::uuid;
+alter table public.default_workflow_installations
+  alter column user_id type uuid using user_id::uuid;
+alter table public.quick_actions
+  alter column user_id type uuid using user_id::uuid;
+alter table public.workflow_reference_documents
+  alter column user_id type uuid using user_id::uuid;
+alter table public.workflow_open_source_submissions
+  alter column submitted_by_user_id type uuid using submitted_by_user_id::uuid;
+alter table public.chats
+  alter column user_id type uuid using user_id::uuid;
+alter table public.word_documents
+  alter column user_id type uuid using user_id::uuid;
+alter table public.word_chats
+  alter column user_id type uuid using user_id::uuid;
+alter table public.tabular_reviews
+  alter column user_id type uuid using user_id::uuid;
+alter table public.tabular_review_chats
+  alter column user_id type uuid using user_id::uuid;
+
+-- NOT VALID separates installation from verification, so an orphan identifies
+-- the exact relationship that must be repaired without partially committing.
+alter table public.projects
+  add constraint projects_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.project_subfolders
+  add constraint project_subfolders_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.library_folders
+  add constraint library_folders_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.documents
+  add constraint documents_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.document_versions
+  add constraint document_versions_deleted_by_fkey
+  foreign key (deleted_by) references auth.users(id) on delete set null not valid;
+alter table public.workflows
+  add constraint workflows_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.hidden_workflows
+  add constraint hidden_workflows_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.workflow_shares
+  add constraint workflow_shares_shared_by_user_id_fkey
+  foreign key (shared_by_user_id) references auth.users(id) on delete cascade not valid;
+alter table public.default_workflow_installations
+  add constraint default_workflow_installations_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.quick_actions
+  add constraint quick_actions_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.workflow_reference_documents
+  add constraint workflow_reference_documents_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.workflow_open_source_submissions
+  add constraint workflow_open_source_submissions_submitted_by_user_id_fkey
+  foreign key (submitted_by_user_id) references auth.users(id) on delete cascade not valid;
+alter table public.chats
+  add constraint chats_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.word_documents
+  add constraint word_documents_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.word_chats
+  add constraint word_chats_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.tabular_reviews
+  add constraint tabular_reviews_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.tabular_review_chats
+  add constraint tabular_review_chats_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+alter table public.audit_events
+  add constraint audit_events_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete cascade not valid;
+
+alter table public.projects validate constraint projects_user_id_fkey;
+alter table public.project_subfolders validate constraint project_subfolders_user_id_fkey;
+alter table public.library_folders validate constraint library_folders_user_id_fkey;
+alter table public.documents validate constraint documents_user_id_fkey;
+alter table public.document_versions validate constraint document_versions_deleted_by_fkey;
+alter table public.workflows validate constraint workflows_user_id_fkey;
+alter table public.hidden_workflows validate constraint hidden_workflows_user_id_fkey;
+alter table public.workflow_shares validate constraint workflow_shares_shared_by_user_id_fkey;
+alter table public.default_workflow_installations validate constraint default_workflow_installations_user_id_fkey;
+alter table public.quick_actions validate constraint quick_actions_user_id_fkey;
+alter table public.workflow_reference_documents validate constraint workflow_reference_documents_user_id_fkey;
+alter table public.workflow_open_source_submissions validate constraint workflow_open_source_submissions_submitted_by_user_id_fkey;
+alter table public.chats validate constraint chats_user_id_fkey;
+alter table public.word_documents validate constraint word_documents_user_id_fkey;
+alter table public.word_chats validate constraint word_chats_user_id_fkey;
+alter table public.tabular_reviews validate constraint tabular_reviews_user_id_fkey;
+alter table public.tabular_review_chats validate constraint tabular_review_chats_user_id_fkey;
+alter table public.audit_events validate constraint audit_events_user_id_fkey;
+
+-- Recompile RPCs that expose text user IDs while the storage columns are UUID.
+create or replace function public.install_missing_default_workflows(
+  p_user_id text,
+  p_defaults jsonb
+)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  item jsonb;
+  workflow_uuid uuid;
+  installed_count integer := 0;
+  jurisdiction_values text[];
+begin
+  perform pg_advisory_xact_lock(hashtextextended(p_user_id, 0));
+
+  for item in select value from jsonb_array_elements(coalesce(p_defaults, '[]'::jsonb))
+  loop
+    if nullif(trim(item->>'default_key'), '') is null then
+      continue;
+    end if;
+
+    if exists (
+      select 1
+      from public.default_workflow_installations dwi
+      where dwi.user_id::text = p_user_id
+        and dwi.default_key = item->>'default_key'
+    ) then
+      continue;
+    end if;
+
+    select coalesce(array_agg(value), array['General']::text[])
+      into jurisdiction_values
+    from jsonb_array_elements_text(
+      case
+        when jsonb_typeof(item->'jurisdictions') = 'array'
+          then item->'jurisdictions'
+        else '["General"]'::jsonb
+      end
+    );
+
+    insert into public.workflows (
+      user_id,
+      title,
+      type,
+      prompt_md,
+      columns_config,
+      language,
+      practice,
+      jurisdictions
+    ) values (
+      p_user_id::uuid,
+      item->>'title',
+      item->>'type',
+      nullif(item->>'prompt_md', ''),
+      case
+        when jsonb_typeof(item->'columns_config') = 'array'
+          then item->'columns_config'
+        else null
+      end,
+      coalesce(nullif(item->>'language', ''), 'English'),
+      coalesce(nullif(item->>'practice', ''), 'General Transactions'),
+      jurisdiction_values
+    )
+    returning id into workflow_uuid;
+
+    insert into public.default_workflow_installations (
+      user_id,
+      default_key,
+      workflow_id
+    ) values (
+      p_user_id::uuid,
+      item->>'default_key',
+      workflow_uuid
+    );
+
+    insert into public.quick_actions (
+      user_id,
+      workflow_id,
+      prompt,
+      document_upload,
+      enabled,
+      sort_order
+    ) values (
+      p_user_id::uuid,
+      workflow_uuid,
+      coalesce(item->>'quick_action_prompt', ''),
+      coalesce((item->>'document_upload')::boolean, false),
+      true,
+      coalesce((item->>'sort_order')::integer, installed_count)
+    );
+
+    installed_count := installed_count + 1;
+  end loop;
+
+  return installed_count;
+end;
+$$;
+
+create or replace function public.get_chats_overview(
+  p_user_id text,
+  p_limit integer default null,
+  p_offset integer default 0
+)
+returns table (
+  id uuid,
+  project_id uuid,
+  user_id text,
+  title text,
+  created_at timestamptz,
+  project_name text
+)
+language sql
+stable
+as $$
+  select
+    c.id,
+    c.project_id,
+    c.user_id::text as user_id,
+    c.title,
+    c.created_at,
+    p.name as project_name
+  from public.chats c
+  left join public.projects p on p.id = c.project_id
+  where c.user_id::text = p_user_id
+     or (
+       p.id is not null
+       and p.user_id::text = p_user_id
+     )
+  order by c.created_at desc, c.id asc
+  limit case
+    when p_limit is null then null
+    else greatest(1, least(p_limit, 100))
+  end
+  offset greatest(coalesce(p_offset, 0), 0);
+$$;
+
+create or replace function public.get_projects_overview(
+  p_user_id text,
+  p_user_email text default null
+)
+returns table (
+  id uuid,
+  user_id text,
+  name text,
+  cm_number text,
+  practice text,
+  shared_with jsonb,
+  created_at timestamptz,
+  updated_at timestamptz,
+  is_owner boolean,
+  owner_display_name text,
+  owner_email text,
+  document_count integer,
+  chat_count integer,
+  review_count integer
+)
+language sql
+stable
+as $$
+  with visible_projects as (
+    select p.*
+    from public.projects p
+    where p.user_id::text = p_user_id
+       or (
+        coalesce(p_user_email, '') <> ''
+        and p.user_id::text <> p_user_id
+        and p.shared_with @> jsonb_build_array(p_user_email)
+      )
+  ),
+  document_counts as (
+    select d.project_id, count(*)::integer as document_count
+    from public.documents d
+    where d.project_id in (select vp.id from visible_projects vp)
+    group by d.project_id
+  ),
+  chat_counts as (
+    select c.project_id, count(*)::integer as chat_count
+    from public.chats c
+    where c.project_id in (select vp.id from visible_projects vp)
+    group by c.project_id
+  ),
+  review_counts as (
+    select tr.project_id, count(*)::integer as review_count
+    from public.tabular_reviews tr
+    where tr.project_id in (select vp.id from visible_projects vp)
+    group by tr.project_id
+  )
+  select
+    vp.id,
+    vp.user_id::text as user_id,
+    vp.name,
+    vp.cm_number,
+    vp.practice,
+    vp.shared_with,
+    vp.created_at,
+    vp.updated_at,
+    vp.user_id::text = p_user_id as is_owner,
+    nullif(trim(up.display_name), '') as owner_display_name,
+    null::text as owner_email,
+    coalesce(dc.document_count, 0) as document_count,
+    coalesce(cc.chat_count, 0) as chat_count,
+    coalesce(rc.review_count, 0) as review_count
+  from visible_projects vp
+  left join public.user_profiles up
+    on up.user_id::text = vp.user_id::text
+  left join document_counts dc
+    on dc.project_id = vp.id
+  left join chat_counts cc
+    on cc.project_id = vp.id
+  left join review_counts rc
+    on rc.project_id = vp.id
+  order by vp.created_at desc;
+$$;
+
+create or replace function public.get_tabular_reviews_overview(
+  p_user_id text,
+  p_user_email text,
+  p_project_id text,
+  p_scope text,
+  p_limit integer,
+  p_offset integer,
+  p_search_term text,
+  p_sort_key text,
+  p_sort_direction text
+)
+returns table (
+  id uuid,
+  project_id uuid,
+  user_id text,
+  title text,
+  columns_config jsonb,
+  document_ids jsonb,
+  workflow_id uuid,
+  shared_with jsonb,
+  created_at timestamptz,
+  updated_at timestamptz,
+  is_owner boolean,
+  document_count integer
+)
+language sql
+stable
+as $$
+  with accessible_projects as (
+    select p.id
+    from public.projects p
+    where p.user_id::text = p_user_id
+       or (
+        coalesce(p_user_email, '') <> ''
+        and p.user_id::text <> p_user_id
+        and p.shared_with @> jsonb_build_array(p_user_email)
+      )
+  ),
+  visible_reviews as (
+    select tr.*
+    from public.tabular_reviews tr
+    where (p_project_id is null or tr.project_id::text = p_project_id)
+      and (
+        coalesce(p_scope, 'all') = 'all'
+        or (p_scope = 'in-project' and tr.project_id is not null)
+        or (p_scope = 'standalone' and tr.project_id is null)
+      )
+      and (
+        p_search_term is null
+        or p_search_term = ''
+        or lower(tr.title) like
+          '%' ||
+          replace(
+            replace(
+              replace(lower(p_search_term), '\', '\\'),
+              '%',
+              '\%'
+            ),
+            '_',
+            '\_'
+          ) ||
+          '%'
+          escape '\'
+      )
+      and (
+        p_project_id is null
+        or exists (
+          select 1
+          from accessible_projects ap
+          where ap.id::text = p_project_id
+        )
+      )
+      and (
+        tr.user_id::text = p_user_id
+        or (
+          tr.project_id in (select ap.id from accessible_projects ap)
+          and tr.user_id::text <> p_user_id
+        )
+        or (
+          p_project_id is null
+          and coalesce(p_user_email, '') <> ''
+          and tr.user_id::text <> p_user_id
+          and tr.shared_with @> jsonb_build_array(p_user_email)
+        )
+      )
+  ),
+  cell_document_counts as (
+    select
+      tc.review_id,
+      count(distinct tc.document_id)::integer as document_count
+    from public.tabular_cells tc
+    where tc.review_id in (
+      select vr.id
+      from visible_reviews vr
+      where jsonb_typeof(vr.document_ids) is distinct from 'array'
+    )
+    group by tc.review_id
+  ),
+  review_document_counts as (
+    select
+      vr.id,
+      case
+        when jsonb_typeof(vr.document_ids) = 'array'
+          then (
+            select count(distinct doc_id.value)::integer
+            from jsonb_array_elements_text(vr.document_ids) as doc_id(value)
+          )
+        else coalesce(cdc.document_count, 0)
+      end as document_count
+    from visible_reviews vr
+    left join cell_document_counts cdc
+      on cdc.review_id = vr.id
+  )
+  select
+    vr.id,
+    vr.project_id,
+    vr.user_id::text as user_id,
+    vr.title,
+    vr.columns_config,
+    vr.document_ids,
+    vr.workflow_id,
+    vr.shared_with,
+    vr.created_at,
+    vr.updated_at,
+    vr.user_id::text = p_user_id as is_owner,
+    rdc.document_count
+  from visible_reviews vr
+  join review_document_counts rdc
+    on rdc.id = vr.id
+  order by
+    case
+      when p_sort_key = 'name' and p_sort_direction = 'asc' then lower(coalesce(vr.title, ''))
+      else null
+    end asc,
+    case
+      when p_sort_key = 'name' and p_sort_direction = 'desc' then lower(coalesce(vr.title, ''))
+      else null
+    end desc,
+    case
+      when p_sort_key = 'columns' and p_sort_direction = 'asc' then jsonb_array_length(coalesce(vr.columns_config, '[]'::jsonb))
+      else null
+    end asc,
+    case
+      when p_sort_key = 'columns' and p_sort_direction = 'desc' then jsonb_array_length(coalesce(vr.columns_config, '[]'::jsonb))
+      else null
+    end desc,
+    case
+      when p_sort_key = 'documents' and p_sort_direction = 'asc' then rdc.document_count
+      else null
+    end asc,
+    case
+      when p_sort_key = 'documents' and p_sort_direction = 'desc' then rdc.document_count
+      else null
+    end desc,
+    case
+      when p_sort_key = 'created' and p_sort_direction = 'asc' then vr.created_at
+      else null
+    end asc,
+    case
+      when p_sort_key = 'created' and p_sort_direction = 'desc' then vr.created_at
+      else null
+    end desc,
+    vr.created_at desc,
+    vr.id asc
+  limit greatest(coalesce(p_limit, 20), 1)
+  offset greatest(coalesce(p_offset, 0), 0);
+$$;
+
+create or replace function public.get_tabular_reviews_overview(
+  p_user_id text,
+  p_user_email text default null,
+  p_project_id text default null
+)
+returns table (
+  id uuid,
+  project_id uuid,
+  user_id text,
+  title text,
+  columns_config jsonb,
+  document_ids jsonb,
+  workflow_id uuid,
+  shared_with jsonb,
+  created_at timestamptz,
+  updated_at timestamptz,
+  is_owner boolean,
+  document_count integer
+)
+language sql
+stable
+as $$
+  select *
+  from public.get_tabular_reviews_overview(
+    p_user_id,
+    p_user_email,
+    p_project_id,
+    'all',
+    2147483647,
+    0,
+    null,
+    'created',
+    'desc'
+  );
+$$;
+
+create or replace function public.get_tabular_review_ids_overview(
+  p_user_id text,
+  p_user_email text,
+  p_project_id text,
+  p_scope text,
+  p_search_term text,
+  p_limit integer,
+  p_offset integer
+)
+returns table (
+  id uuid,
+  user_id text
+)
+language sql
+stable
+as $$
+  with accessible_projects as (
+    select p.id
+    from public.projects p
+    where p.user_id::text = p_user_id
+       or (
+        coalesce(p_user_email, '') <> ''
+        and p.user_id::text <> p_user_id
+        and p.shared_with @> jsonb_build_array(p_user_email)
+      )
+  )
+  select tr.id, tr.user_id::text as user_id
+  from public.tabular_reviews tr
+  where (p_project_id is null or tr.project_id::text = p_project_id)
+    and (
+      coalesce(p_scope, 'all') = 'all'
+      or (p_scope = 'in-project' and tr.project_id is not null)
+      or (p_scope = 'standalone' and tr.project_id is null)
+    )
+    and (
+      p_search_term is null
+      or p_search_term = ''
+      or lower(tr.title) like
+        '%' ||
+        replace(
+          replace(
+            replace(lower(p_search_term), '\', '\\'),
+            '%',
+            '\%'
+          ),
+          '_',
+          '\_'
+        ) ||
+        '%'
+        escape '\'
+    )
+    and (
+      p_project_id is null
+      or exists (
+        select 1
+        from accessible_projects ap
+        where ap.id::text = p_project_id
+      )
+    )
+    and (
+      tr.user_id::text = p_user_id
+      or (
+        tr.project_id in (select ap.id from accessible_projects ap)
+        and tr.user_id::text <> p_user_id
+      )
+      or (
+        p_project_id is null
+        and coalesce(p_user_email, '') <> ''
+        and tr.user_id::text <> p_user_id
+        and tr.shared_with @> jsonb_build_array(p_user_email)
+      )
+    )
+  order by tr.created_at desc, tr.id asc
+  limit greatest(coalesce(p_limit, 1000), 1)
+  offset greatest(coalesce(p_offset, 0), 0);
+$$;
+
+create or replace function public.search_library_documents(
+  p_user_id text,
+  p_library_kind text,
+  p_limit integer,
+  p_offset integer,
+  p_search_term text default null,
+  p_file_type text default null,
+  p_sort_key text default 'updated',
+  p_sort_direction text default 'desc'
+)
+returns table (
+  id uuid,
+  project_id uuid,
+  user_id text,
+  status text,
+  folder_id uuid,
+  library_kind text,
+  library_folder_id uuid,
+  current_version_id uuid,
+  created_at timestamptz,
+  updated_at timestamptz,
+  filename text,
+  file_type text,
+  storage_path text,
+  pdf_storage_path text,
+  size_bytes integer,
+  page_count integer,
+  active_version_number integer
+)
+language sql
+stable
+as $$
+  select
+    d.id,
+    d.project_id,
+    d.user_id::text as user_id,
+    d.status,
+    d.folder_id,
+    d.library_kind,
+    d.library_folder_id,
+    d.current_version_id,
+    d.created_at,
+    d.updated_at,
+    coalesce(nullif(trim(v.filename), ''), 'Untitled document') as filename,
+    v.file_type,
+    v.storage_path,
+    v.pdf_storage_path,
+    v.size_bytes,
+    v.page_count,
+    v.version_number as active_version_number
+  from public.documents d
+  left join public.document_versions v
+    on v.id = d.current_version_id
+   and v.deleted_at is null
+  where d.user_id::text = p_user_id
+    and d.project_id is null
+    and (
+      (p_library_kind = 'file' and coalesce(d.library_kind, 'file') = 'file')
+      or d.library_kind = p_library_kind
+    )
+    and (
+      p_search_term is null
+      or p_search_term = ''
+      or lower(coalesce(v.filename, '')) like
+        '%' || replace(replace(replace(lower(p_search_term), '\', '\\'), '%', '\%'), '_', '\_') || '%'
+        escape '\'
+    )
+    and (
+      p_file_type is null
+      or lower(coalesce(v.file_type, '')) = lower(p_file_type)
+    )
+  order by
+    case when p_sort_key = 'name' and p_sort_direction = 'asc' then lower(coalesce(v.filename, '')) else null end asc,
+    case when p_sort_key = 'name' and p_sort_direction = 'desc' then lower(coalesce(v.filename, '')) else null end desc,
+    case when p_sort_key = 'type' and p_sort_direction = 'asc' then lower(coalesce(v.file_type, '')) else null end asc,
+    case when p_sort_key = 'type' and p_sort_direction = 'desc' then lower(coalesce(v.file_type, '')) else null end desc,
+    case when p_sort_key = 'size' and p_sort_direction = 'asc' then coalesce(v.size_bytes, 0) else null end asc,
+    case when p_sort_key = 'size' and p_sort_direction = 'desc' then coalesce(v.size_bytes, 0) else null end desc,
+    case when p_sort_key = 'version' and p_sort_direction = 'asc' then coalesce(v.version_number, 0) else null end asc,
+    case when p_sort_key = 'version' and p_sort_direction = 'desc' then coalesce(v.version_number, 0) else null end desc,
+    case when p_sort_key = 'created' and p_sort_direction = 'asc' then d.created_at else null end asc,
+    case when p_sort_key = 'created' and p_sort_direction = 'desc' then d.created_at else null end desc,
+    case when p_sort_key = 'updated' and p_sort_direction = 'asc' then d.updated_at else null end asc,
+    case when p_sort_key = 'updated' and p_sort_direction = 'desc' then d.updated_at else null end desc,
+    d.updated_at desc,
+    d.id asc
+  limit greatest(coalesce(p_limit, 50), 1)
+  offset greatest(coalesce(p_offset, 0), 0);
+$$;
+
+create or replace function public.get_library_filter_options(
+  p_user_id text,
+  p_library_kind text
+)
+returns table (file_types text[])
+language sql
+stable
+as $$
+  select coalesce(
+    array_agg(distinct lower(v.file_type) order by lower(v.file_type))
+      filter (where nullif(trim(v.file_type), '') is not null),
+    array[]::text[]
+  ) as file_types
+  from public.documents d
+  left join public.document_versions v
+    on v.id = d.current_version_id
+   and v.deleted_at is null
+  where d.user_id::text = p_user_id
+    and d.project_id is null
+    and (
+      (p_library_kind = 'file' and coalesce(d.library_kind, 'file') = 'file')
+      or d.library_kind = p_library_kind
+    );
+$$;
+
+create or replace function public.get_project_filter_options(
+  p_user_id text,
+  p_user_email text default null
+)
+returns table (practices text[], owners jsonb)
+language sql
+stable
+as $$
+  with visible_projects as (
+    select p.user_id, nullif(trim(p.practice), '') as practice
+    from public.projects p
+    where p.user_id::text = p_user_id
+       or (
+         coalesce(p_user_email, '') <> ''
+         and p.user_id::text <> p_user_id
+         and p.shared_with @> jsonb_build_array(p_user_email)
+       )
+  ),
+  distinct_owners as (
+    select distinct vp.user_id
+    from visible_projects vp
+  ),
+  owner_options as (
+    select
+      o.user_id,
+      case
+        when o.user_id::text = p_user_id then 'Me'
+        else coalesce(
+          nullif(trim(up.display_name), ''),
+          nullif(trim(up.email), ''),
+          'Shared'
+        )
+      end as label
+    from distinct_owners o
+    left join public.user_profiles up
+      on up.user_id::text = o.user_id::text
+  )
+  select
+    coalesce(
+      (select array_agg(distinct practice order by practice)
+       from visible_projects
+       where practice is not null),
+      array[]::text[]
+    ) as practices,
+    coalesce(
+      (select jsonb_agg(
+          jsonb_build_object('value', user_id, 'label', label)
+          order by label, user_id
+       ) from owner_options),
+      '[]'::jsonb
+    ) as owners;
+$$;
+
+create or replace function public.get_projects_overview(
+  p_user_id text,
+  p_user_email text,
+  p_scope text,
+  p_limit integer,
+  p_offset integer,
+  p_search_term text,
+  p_sort_key text,
+  p_sort_direction text,
+  p_practice text,
+  p_owner_user_id text
+)
+returns table (
+  id uuid,
+  user_id text,
+  name text,
+  cm_number text,
+  practice text,
+  shared_with jsonb,
+  created_at timestamptz,
+  updated_at timestamptz,
+  is_owner boolean,
+  owner_display_name text,
+  owner_email text,
+  document_count integer,
+  chat_count integer,
+  review_count integer
+)
+language sql
+stable
+as $$
+  with visible_projects as (
+    select p.*
+    from public.projects p
+    where (
+        p.user_id::text = p_user_id
+        or (
+          coalesce(p_user_email, '') <> ''
+          and p.user_id::text <> p_user_id
+          and p.shared_with @> jsonb_build_array(p_user_email)
+        )
+      )
+      and (
+        coalesce(p_scope, 'all') = 'all'
+        or (p_scope = 'mine' and p.user_id::text = p_user_id)
+        or (p_scope = 'shared' and p.user_id::text <> p_user_id)
+      )
+      and (
+        p_search_term is null
+        or p_search_term = ''
+        or lower(coalesce(p.name, '')) like
+          '%' || replace(replace(replace(lower(p_search_term), '\', '\\'), '%', '\%'), '_', '\_') || '%'
+          escape '\'
+        or lower(coalesce(p.cm_number, '')) like
+          '%' || replace(replace(replace(lower(p_search_term), '\', '\\'), '%', '\%'), '_', '\_') || '%'
+          escape '\'
+        or lower(coalesce(p.practice, '')) like
+          '%' || replace(replace(replace(lower(p_search_term), '\', '\\'), '%', '\%'), '_', '\_') || '%'
+          escape '\'
+      )
+      and (p_practice is null or p.practice = p_practice)
+      and (p_owner_user_id is null or p.user_id::text = p_owner_user_id)
+  ),
+  document_counts as (
+    select d.project_id, count(*)::integer as document_count
+    from public.documents d
+    where d.project_id in (select vp.id from visible_projects vp)
+    group by d.project_id
+  ),
+  chat_counts as (
+    select c.project_id, count(*)::integer as chat_count
+    from public.chats c
+    where c.project_id in (select vp.id from visible_projects vp)
+    group by c.project_id
+  ),
+  review_counts as (
+    select tr.project_id, count(*)::integer as review_count
+    from public.tabular_reviews tr
+    where tr.project_id in (select vp.id from visible_projects vp)
+    group by tr.project_id
+  )
+  select
+    vp.id,
+    vp.user_id::text as user_id,
+    vp.name,
+    vp.cm_number,
+    vp.practice,
+    vp.shared_with,
+    vp.created_at,
+    vp.updated_at,
+    vp.user_id::text = p_user_id as is_owner,
+    nullif(trim(up.display_name), '') as owner_display_name,
+    null::text as owner_email,
+    coalesce(dc.document_count, 0) as document_count,
+    coalesce(cc.chat_count, 0) as chat_count,
+    coalesce(rc.review_count, 0) as review_count
+  from visible_projects vp
+  left join public.user_profiles up
+    on up.user_id::text = vp.user_id::text
+  left join document_counts dc
+    on dc.project_id = vp.id
+  left join chat_counts cc
+    on cc.project_id = vp.id
+  left join review_counts rc
+    on rc.project_id = vp.id
+  order by
+    case when p_sort_key = 'name' and p_sort_direction = 'asc' then lower(coalesce(vp.name, '')) else null end asc,
+    case when p_sort_key = 'name' and p_sort_direction = 'desc' then lower(coalesce(vp.name, '')) else null end desc,
+    case when p_sort_key = 'cm' and p_sort_direction = 'asc' then lower(coalesce(vp.cm_number, '')) else null end asc,
+    case when p_sort_key = 'cm' and p_sort_direction = 'desc' then lower(coalesce(vp.cm_number, '')) else null end desc,
+    case when p_sort_key = 'files' and p_sort_direction = 'asc' then coalesce(dc.document_count, 0) else null end asc,
+    case when p_sort_key = 'files' and p_sort_direction = 'desc' then coalesce(dc.document_count, 0) else null end desc,
+    case when p_sort_key = 'chats' and p_sort_direction = 'asc' then coalesce(cc.chat_count, 0) else null end asc,
+    case when p_sort_key = 'chats' and p_sort_direction = 'desc' then coalesce(cc.chat_count, 0) else null end desc,
+    case when p_sort_key = 'reviews' and p_sort_direction = 'asc' then coalesce(rc.review_count, 0) else null end asc,
+    case when p_sort_key = 'reviews' and p_sort_direction = 'desc' then coalesce(rc.review_count, 0) else null end desc,
+    case when p_sort_key = 'created' and p_sort_direction = 'asc' then vp.created_at else null end asc,
+    case when p_sort_key = 'created' and p_sort_direction = 'desc' then vp.created_at else null end desc,
+    case when p_sort_key = 'updated' and p_sort_direction = 'asc' then vp.updated_at else null end asc,
+    case when p_sort_key = 'updated' and p_sort_direction = 'desc' then vp.updated_at else null end desc,
+    vp.created_at desc,
+    vp.id asc
+  limit greatest(coalesce(p_limit, 20), 1)
+  offset greatest(coalesce(p_offset, 0), 0);
+$$;
+
+create or replace function public.get_project_ids_overview(
+  p_user_id text,
+  p_user_email text,
+  p_scope text,
+  p_search_term text,
+  p_practice text,
+  p_owner_user_id text,
+  p_limit integer,
+  p_offset integer
+)
+returns table (
+  id uuid,
+  user_id text
+)
+language sql
+stable
+as $$
+  select p.id, p.user_id::text as user_id
+  from public.projects p
+  where (
+      p.user_id::text = p_user_id
+      or (
+        coalesce(p_user_email, '') <> ''
+        and p.user_id::text <> p_user_id
+        and p.shared_with @> jsonb_build_array(p_user_email)
+      )
+    )
+    and (
+      coalesce(p_scope, 'all') = 'all'
+      or (p_scope = 'mine' and p.user_id::text = p_user_id)
+      or (p_scope = 'shared' and p.user_id::text <> p_user_id)
+    )
+    and (
+      p_search_term is null
+      or p_search_term = ''
+      or lower(coalesce(p.name, '')) like
+        '%' || replace(replace(replace(lower(p_search_term), '\', '\\'), '%', '\%'), '_', '\_') || '%'
+        escape '\'
+      or lower(coalesce(p.cm_number, '')) like
+        '%' || replace(replace(replace(lower(p_search_term), '\', '\\'), '%', '\%'), '_', '\_') || '%'
+        escape '\'
+      or lower(coalesce(p.practice, '')) like
+        '%' || replace(replace(replace(lower(p_search_term), '\', '\\'), '%', '\%'), '_', '\_') || '%'
+        escape '\'
+    )
+    and (p_practice is null or p.practice = p_practice)
+    and (p_owner_user_id is null or p.user_id::text = p_owner_user_id)
+  order by p.created_at desc, p.id asc
+  limit greatest(coalesce(p_limit, 1000), 1)
+  offset greatest(coalesce(p_offset, 0), 0);
+$$;
+
+create or replace function public.get_project_summaries(
+  p_user_id text,
+  p_user_email text,
+  p_limit integer,
+  p_offset integer
+)
+returns table (
+  id uuid,
+  user_id text,
+  name text,
+  created_at timestamptz,
+  updated_at timestamptz,
+  is_owner boolean
+)
+language sql
+stable
+as $$
+  select
+    p.id,
+    p.user_id::text as user_id,
+    p.name,
+    p.created_at,
+    p.updated_at,
+    p.user_id::text = p_user_id as is_owner
+  from public.projects p
+  where p.user_id::text = p_user_id
+     or (
+       coalesce(p_user_email, '') <> ''
+       and p.user_id::text <> p_user_id
+       and p.shared_with @> jsonb_build_array(p_user_email)
+     )
+  order by p.updated_at desc, p.created_at desc, p.id asc
+  limit greatest(coalesce(p_limit, 11), 1)
+  offset greatest(coalesce(p_offset, 0), 0);
+$$;
+
+create or replace function public.get_library_document_ids(
+  p_user_id text,
+  p_library_kind text,
+  p_search_term text,
+  p_file_type text,
+  p_limit integer,
+  p_offset integer
+)
+returns table (
+  id uuid,
+  user_id text
+)
+language sql
+stable
+as $$
+  select d.id, d.user_id::text as user_id
+  from public.documents d
+  left join public.document_versions v
+    on v.id = d.current_version_id
+   and v.deleted_at is null
+  where d.user_id::text = p_user_id
+    and d.project_id is null
+    and (
+      (p_library_kind = 'file' and coalesce(d.library_kind, 'file') = 'file')
+      or d.library_kind = p_library_kind
+    )
+    and (
+      p_search_term is null
+      or p_search_term = ''
+      or lower(coalesce(v.filename, '')) like
+        '%' || replace(replace(replace(lower(p_search_term), '\', '\\'), '%', '\%'), '_', '\_') || '%'
+        escape '\'
+    )
+    and (
+      p_file_type is null
+      or lower(coalesce(v.file_type, '')) = lower(p_file_type)
+    )
+  order by d.updated_at desc, d.id asc
+  limit greatest(coalesce(p_limit, 1000), 1)
+  offset greatest(coalesce(p_offset, 0), 0);
+$$;
+
+commit;

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -194,7 +194,7 @@ alter table public.user_mcp_tool_audit_logs enable row level security;
 
 create table if not exists public.projects (
   id uuid primary key default gen_random_uuid(),
-  user_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   name text not null,
   cm_number text,
   practice text,
@@ -216,7 +216,7 @@ create index if not exists projects_shared_with_idx
 create table if not exists public.project_subfolders (
   id uuid primary key default gen_random_uuid(),
   project_id uuid not null references public.projects(id) on delete cascade,
-  user_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   name text not null,
   parent_folder_id uuid references public.project_subfolders(id) on delete cascade,
   created_at timestamptz not null default now(),
@@ -228,7 +228,7 @@ create index if not exists idx_project_subfolders_project
 
 create table if not exists public.library_folders (
   id uuid primary key default gen_random_uuid(),
-  user_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   library_kind text not null default 'file',
   name text not null,
   parent_folder_id uuid references public.library_folders(id) on delete cascade,
@@ -247,7 +247,7 @@ create index if not exists idx_library_folders_parent
 create table if not exists public.documents (
   id uuid primary key default gen_random_uuid(),
   project_id uuid references public.projects(id) on delete cascade,
-  user_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   status text not null default 'pending',
   folder_id uuid references public.project_subfolders(id) on delete set null,
   library_kind text not null default 'file',
@@ -281,7 +281,7 @@ create table if not exists public.document_versions (
   page_count integer,
   content_sha256 text,
   deleted_at timestamptz,
-  deleted_by uuid,
+  deleted_by uuid references auth.users(id) on delete set null,
   created_at timestamptz not null default now(),
   constraint document_versions_source_check
     check (source = any (array[
@@ -360,7 +360,7 @@ create index if not exists document_edits_version_id_idx
 
 create table if not exists public.workflows (
   id uuid primary key default gen_random_uuid(),
-  user_id text,
+  user_id uuid references auth.users(id) on delete cascade,
   title text not null,
   type text not null,
   prompt_md text,
@@ -376,7 +376,7 @@ create index if not exists idx_workflows_user
 
 create table if not exists public.hidden_workflows (
   id uuid primary key default gen_random_uuid(),
-  user_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   workflow_id text not null,
   created_at timestamptz not null default now(),
   unique(user_id, workflow_id)
@@ -388,7 +388,7 @@ create index if not exists idx_hidden_workflows_user
 create table if not exists public.workflow_shares (
   id uuid primary key default gen_random_uuid(),
   workflow_id uuid not null references public.workflows(id) on delete cascade,
-  shared_by_user_id text not null,
+  shared_by_user_id uuid not null references auth.users(id) on delete cascade,
   shared_with_email text not null,
   allow_edit boolean not null default false,
   created_at timestamptz not null default now(),
@@ -404,7 +404,7 @@ create index if not exists workflow_shares_email_idx
 
 create table if not exists public.default_workflow_installations (
   id uuid primary key default gen_random_uuid(),
-  user_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   default_key text not null,
   workflow_id uuid references public.workflows(id) on delete set null,
   installed_at timestamptz not null default now(),
@@ -416,7 +416,7 @@ create table if not exists public.default_workflow_installations (
 
 create table if not exists public.quick_actions (
   id uuid primary key default gen_random_uuid(),
-  user_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   workflow_id uuid not null references public.workflows(id) on delete cascade,
   prompt text not null default '',
   document_upload boolean not null default false,
@@ -466,7 +466,7 @@ create index if not exists workflow_addons_active_pack_idx
 create table if not exists public.workflow_reference_documents (
   id uuid primary key default gen_random_uuid(),
   workflow_id uuid not null references public.workflows(id) on delete cascade,
-  user_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   filename text not null,
   file_type text not null,
   storage_path text not null,
@@ -524,7 +524,7 @@ begin
     if exists (
       select 1
       from public.default_workflow_installations dwi
-      where dwi.user_id = p_user_id
+      where dwi.user_id::text = p_user_id
         and dwi.default_key = item->>'default_key'
     ) then
       continue;
@@ -550,7 +550,7 @@ begin
       practice,
       jurisdictions
     ) values (
-      p_user_id,
+      p_user_id::uuid,
       item->>'title',
       item->>'type',
       nullif(item->>'prompt_md', ''),
@@ -570,7 +570,7 @@ begin
       default_key,
       workflow_id
     ) values (
-      p_user_id,
+      p_user_id::uuid,
       item->>'default_key',
       workflow_uuid
     );
@@ -583,7 +583,7 @@ begin
       enabled,
       sort_order
     ) values (
-      p_user_id,
+      p_user_id::uuid,
       workflow_uuid,
       coalesce(item->>'quick_action_prompt', ''),
       coalesce((item->>'document_upload')::boolean, false),
@@ -603,7 +603,7 @@ $$;
 create table if not exists public.workflow_open_source_submissions (
   id uuid primary key default gen_random_uuid(),
   workflow_id uuid not null references public.workflows(id) on delete cascade,
-  submitted_by_user_id text not null,
+  submitted_by_user_id uuid not null references auth.users(id) on delete cascade,
   submitter_email text,
   submitter_name text,
   contributor_mode text not null default 'anonymous',
@@ -732,7 +732,7 @@ $$;
 create table if not exists public.chats (
   id uuid primary key default gen_random_uuid(),
   project_id uuid references public.projects(id) on delete cascade,
-  user_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   title text,
   created_at timestamptz not null default now()
 );
@@ -765,16 +765,16 @@ as $$
   select
     c.id,
     c.project_id,
-    c.user_id,
+    c.user_id::text as user_id,
     c.title,
     c.created_at,
     p.name as project_name
   from public.chats c
   left join public.projects p on p.id = c.project_id
-  where c.user_id = p_user_id
+  where c.user_id::text = p_user_id
      or (
        p.id is not null
-       and p.user_id = p_user_id
+       and p.user_id::text = p_user_id
      )
   order by c.created_at desc, c.id asc
   limit case
@@ -806,7 +806,7 @@ create index if not exists idx_chat_messages_chat
 
 create table if not exists public.word_documents (
   id uuid primary key default gen_random_uuid(),
-  user_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   client_document_id uuid not null,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
@@ -820,7 +820,7 @@ create table if not exists public.word_chats (
   id uuid primary key default gen_random_uuid(),
   word_document_id uuid not null
     references public.word_documents(id) on delete cascade,
-  user_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   title text,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
@@ -874,7 +874,7 @@ $$;
 create table if not exists public.tabular_reviews (
   id uuid primary key default gen_random_uuid(),
   project_id uuid references public.projects(id) on delete cascade,
-  user_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   title text,
   columns_config jsonb,
   document_ids jsonb,
@@ -924,10 +924,10 @@ as $$
   with visible_projects as (
     select p.*
     from public.projects p
-    where p.user_id = p_user_id
+    where p.user_id::text = p_user_id
        or (
         coalesce(p_user_email, '') <> ''
-        and p.user_id <> p_user_id
+        and p.user_id::text <> p_user_id
         and p.shared_with @> jsonb_build_array(p_user_email)
       )
   ),
@@ -951,14 +951,14 @@ as $$
   )
   select
     vp.id,
-    vp.user_id,
+    vp.user_id::text as user_id,
     vp.name,
     vp.cm_number,
     vp.practice,
     vp.shared_with,
     vp.created_at,
     vp.updated_at,
-    vp.user_id = p_user_id as is_owner,
+    vp.user_id::text = p_user_id as is_owner,
     nullif(trim(up.display_name), '') as owner_display_name,
     null::text as owner_email,
     coalesce(dc.document_count, 0) as document_count,
@@ -966,7 +966,7 @@ as $$
     coalesce(rc.review_count, 0) as review_count
   from visible_projects vp
   left join public.user_profiles up
-    on up.user_id::text = vp.user_id
+    on up.user_id::text = vp.user_id::text
   left join document_counts dc
     on dc.project_id = vp.id
   left join chat_counts cc
@@ -1055,10 +1055,10 @@ as $$
   with accessible_projects as (
     select p.id
     from public.projects p
-    where p.user_id = p_user_id
+    where p.user_id::text = p_user_id
        or (
         coalesce(p_user_email, '') <> ''
-        and p.user_id <> p_user_id
+        and p.user_id::text <> p_user_id
         and p.shared_with @> jsonb_build_array(p_user_email)
       )
   ),
@@ -1097,15 +1097,15 @@ as $$
         )
       )
       and (
-        tr.user_id = p_user_id
+        tr.user_id::text = p_user_id
         or (
           tr.project_id in (select ap.id from accessible_projects ap)
-          and tr.user_id <> p_user_id
+          and tr.user_id::text <> p_user_id
         )
         or (
           p_project_id is null
           and coalesce(p_user_email, '') <> ''
-          and tr.user_id <> p_user_id
+          and tr.user_id::text <> p_user_id
           and tr.shared_with @> jsonb_build_array(p_user_email)
         )
       )
@@ -1140,7 +1140,7 @@ as $$
   select
     vr.id,
     vr.project_id,
-    vr.user_id,
+    vr.user_id::text as user_id,
     vr.title,
     vr.columns_config,
     vr.document_ids,
@@ -1148,7 +1148,7 @@ as $$
     vr.shared_with,
     vr.created_at,
     vr.updated_at,
-    vr.user_id = p_user_id as is_owner,
+    vr.user_id::text = p_user_id as is_owner,
     rdc.document_count
   from visible_reviews vr
   join review_document_counts rdc
@@ -1247,14 +1247,14 @@ as $$
   with accessible_projects as (
     select p.id
     from public.projects p
-    where p.user_id = p_user_id
+    where p.user_id::text = p_user_id
        or (
         coalesce(p_user_email, '') <> ''
-        and p.user_id <> p_user_id
+        and p.user_id::text <> p_user_id
         and p.shared_with @> jsonb_build_array(p_user_email)
       )
   )
-  select tr.id, tr.user_id
+  select tr.id, tr.user_id::text as user_id
   from public.tabular_reviews tr
   where (p_project_id is null or tr.project_id::text = p_project_id)
     and (
@@ -1288,15 +1288,15 @@ as $$
       )
     )
     and (
-      tr.user_id = p_user_id
+      tr.user_id::text = p_user_id
       or (
         tr.project_id in (select ap.id from accessible_projects ap)
-        and tr.user_id <> p_user_id
+        and tr.user_id::text <> p_user_id
       )
       or (
         p_project_id is null
         and coalesce(p_user_email, '') <> ''
-        and tr.user_id <> p_user_id
+        and tr.user_id::text <> p_user_id
         and tr.shared_with @> jsonb_build_array(p_user_email)
       )
     )
@@ -1308,7 +1308,7 @@ $$;
 create table if not exists public.tabular_review_chats (
   id uuid primary key default gen_random_uuid(),
   review_id uuid not null references public.tabular_reviews(id) on delete cascade,
-  user_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   title text,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
@@ -1410,7 +1410,7 @@ as $$
   select
     d.id,
     d.project_id,
-    d.user_id,
+    d.user_id::text as user_id,
     d.status,
     d.folder_id,
     d.library_kind,
@@ -1429,7 +1429,7 @@ as $$
   left join public.document_versions v
     on v.id = d.current_version_id
    and v.deleted_at is null
-  where d.user_id = p_user_id
+  where d.user_id::text = p_user_id
     and d.project_id is null
     and (
       (p_library_kind = 'file' and coalesce(d.library_kind, 'file') = 'file')
@@ -1482,7 +1482,7 @@ as $$
   left join public.document_versions v
     on v.id = d.current_version_id
    and v.deleted_at is null
-  where d.user_id = p_user_id
+  where d.user_id::text = p_user_id
     and d.project_id is null
     and (
       (p_library_kind = 'file' and coalesce(d.library_kind, 'file') = 'file')
@@ -1501,10 +1501,10 @@ as $$
   with visible_projects as (
     select p.user_id, nullif(trim(p.practice), '') as practice
     from public.projects p
-    where p.user_id = p_user_id
+    where p.user_id::text = p_user_id
        or (
          coalesce(p_user_email, '') <> ''
-         and p.user_id <> p_user_id
+         and p.user_id::text <> p_user_id
          and p.shared_with @> jsonb_build_array(p_user_email)
        )
   ),
@@ -1516,7 +1516,7 @@ as $$
     select
       o.user_id,
       case
-        when o.user_id = p_user_id then 'Me'
+        when o.user_id::text = p_user_id then 'Me'
         else coalesce(
           nullif(trim(up.display_name), ''),
           nullif(trim(up.email), ''),
@@ -1525,7 +1525,7 @@ as $$
       end as label
     from distinct_owners o
     left join public.user_profiles up
-      on up.user_id::text = o.user_id
+      on up.user_id::text = o.user_id::text
   )
   select
     coalesce(
@@ -1671,17 +1671,17 @@ as $$
     select p.*
     from public.projects p
     where (
-        p.user_id = p_user_id
+        p.user_id::text = p_user_id
         or (
           coalesce(p_user_email, '') <> ''
-          and p.user_id <> p_user_id
+          and p.user_id::text <> p_user_id
           and p.shared_with @> jsonb_build_array(p_user_email)
         )
       )
       and (
         coalesce(p_scope, 'all') = 'all'
-        or (p_scope = 'mine' and p.user_id = p_user_id)
-        or (p_scope = 'shared' and p.user_id <> p_user_id)
+        or (p_scope = 'mine' and p.user_id::text = p_user_id)
+        or (p_scope = 'shared' and p.user_id::text <> p_user_id)
       )
       and (
         p_search_term is null
@@ -1697,7 +1697,7 @@ as $$
           escape '\'
       )
       and (p_practice is null or p.practice = p_practice)
-      and (p_owner_user_id is null or p.user_id = p_owner_user_id)
+      and (p_owner_user_id is null or p.user_id::text = p_owner_user_id)
   ),
   document_counts as (
     select d.project_id, count(*)::integer as document_count
@@ -1719,14 +1719,14 @@ as $$
   )
   select
     vp.id,
-    vp.user_id,
+    vp.user_id::text as user_id,
     vp.name,
     vp.cm_number,
     vp.practice,
     vp.shared_with,
     vp.created_at,
     vp.updated_at,
-    vp.user_id = p_user_id as is_owner,
+    vp.user_id::text = p_user_id as is_owner,
     nullif(trim(up.display_name), '') as owner_display_name,
     null::text as owner_email,
     coalesce(dc.document_count, 0) as document_count,
@@ -1734,7 +1734,7 @@ as $$
     coalesce(rc.review_count, 0) as review_count
   from visible_projects vp
   left join public.user_profiles up
-    on up.user_id::text = vp.user_id
+    on up.user_id::text = vp.user_id::text
   left join document_counts dc
     on dc.project_id = vp.id
   left join chat_counts cc
@@ -1789,20 +1789,20 @@ returns table (
 language sql
 stable
 as $$
-  select p.id, p.user_id
+  select p.id, p.user_id::text as user_id
   from public.projects p
   where (
-      p.user_id = p_user_id
+      p.user_id::text = p_user_id
       or (
         coalesce(p_user_email, '') <> ''
-        and p.user_id <> p_user_id
+        and p.user_id::text <> p_user_id
         and p.shared_with @> jsonb_build_array(p_user_email)
       )
     )
     and (
       coalesce(p_scope, 'all') = 'all'
-      or (p_scope = 'mine' and p.user_id = p_user_id)
-      or (p_scope = 'shared' and p.user_id <> p_user_id)
+      or (p_scope = 'mine' and p.user_id::text = p_user_id)
+      or (p_scope = 'shared' and p.user_id::text <> p_user_id)
     )
     and (
       p_search_term is null
@@ -1818,7 +1818,7 @@ as $$
         escape '\'
     )
     and (p_practice is null or p.practice = p_practice)
-    and (p_owner_user_id is null or p.user_id = p_owner_user_id)
+    and (p_owner_user_id is null or p.user_id::text = p_owner_user_id)
   order by p.created_at desc, p.id asc
   limit greatest(coalesce(p_limit, 1000), 1)
   offset greatest(coalesce(p_offset, 0), 0);
@@ -2041,16 +2041,16 @@ stable
 as $$
   select
     p.id,
-    p.user_id,
+    p.user_id::text as user_id,
     p.name,
     p.created_at,
     p.updated_at,
-    p.user_id = p_user_id as is_owner
+    p.user_id::text = p_user_id as is_owner
   from public.projects p
-  where p.user_id = p_user_id
+  where p.user_id::text = p_user_id
      or (
        coalesce(p_user_email, '') <> ''
-       and p.user_id <> p_user_id
+       and p.user_id::text <> p_user_id
        and p.shared_with @> jsonb_build_array(p_user_email)
      )
   order by p.updated_at desc, p.created_at desc, p.id asc
@@ -2075,12 +2075,12 @@ returns table (
 language sql
 stable
 as $$
-  select d.id, d.user_id
+  select d.id, d.user_id::text as user_id
   from public.documents d
   left join public.document_versions v
     on v.id = d.current_version_id
    and v.deleted_at is null
-  where d.user_id = p_user_id
+  where d.user_id::text = p_user_id
     and d.project_id is null
     and (
       (p_library_kind = 'file' and coalesce(d.library_kind, 'file') = 'file')
@@ -2119,7 +2119,7 @@ $$;
 create table if not exists public.audit_events (
   id uuid primary key default gen_random_uuid(),
   created_at timestamptz not null default now(),
-  user_id uuid not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
   user_email text,
   action text not null,
   status text not null default 'completed',

--- a/backend/src/__tests__/integration/access.supabase.test.ts
+++ b/backend/src/__tests__/integration/access.supabase.test.ts
@@ -20,20 +20,42 @@ maybeDescribe("Supabase access integration", () => {
             auth: { persistSession: false },
         });
         const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-        const ownerId = crypto.randomUUID();
-        const reviewerId = crypto.randomUUID();
+        const ownerEmail = `owner-${suffix}@example.com`;
+        const reviewerEmail = `reviewer-${suffix}@example.com`;
+        let ownerId = "";
+        let reviewerId = "";
         const sharedProjectId = crypto.randomUUID();
         const privateProjectId = crypto.randomUUID();
         const sharedDocId = crypto.randomUUID();
         const privateDocId = crypto.randomUUID();
 
         try {
+            const owner = await admin.auth.admin.createUser({
+                email: ownerEmail,
+                password: "StackTest1!",
+                email_confirm: true,
+            });
+            if (owner.error || !owner.data.user) {
+                throw owner.error ?? new Error("Could not create owner");
+            }
+            ownerId = owner.data.user.id;
+
+            const reviewer = await admin.auth.admin.createUser({
+                email: reviewerEmail,
+                password: "StackTest1!",
+                email_confirm: true,
+            });
+            if (reviewer.error || !reviewer.data.user) {
+                throw reviewer.error ?? new Error("Could not create reviewer");
+            }
+            reviewerId = reviewer.data.user.id;
+
             const projectsInsert = await admin.from("projects").insert([
                 {
                     id: sharedProjectId,
                     user_id: ownerId,
                     name: `shared-${suffix}`,
-                    shared_with: [`reviewer-${suffix}@example.com`],
+                    shared_with: [reviewerEmail],
                 },
                 {
                     id: privateProjectId,
@@ -73,7 +95,7 @@ maybeDescribe("Supabase access integration", () => {
             await expect(
                 listAccessibleProjectIds(
                     reviewerId,
-                    `reviewer-${suffix}@example.com`,
+                    reviewerEmail,
                     admin as any,
                 ),
             ).resolves.toContain(sharedProjectId);
@@ -82,7 +104,7 @@ maybeDescribe("Supabase access integration", () => {
                 filterAccessibleDocumentIds(
                     [sharedDocId, privateDocId],
                     reviewerId,
-                    `reviewer-${suffix}@example.com`,
+                    reviewerEmail,
                     admin as any,
                 ),
             ).resolves.toEqual([sharedDocId]);
@@ -92,6 +114,8 @@ maybeDescribe("Supabase access integration", () => {
                 .from("projects")
                 .delete()
                 .in("id", [sharedProjectId, privateProjectId]);
+            if (reviewerId) await admin.auth.admin.deleteUser(reviewerId);
+            if (ownerId) await admin.auth.admin.deleteUser(ownerId);
         }
     });
 });

--- a/backend/src/__tests__/integration/projectsPagination.supabase.test.ts
+++ b/backend/src/__tests__/integration/projectsPagination.supabase.test.ts
@@ -6,9 +6,9 @@ const serviceKey = process.env.SUPABASE_TEST_SERVICE_ROLE_KEY;
 const maybeDescribe = url && serviceKey ? describe : describe.skip;
 
 maybeDescribe("Supabase projects-overview pagination", () => {
-    const ownerId = crypto.randomUUID();
-    const ownerEmail = `pagination-${ownerId}@test.local`;
-    const otherUserId = crypto.randomUUID();
+    let ownerId = "";
+    let ownerEmail = "";
+    let otherUserId = "";
     const myProjectIds = Array.from({ length: 25 }, () => crypto.randomUUID());
     const sharedProjectIds = Array.from({ length: 5 }, () => crypto.randomUUID());
     const tiedCreatedAt = "2026-07-27T00:00:00.000Z";
@@ -18,6 +18,31 @@ maybeDescribe("Supabase projects-overview pagination", () => {
         admin = createClient(url!, serviceKey!, {
             auth: { persistSession: false, autoRefreshToken: false },
         });
+
+        const suffix = Date.now();
+        ownerEmail = `pagination-owner-${suffix}@test.local`;
+        const owner = await admin.auth.admin.createUser({
+            email: ownerEmail,
+            password: "StackTest1!",
+            email_confirm: true,
+        });
+        if (owner.error || !owner.data.user) {
+            throw owner.error ?? new Error("Could not create pagination owner");
+        }
+        ownerId = owner.data.user.id;
+
+        const otherUser = await admin.auth.admin.createUser({
+            email: `pagination-other-${suffix}@test.local`,
+            password: "StackTest1!",
+            email_confirm: true,
+        });
+        if (otherUser.error || !otherUser.data.user) {
+            throw (
+                otherUser.error ??
+                new Error("Could not create shared-project owner")
+            );
+        }
+        otherUserId = otherUser.data.user.id;
 
         const myProjects = await admin.from("projects").insert(
             myProjectIds.map((id) => ({
@@ -49,6 +74,8 @@ maybeDescribe("Supabase projects-overview pagination", () => {
         if (!admin) return;
         await admin.from("projects").delete().in("id", myProjectIds);
         await admin.from("projects").delete().in("id", sharedProjectIds);
+        if (otherUserId) await admin.auth.admin.deleteUser(otherUserId);
+        if (ownerId) await admin.auth.admin.deleteUser(ownerId);
     });
 
     it("paginates tied rows deterministically without duplicates", async () => {

--- a/backend/src/__tests__/integration/tabularPagination.supabase.test.ts
+++ b/backend/src/__tests__/integration/tabularPagination.supabase.test.ts
@@ -6,8 +6,8 @@ const serviceKey = process.env.SUPABASE_TEST_SERVICE_ROLE_KEY;
 const maybeDescribe = url && serviceKey ? describe : describe.skip;
 
 maybeDescribe("Supabase tabular-review pagination", () => {
-    const ownerId = crypto.randomUUID();
-    const ownerEmail = `pagination-${ownerId}@test.local`;
+    let ownerId = "";
+    let ownerEmail = "";
     const projectId = crypto.randomUUID();
     const projectReviewIds = Array.from({ length: 25 }, () =>
         crypto.randomUUID(),
@@ -22,6 +22,17 @@ maybeDescribe("Supabase tabular-review pagination", () => {
         admin = createClient(url!, serviceKey!, {
             auth: { persistSession: false, autoRefreshToken: false },
         });
+
+        ownerEmail = `pagination-${Date.now()}@test.local`;
+        const owner = await admin.auth.admin.createUser({
+            email: ownerEmail,
+            password: "StackTest1!",
+            email_confirm: true,
+        });
+        if (owner.error || !owner.data.user) {
+            throw owner.error ?? new Error("Could not create pagination owner");
+        }
+        ownerId = owner.data.user.id;
 
         const project = await admin.from("projects").insert({
             id: projectId,
@@ -72,6 +83,7 @@ maybeDescribe("Supabase tabular-review pagination", () => {
             .delete()
             .in("id", standaloneReviewIds);
         await admin.from("projects").delete().eq("id", projectId);
+        if (ownerId) await admin.auth.admin.deleteUser(ownerId);
     });
 
     it("paginates tied rows deterministically without duplicates", async () => {


### PR DESCRIPTION
## Summary

- migrate every application ownership/actor user ID to UUID storage with an auth.users foreign key
- cascade deletion for owned records while preserving document version history with ON DELETE SET NULL
- keep existing text-based RPC inputs and outputs compatible by casting at SQL boundaries
- add an atomic upgrade migration that rejects malformed IDs and validates existing rows for orphans

The issue listed seven affected columns. Current main had 18 missing relationships, including newer Library, Word add-in, workflow installation/reference, open-source submission, tabular chat, document deletion actor, and audit tables; this fixes all of them.

## Verification

- fresh schema and baseline-plus-migrations produce identical canonical fingerprints
- migration succeeds from the pinned production baseline
- malformed IDs abort and roll back the migration
- well-formed orphan IDs fail FK validation and roll back the migration
- live PostgreSQL checks cover FK enforcement, RPC compatibility, ON DELETE CASCADE, and ON DELETE SET NULL
- git diff --check

Closes #104