### PR TITLE
fix: make project sharing email matching case-insensitive

### DIFF
--- a/backend/migrations/20260814_01_normalize_project_sharing_emails.sql
+++ b/backend/migrations/20260814_01_normalize_project_sharing_emails.sql
@@ -1,0 +1,35 @@
+-- Migration date: 2026-08-14
+--
+-- Normalize legacy project-sharing emails so indexed JSONB containment remains
+-- reliable regardless of how an invitation was capitalized when it was stored.
+-- Current POST/PATCH routes already enforce this representation for new writes.
+
+with normalized_projects as (
+  select
+    p.id,
+    coalesce(
+      jsonb_agg(entries.email order by entries.first_position)
+        filter (where entries.email is not null),
+      '[]'::jsonb
+    ) as shared_with
+  from public.projects p
+  left join lateral (
+    select
+      lower(trim(raw.value)) as email,
+      min(raw.position) as first_position
+    from jsonb_array_elements_text(
+      case
+        when jsonb_typeof(p.shared_with) = 'array' then p.shared_with
+        else '[]'::jsonb
+      end
+    ) with ordinality as raw(value, position)
+    where trim(raw.value) <> ''
+    group by lower(trim(raw.value))
+  ) entries on true
+  group by p.id
+)
+update public.projects p
+set shared_with = normalized_projects.shared_with
+from normalized_projects
+where p.id = normalized_projects.id
+  and p.shared_with is distinct from normalized_projects.shared_with;

--- a/backend/src/__tests__/integration/projects.routes.test.ts
+++ b/backend/src/__tests__/integration/projects.routes.test.ts
@@ -554,7 +554,7 @@ describe("projects.routes", () => {
         });
     });
 
