### PR TITLE
fix: log storage errors and reuse Supabase admin client

### DIFF
--- a/backend/src/lib/__tests__/storageErrors.test.ts
+++ b/backend/src/lib/__tests__/storageErrors.test.ts
@@ -1,0 +1,82 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  getSignedUrl: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-s3", () => {
+  class S3Client {
+    send = mocks.send;
+  }
+  class Command {
+    constructor(readonly input: unknown) {}
+  }
+  return {
+    S3Client,
+    PutObjectCommand: Command,
+    DeleteObjectCommand: Command,
+    ListObjectsV2Command: Command,
+    GetObjectCommand: Command,
+  };
+});
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: mocks.getSignedUrl,
+}));
+
+let downloadFile: typeof import("../storage").downloadFile;
+let getSignedUrl: typeof import("../storage").getSignedUrl;
+
+beforeAll(async () => {
+  process.env.R2_ENDPOINT_URL = "https://r2.example.test";
+  process.env.R2_ACCESS_KEY_ID = "test-access-key";
+  process.env.R2_SECRET_ACCESS_KEY = "test-secret-key";
+  vi.resetModules();
+  ({ downloadFile, getSignedUrl } = await import("../storage"));
+});
+
+beforeEach(() => {
+  mocks.send.mockReset();
+  mocks.getSignedUrl.mockReset();
+});
+
+describe("storage error logging", () => {
+  it("logs download failures with the object key and a safe error", async () => {
+    const failure = new Error("download failed");
+    mocks.send.mockRejectedValue(failure);
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(
+      downloadFile("documents/u1/d1/source.pdf"),
+    ).resolves.toBeNull();
+
+    expect(log).toHaveBeenCalledWith("[storage] downloadFile failed", {
+      key: "documents/u1/d1/source.pdf",
+      error: expect.objectContaining({
+        name: "Error",
+        message: "download failed",
+      }),
+    });
+    log.mockRestore();
+  });
+
+  it("logs signed-URL failures with the object key and a safe error", async () => {
+    const failure = new Error("signing failed");
+    mocks.getSignedUrl.mockRejectedValue(failure);
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(
+      getSignedUrl("documents/u1/d1/source.pdf"),
+    ).resolves.toBeNull();
+
+    expect(log).toHaveBeenCalledWith("[storage] getSignedUrl failed", {
+      key: "documents/u1/d1/source.pdf",
+      error: expect.objectContaining({
+        name: "Error",
+        message: "signing failed",
+      }),
+    });
+    log.mockRestore();
+  });
+});