-    // ── GET /projects/:projectId (detail, inline access) ──────────────────
+    // ── GET /projects/:projectId (detail, shared access helper) ───────────
     describe("GET /projects/:projectId", () => {
         it("returns 404 when the project does not exist", async () => {
             supabaseState.tables.projects = { data: null, error: null };
@@ -568,14 +568,7 @@ describe("projects.routes", () => {
         });
 
         it("returns 404 when the caller is neither owner nor shared", async () => {
-            supabaseState.tables.projects = {
-                data: {
-                    id: "p1",
-                    user_id: "someone-else",
-                    shared_with: ["other@x.com"],
-                },
-                error: null,
-            };
+            checkProjectAccess.mockResolvedValue({ ok: false });
 
       const res = await request(app)
         .get("/projects/p1")
@@ -583,14 +576,29 @@ describe("projects.routes", () => {
 
             expect(res.status).toBe(404);
             expect(res.body.detail).toBe("Project not found");
+            expect(checkProjectAccess).toHaveBeenCalledWith(
+                "p1",
+                "u1",
+                "u1@test.local",
+                expect.anything(),
+            );
         });
 
-        it("grants access to a shared member (is_owner false)", async () => {
+        it("delegates mixed-case shared access to the case-insensitive helper", async () => {
+            checkProjectAccess.mockResolvedValue({
+                ok: true,
+                isOwner: false,
+                project: {
+                    id: "p1",
+                    user_id: "someone-else",
+                    shared_with: ["U1@Test.Local"],
+                },
+            });
             supabaseState.tables.projects = {
                 data: {
                     id: "p1",
                     user_id: "someone-else",
-                    shared_with: ["u1@test.local"],
+                    shared_with: ["U1@Test.Local"],
                 },
                 error: null,
             };
@@ -603,6 +611,7 @@ describe("projects.routes", () => {
 
             expect(res.status).toBe(200);
             expect(res.body).toMatchObject({ id: "p1", is_owner: false });
+            expect(checkProjectAccess).toHaveBeenCalledTimes(1);
         });
 
         it("returns 200 with documents/folders/is_owner when owned", async () => {

--- a/backend/src/lib/__tests__/access.test.ts
+++ b/backend/src/lib/__tests__/access.test.ts
@@ -29,17 +29,12 @@ function makeDb(tables: Record<string, Row[]>) {
                 },
                 filter: (column: string, operator: string, value: string) => {
                     if (operator !== "cs") return query;
-                    const expected = (JSON.parse(value) as string[]).map((item) =>
-                        item.toLowerCase(),
-                    );
+                    const expected = JSON.parse(value) as string[];
                     rows = rows.filter((row) => {
                         const actual = row[column];
-                        const normalizedActual = Array.isArray(actual)
-                            ? actual.map((item) => String(item).toLowerCase())
-                            : [];
                         return (
                             Array.isArray(actual) &&
-                            expected.every((item) => normalizedActual.includes(item))
+                            expected.every((item) => actual.includes(item))
                         );
                     });
                     return query;
@@ -62,7 +57,7 @@ describe("access helpers", () => {
             {
                 id: "shared-project",
                 user_id: "other-owner",
-                shared_with: ["Reviewer@Example.com"],
+                shared_with: ["reviewer@example.com"],
             },
             { id: "private-project", user_id: "other-owner", shared_with: [] },
         ],
@@ -92,7 +87,7 @@ describe("access helpers", () => {
             checkProjectAccess(
                 "shared-project",
                 "reviewer",
-                "reviewer@example.com",
+                " REVIEWER@EXAMPLE.COM ",
                 db,
             ),
         ).resolves.toMatchObject({ ok: true, isOwner: false });
@@ -142,7 +137,7 @@ describe("access helpers", () => {
 
     it("lists own and directly shared projects", async () => {
         await expect(
-            listAccessibleProjectIds("owner", "reviewer@example.com", db),
+            listAccessibleProjectIds("owner", " Reviewer@Example.com ", db),
         ).resolves.toEqual(expect.arrayContaining(["own-project", "shared-project"]));
     });
 

--- a/backend/src/lib/__tests__/projectsOverview.test.ts
+++ b/backend/src/lib/__tests__/projectsOverview.test.ts
@@ -10,7 +10,7 @@ describe("buildProjectsOverviewRpcArgs", () => {
         expect(
             buildProjectsOverviewRpcArgs({
                 userId: "user-1",
-                userEmail: "user@example.com",
+                userEmail: " User@Example.com ",
                 scope: "mine",
                 pagination: { limit: 25, offset: 10 },
                 searchTerm: "merger",
@@ -58,7 +58,7 @@ describe("buildProjectIdsOverviewRpcArgs", () => {
         expect(
             buildProjectIdsOverviewRpcArgs({
                 userId: "user-1",
-                userEmail: "user@example.com",
+                userEmail: " User@Example.com ",
                 scope: "shared",
                 searchTerm: "merger",
                 practice: "Litigation",

--- a/backend/src/lib/access.ts
+++ b/backend/src/lib/access.ts
@@ -48,7 +48,7 @@ export async function checkProjectAccess(
         return { ok: true, isOwner: true, project: proj };
     }
     const sharedWith = Array.isArray(proj.shared_with) ? proj.shared_with : [];
-    const email = (userEmail ?? "").toLowerCase();
+    const email = (userEmail ?? "").trim().toLowerCase();
     if (
         email &&
         sharedWith.some((e) => (e ?? "").toLowerCase() === email)
@@ -171,13 +171,18 @@ export async function listAccessibleProjectIds(
     userEmail: string | null | undefined,
     db: Db,
 ): Promise<string[]> {
+    const normalizedEmail = userEmail?.trim().toLowerCase() ?? "";
     const [{ data: own }, { data: shared }] = await Promise.all([
         db.from("projects").select("id").eq("user_id", userId),
-        userEmail
+        normalizedEmail
             ? db
                   .from("projects")
                   .select("id")
-                  .filter("shared_with", "cs", JSON.stringify([userEmail]))
+                  .filter(
+                      "shared_with",
+                      "cs",
+                      JSON.stringify([normalizedEmail]),
+                  )
                   .neq("user_id", userId)
             : Promise.resolve({ data: [] as { id: string }[] }),
     ]);

--- a/backend/src/lib/projectsOverview.ts
+++ b/backend/src/lib/projectsOverview.ts
@@ -30,7 +30,7 @@ export function buildProjectsOverviewRpcArgs(params: {
 }): ProjectsOverviewRpcArgs {
     return {
         p_user_id: params.userId,
-        p_user_email: params.userEmail ?? null,
+        p_user_email: params.userEmail?.trim().toLowerCase() || null,
         p_scope: params.scope ?? "all",
         p_limit: params.pagination?.limit ?? 20,
         p_offset: params.pagination?.offset ?? 0,
@@ -69,7 +69,7 @@ export function buildProjectIdsOverviewRpcArgs(params: {
 }): ProjectIdsOverviewRpcArgs {
     return {
         p_user_id: params.userId,
-        p_user_email: params.userEmail ?? null,
+        p_user_email: params.userEmail?.trim().toLowerCase() || null,
         p_scope: params.scope ?? "all",
         p_search_term: params.searchTerm ?? null,
         p_practice: params.practice ?? null,

--- a/backend/src/lib/userDataExport.ts
+++ b/backend/src/lib/userDataExport.ts
@@ -364,7 +364,11 @@ export async function buildUserAccountExport(
         userEmail
             ? selectAll(db, "projects", (query) =>
                   query
-                      .filter("shared_with", "cs", JSON.stringify([userEmail]))
+                      .filter(
+                          "shared_with",
+                          "cs",
+                          JSON.stringify([userEmail.trim().toLowerCase()]),
+                      )
                       .neq("user_id", userId)
                       .order("created_at", { ascending: true }),
                   "id, user_id, name, cm_number, created_at, updated_at",

--- a/backend/src/routes/audit.ts
+++ b/backend/src/routes/audit.ts
@@ -30,7 +30,7 @@ export async function accessibleProjectIds(
     const shared = await db
       .from("projects")
       .select("id")
-      .contains("shared_with", [email]);
+      .contains("shared_with", [email.trim().toLowerCase()]);
     for (const row of (shared.data ?? []) as { id: string }[]) ids.add(row.id);
   }
   return [...ids];

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -256,6 +256,7 @@ const PROJECT_PAGINATION_QUERY_KEYS = [
 projectsRouter.get("/", requireAuth, async (req, res) => {
   const userId = res.locals.userId as string;
   const userEmail = res.locals.userEmail as string | undefined;
+  const normalizedUserEmail = userEmail?.trim().toLowerCase();
   const includeDocuments = req.query.include === "documents";
 
   if (req.query.view === "directory-search") {
@@ -269,7 +270,7 @@ projectsRouter.get("/", requireAuth, async (req, res) => {
     );
     const { data, error } = await db.rpc("get_project_summaries", {
       p_user_id: userId,
-      p_user_email: userEmail ?? null,
+      p_user_email: normalizedUserEmail ?? null,
       p_limit: pagination.limit,
       p_offset: pagination.offset,
     });
@@ -284,7 +285,7 @@ projectsRouter.get("/", requireAuth, async (req, res) => {
   const rpcArgs = hasPaginationParams
     ? buildProjectsOverviewRpcArgs({
         userId,
-        userEmail,
+        userEmail: normalizedUserEmail,
         scope: parseProjectScope(req.query.scope),
         pagination: parsePaginationQuery(
           req.query as Record<string, unknown>,
@@ -294,7 +295,7 @@ projectsRouter.get("/", requireAuth, async (req, res) => {
         practice: normalizeSearchTerm(req.query.practice),
         ownerUserId: normalizeSearchTerm(req.query.owner_user_id),
       })
-    : { p_user_id: userId, p_user_email: userEmail ?? null };
+    : { p_user_id: userId, p_user_email: normalizedUserEmail ?? null };
 
   const { data, error } = await db.rpc("get_projects_overview", rpcArgs);
   if (error) return void res.status(500).json({ detail: error.message });
@@ -423,13 +424,17 @@ async function handleProjectDirectorySearch(req: Request, res: Response) {
     req.query as Record<string, unknown>,
   );
   const db = createServerSupabase();
+  const normalizedUserEmail = userEmail?.trim().toLowerCase();
 
   const projectQueries = [
     db.from("projects").select("*").eq("user_id", userId),
   ];
-  if (userEmail) {
+  if (normalizedUserEmail) {
     projectQueries.push(
-      db.from("projects").select("*").contains("shared_with", [userEmail]),
+      db
+        .from("projects")
+        .select("*")
+        .contains("shared_with", [normalizedUserEmail]),
     );
   }
   const projectResults = await Promise.all(projectQueries);
@@ -539,10 +544,11 @@ projectsRouter.get("/:projectId/directory", requireAuth, async (req, res) => {
 projectsRouter.get("/filter-options", requireAuth, async (req, res) => {
   const userId = res.locals.userId as string;
   const userEmail = res.locals.userEmail as string | undefined;
+  const normalizedUserEmail = userEmail?.trim().toLowerCase();
   const db = createServerSupabase();
   const { data, error } = await db.rpc("get_project_filter_options", {
     p_user_id: userId,
-    p_user_email: userEmail ?? null,
+    p_user_email: normalizedUserEmail ?? null,
   });
   if (error) return void res.status(500).json({ detail: error.message });
 
@@ -622,20 +628,16 @@ projectsRouter.get("/:projectId", requireAuth, async (req, res) => {
   const { projectId } = req.params;
   const db = createServerSupabase();
 
+  const access = await checkProjectAccess(projectId, userId, userEmail, db);
+  if (!access.ok)
+    return void res.status(404).json({ detail: "Project not found" });
+
   const { data: project, error } = await db
     .from("projects")
     .select("*")
     .eq("id", projectId)
     .single();
   if (error || !project)
-    return void res.status(404).json({ detail: "Project not found" });
-
-  const canAccess =
-    project.user_id === userId ||
-    (userEmail &&
-      Array.isArray(project.shared_with) &&
-      project.shared_with.includes(userEmail));
-  if (!canAccess)
     return void res.status(404).json({ detail: "Project not found" });
 
   const [{ data: docs }, { data: folderData }] = await Promise.all([
@@ -660,7 +662,7 @@ projectsRouter.get("/:projectId", requireAuth, async (req, res) => {
   await attachDocumentOwnerLabels(db, docsTyped);
   res.json({
     ...project,
-    is_owner: project.user_id === userId,
+    is_owner: access.isOwner,
     documents: docsTyped,
     folders: folderData ?? [],
   });


### PR DESCRIPTION
## Summary

Makes project sharing consistently case-insensitive for both project detail and collection access, including shares stored before write-time normalization was added.

Closes #70
Closes #85

## Why / Motivation

Project detail used a case-sensitive inline Array.includes check, while project-list and related JSONB containment queries depend on lowercase stored values. Legacy mixed-case invitations could therefore hide or deny a legitimately shared project.

## Changes

- Routes GET /projects/:projectId authorization through the shared checkProjectAccess helper.
- Normalizes project-sharing email inputs before overview, summary, filter, directory, audit, export, and accessible-project queries.
- Adds an idempotent migration that trims and lowercases legacy projects.shared_with entries, drops blanks, and deduplicates them while preserving first-seen order.
- Keeps indexed JSONB containment queries instead of replacing them with scans.
- Adds regression coverage for mixed-case and whitespace-padded emails.

## Tradeoffs & risks

The data migration updates only rows whose normalized array differs, but it will briefly lock each changed project row. Project detail now performs the centralized access lookup before loading the complete project record, adding one small database read in exchange for consistent authorization behavior.

## How verified

- npm run build
- npm test — 597 passed, 24 skipped
- Applied the migration to disposable PostgreSQL rows containing mixed-case, padded, blank, and duplicate addresses; verified the normalized result and verified a second run reported UPDATE 0.

## Checklist

- [x] Ran the relevant build/test command for the area changed.
- [x] Reviewed git diff and removed unrelated changes.
- [x] Documentation and environment examples are unaffected.
- [x] No secrets, API keys, real documents, or .env files committed.