--- a/backend/src/lib/__tests__/supabase.test.ts
+++ b/backend/src/lib/__tests__/supabase.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClient } = vi.hoisted(() => ({
+  createClient: vi.fn((url: string, key: string) => ({ url, key })),
+}));
+
+vi.mock("@supabase/supabase-js", () => ({ createClient }));
+
+import { createServerSupabase } from "../supabase";
+
+describe("createServerSupabase", () => {
+  beforeEach(() => {
+    createClient.mockClear();
+    process.env.SUPABASE_URL = `https://${crypto.randomUUID()}.supabase.test`;
+    process.env.SUPABASE_SECRET_KEY = crypto.randomUUID();
+  });
+
+  it("reuses one admin client for the same configuration", () => {
+    const first = createServerSupabase();
+    const second = createServerSupabase();
+
+    expect(second).toBe(first);
+    expect(createClient).toHaveBeenCalledTimes(1);
+    expect(createClient).toHaveBeenCalledWith(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SECRET_KEY,
+      {
+        auth: {
+          persistSession: false,
+          autoRefreshToken: false,
+        },
+      },
+    );
+  });
+
+  it("creates a new client when the configuration changes", () => {
+    const first = createServerSupabase();
+    process.env.SUPABASE_SECRET_KEY = crypto.randomUUID();
+
+    const second = createServerSupabase();
+
+    expect(second).not.toBe(first);
+    expect(createClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects missing server configuration", () => {
+    delete process.env.SUPABASE_URL;
+
+    expect(() => createServerSupabase()).toThrow(
+      "SUPABASE_URL and SUPABASE_SECRET_KEY must be set",
+    );
+    expect(createClient).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/lib/storage.ts
+++ b/backend/src/lib/storage.ts
@@ -17,6 +17,7 @@ import {
 } from "@aws-sdk/client-s3";
 import * as S3Commands from "@aws-sdk/client-s3";
 import { getSignedUrl as awsGetSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { safeErrorLog } from "./safeError";
 
 const GetObjectCommand = (S3Commands as any).GetObjectCommand;
 
@@ -88,7 +89,11 @@ export async function downloadFile(key: string): Promise<ArrayBuffer | null> {
     if (!response.Body) return null;
     const bytes = await response.Body.transformToByteArray();
     return bytes.buffer as ArrayBuffer;
-  } catch {
+  } catch (error) {
+    console.error("[storage] downloadFile failed", {
+      key,
+      error: safeErrorLog(error),
+    });
     return null;
   }
 }
@@ -149,7 +154,11 @@ export async function getSignedUrl(
       ResponseContentDisposition: responseContentDisposition,
     }) as any;
     return await awsGetSignedUrl(client, command, { expiresIn });
-  } catch {
+  } catch (error) {
+    console.error("[storage] getSignedUrl failed", {
+      key,
+      error: safeErrorLog(error),
+    });
     return null;
   }
 }

--- a/backend/src/lib/supabase.ts
+++ b/backend/src/lib/supabase.ts
@@ -1,4 +1,12 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let cachedAdminClient:
+  | {
+      url: string;
+      key: string;
+      client: SupabaseClient<any, "public", any>;
+    }
+  | undefined;
 
 /**
  * Server-side Supabase client using the service role key.
@@ -10,5 +18,17 @@ export function createServerSupabase() {
   if (!url || !key) {
     throw new Error("SUPABASE_URL and SUPABASE_SECRET_KEY must be set");
   }
-  return createClient(url, key, { auth: { persistSession: false } });
+
+  if (cachedAdminClient?.url === url && cachedAdminClient.key === key) {
+    return cachedAdminClient.client;
+  }
+
+  const client = createClient(url, key, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+  cachedAdminClient = { url, key, client };
+  return client;
 }

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from "express";
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabase } from "../lib/supabase";
 import { syncProfileEmail } from "../lib/userLookup";
 
 const isDev = process.env.NODE_ENV !== "production";
@@ -30,7 +30,7 @@ function isLoginMfaBootstrapRoute(req: Request) {
 async function enforceLoginMfaIfEnabled(
   req: Request,
   res: Response,
-  admin: SupabaseClient<any, "public", any>,
+  admin: ReturnType<typeof createServerSupabase>,
   token: string,
 ) {
   if (isLoginMfaBootstrapRoute(req)) return true;
@@ -87,6 +87,15 @@ async function enforceLoginMfaIfEnabled(
   return true;
 }
 
+function getAdminClient(res: Response) {
+  try {
+    return createServerSupabase();
+  } catch {
+    res.status(500).json({ detail: "Server auth is not configured" });
+    return null;
+  }
+}
+
 export async function requireAuth(
   req: Request,
   res: Response,
@@ -99,17 +108,8 @@ export async function requireAuth(
   }
   const token = auth.slice(7).trim();
 
-  const supabaseUrl = process.env.SUPABASE_URL ?? "";
-  const serviceKey = process.env.SUPABASE_SECRET_KEY ?? "";
-
-  if (!supabaseUrl || !serviceKey) {
-    res.status(500).json({ detail: "Server auth is not configured" });
-    return;
-  }
-
-  const admin = createClient(supabaseUrl, serviceKey, {
-    auth: { persistSession: false },
-  });
+  const admin = getAdminClient(res);
+  if (!admin) return;
   const { data } = await admin.auth.getUser(token);
   if (!data.user) {
     res.status(401).json({ detail: "Invalid or expired token" });
@@ -153,17 +153,8 @@ export async function requireMfaIfEnrolled(
     return;
   }
 
-  const supabaseUrl = process.env.SUPABASE_URL ?? "";
-  const serviceKey = process.env.SUPABASE_SECRET_KEY ?? "";
-
-  if (!supabaseUrl || !serviceKey) {
-    res.status(500).json({ detail: "Server auth is not configured" });
-    return;
-  }
-
-  const admin = createClient(supabaseUrl, serviceKey, {
-    auth: { persistSession: false },
-  });
+  const admin = getAdminClient(res);
+  if (!admin) return;
   const { data, error } =
     await admin.auth.mfa.getAuthenticatorAssuranceLevel(token);
 


### PR DESCRIPTION
## Summary

Improves backend operability by making R2 failures visible and removing repeated Supabase service-role client construction from authenticated requests.

Closes #102
Closes #103

## Why / Motivation

R2 download and signed-URL failures currently collapse to null without any server-side diagnostics. Separately, auth and MFA middleware construct fresh Supabase clients for every request even though the service-role client does not persist a user session.

## Changes

- Logs downloadFile and getSignedUrl failures with the storage key and redacted error details while preserving the existing null return contract.
- Caches the server Supabase client by URL and service key.
- Disables session persistence and automatic token refresh on the shared admin client.
- Reuses the shared factory in both authentication and MFA middleware while preserving the existing configuration-error response.
- Adds focused tests for logging, redaction shape, client reuse, configuration changes, and missing configuration.

## Tradeoffs & risks

Storage object keys now appear in error logs, which is useful for diagnosis but should be handled according to normal log-retention policy. The cached client is shared only as a service-role client; no user session is persisted or refreshed, and bearer tokens continue to be passed explicitly to auth calls.

## How verified

- npm run build
- npm test — 602 passed, 24 skipped

## Checklist

- [x] Ran the relevant build/test command for the area changed.
- [x] Reviewed git diff and removed unrelated changes.
- [x] Documentation and environment examples are unaffected.
- [x] No secrets, API keys, real documents, or .env files committed.