### PR TITLE
fix(docx): avoid numbering generated letter paragraphs

### DIFF
--- a/backend/src/lib/__tests__/documentGeneration.test.ts
+++ b/backend/src/lib/__tests__/documentGeneration.test.ts
@@ -1,0 +1,161 @@
+import JSZip from "jszip";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { uploadFileMock } = vi.hoisted(() => ({
+  uploadFileMock: vi.fn(),
+}));
+
+vi.mock("../storage", () => ({
+  downloadFile: vi.fn(),
+  generatedDocKey: (userId: string, docId: string, filename: string) =>
+    `generated/${userId}/${docId}/${filename}`,
+  uploadFile: (...args: unknown[]) => uploadFileMock(...args),
+}));
+
+vi.mock("../downloadTokens", () => ({
+  buildDownloadUrl: () => "/download/test-token",
+}));
+
+import { generateDocx } from "../chat/tools/documentOps";
+
+function fakeDb() {
+  return {
+    from(table: string) {
+      const result = { data: null, error: null };
+      const query: Record<string, unknown> = {};
+      query.insert = vi.fn(() => query);
+      query.select = vi.fn(() => query);
+      query.update = vi.fn(() => query);
+      query.eq = vi.fn(() => query);
+      query.single = vi.fn(async () => ({
+        data: { id: table === "documents" ? "doc-1" : "version-1" },
+        error: null,
+      }));
+      query.then = (
+        resolve: (value: typeof result) => unknown,
+        reject?: (error: unknown) => unknown,
+      ) => Promise.resolve(result).then(resolve, reject);
+      return query;
+    },
+  };
+}
+
+async function generatedXml(options: {
+  sections: unknown[];
+  numberSections?: boolean;
+}): Promise<{ documentXml: string; numberingXml: string }> {
+  let bytes: ArrayBuffer | undefined;
+  uploadFileMock.mockImplementationOnce(
+    async (_key: string, uploaded: ArrayBuffer) => {
+      bytes = uploaded;
+    },
+  );
+
+  const result = await generateDocx(
+    "Generated document",
+    options.sections,
+    "test-user",
+    fakeDb() as never,
+    options.numberSections === undefined
+      ? undefined
+      : { numberSections: options.numberSections },
+  );
+
+  expect(result).not.toHaveProperty("error");
+  expect(bytes).toBeDefined();
+  const archive = await JSZip.loadAsync(bytes!);
+  const documentXml = await archive.file("word/document.xml")!.async("string");
+  const numberingXml = await archive.file("word/numbering.xml")!.async("string");
+  return { documentXml, numberingXml };
+}
+
+function paragraphContaining(xml: string, text: string): string {
+  return (
+    xml
+      .match(/<w:p(?:\s[^>]*)?>[\s\S]*?<\/w:p>/g)
+      ?.find((paragraph) => paragraph.includes(text)) ?? ""
+  );
+}
+
+beforeEach(() => {
+  uploadFileMock.mockReset();
+});
+
+describe("generateDocx numbering", () => {
+  it("leaves demand-letter headings and prose unnumbered by default", async () => {
+    const { documentXml } = await generatedXml({
+      sections: [
+        {
+          heading: "Demand for Payment",
+          content:
+            "We represent the claimant.\nPayment is required within ten days.",
+        },
+      ],
+    });
+
+    expect(paragraphContaining(documentXml, "DEMAND FOR PAYMENT")).not.toContain(
+      "<w:numPr>",
+    );
+    expect(
+      paragraphContaining(documentXml, "We represent the claimant."),
+    ).not.toContain("<w:numPr>");
+    expect(
+      paragraphContaining(documentXml, "Payment is required within ten days."),
+    ).not.toContain("<w:numPr>");
+  });
+
+  it("numbers only headings when legal section numbering is requested", async () => {
+    const { documentXml } = await generatedXml({
+      numberSections: true,
+      sections: [
+        {
+          heading: "Payment Terms",
+          content: "Payment is due monthly.\nInvoices are payable in ten days.",
+        },
+      ],
+    });
+
+    expect(paragraphContaining(documentXml, "PAYMENT TERMS")).toContain(
+      "<w:numPr>",
+    );
+    expect(paragraphContaining(documentXml, "Payment is due monthly.")).not.toContain(
+      "<w:numPr>",
+    );
+    expect(
+      paragraphContaining(documentXml, "Invoices are payable in ten days."),
+    ).not.toContain("<w:numPr>");
+  });
+
+  it("preserves manually typed numbering when automatic numbering is off", async () => {
+    const { documentXml } = await generatedXml({
+      sections: [{ content: "1. This reference is intentional." }],
+    });
+    const paragraph = paragraphContaining(
+      documentXml,
+      "1. This reference is intentional.",
+    );
+
+    expect(paragraph).toContain("1. This reference is intentional.");
+    expect(paragraph).not.toContain("<w:numPr>");
+  });
+
+  it("renders explicit bullets as bullets rather than legal clauses", async () => {
+    const { documentXml, numberingXml } = await generatedXml({
+      numberSections: true,
+      sections: [
+        {
+          heading: "Requirements",
+          content: "- First item\n- Second item",
+        },
+      ],
+    });
+
+    const first = paragraphContaining(documentXml, "First item");
+    const second = paragraphContaining(documentXml, "Second item");
+    expect(first).toContain("<w:numPr>");
+    expect(second).toContain("<w:numPr>");
+    expect(first).not.toContain("- First item");
+    expect(second).not.toContain("- Second item");
+    expect(numberingXml).toContain('<w:numFmt w:val="bullet"/>');
+  });
+});

--- a/backend/src/lib/chat/prompts.ts
+++ b/backend/src/lib/chat/prompts.ts
@@ -49,9 +49,11 @@ DOCX GENERATION:
 - If the user asks you to create or draft a document, call generate_docx and provide the downloadable Word document rather than only displaying text inline.
 - If the user asks to revise a document you just generated, call edit_document on that document unless they explicitly want a brand-new document or the change is too broad for coherent editing.
 - Use heading levels in order; do not skip from Heading 1 to Heading 3.
-- Numbering starts at 1, never 0. The generator applies legal numbering automatically. Do not type numbering prefixes into headings.
+- Generated documents are unnumbered by default. For letters, demand letters, notices, memos, reports, and other prose documents, omit numberSections (or set it to false) and do not number ordinary paragraphs unless the user explicitly asks for numbering.
+- Set numberSections to true only when the user explicitly requests numbered sections/clauses or a selected workflow, playbook, or source template requires them. When enabled, numbering starts at 1, never 0; do not type duplicate numbering prefixes into headings.
+- Ordinary prose paragraphs are never numbered automatically, including inside a document with numbered section headings. Use explicit list markers only when the content itself is a list.
 - Do not repeat the document title as the first section heading.
-- Contract preambles, party blocks, recitals, and WHEREAS clauses are unnumbered. Begin numbering at the first operative clause or section.
+- In a numbered contract, preambles, party blocks, recitals, and WHEREAS clauses are unnumbered. Begin numbering at the first operative clause or section.
 - Contracts and agreements must end with an unnumbered signature block on a fresh page. Set pageBreak: true on the final section and include signature lines such as By, Name, Title, and Date for each party.
 
 DOCUMENT EDITING:

--- a/backend/src/lib/chat/tools/documentOps.ts
+++ b/backend/src/lib/chat/tools/documentOps.ts
@@ -93,7 +93,11 @@ export async function generateDocx(
   sections: unknown[],
   userId: string,
   db: ReturnType<typeof createServerSupabase>,
-  options?: { landscape?: boolean; projectId?: string | null },
+  options?: {
+    landscape?: boolean;
+    numberSections?: boolean;
+    projectId?: string | null;
+  },
 ) {
   try {
     const {
@@ -149,6 +153,9 @@ export async function generateDocx(
       HeadingLevel.HEADING_3,
       HeadingLevel.HEADING_4,
     ];
+    // `=== true` is intentional: missing, null, or malformed values must
+    // produce an unnumbered document.
+    const numberSections = options?.numberSections === true;
     const LEGAL_NUMBERING_REF = "legal-clause-numbering";
     const legalNumbering = (level: number) => ({
       reference: LEGAL_NUMBERING_REF,
@@ -330,17 +337,23 @@ export async function generateDocx(
         children.push(new Paragraph({ children: [new PageBreak()] }));
       }
       if (section.heading) {
-        const stripped = stripManualNumbering(section.heading);
+        const stripped = numberSections
+          ? stripManualNumbering(section.heading)
+          : { text: section.heading.trim(), levelFromPrefix: null };
         const isUnnumbered = isUnnumberedHeading(stripped.text, sectionIndex);
         const skipHeading = isTitleLikeFirstHeading(
           stripped.text,
           sectionIndex,
         );
-        const idx = Math.min(
-          stripped.levelFromPrefix ?? (section.level ?? 1) - 1,
-          3,
+        const requestedLevel = Number.isInteger(section.level)
+          ? Number(section.level)
+          : 1;
+        const idx = Math.max(
+          0,
+          Math.min(stripped.levelFromPrefix ?? requestedLevel - 1, 3),
         );
-        currentClauseLevel = isUnnumbered || skipHeading ? null : idx;
+        currentClauseLevel =
+          !numberSections || isUnnumbered || skipHeading ? null : idx;
         const headingText =
           idx === 0 && !isUnnumbered
             ? stripped.text.toUpperCase()
@@ -349,7 +362,10 @@ export async function generateDocx(
           children.push(
             new Paragraph({
               heading: headingLevels[idx],
-              numbering: isUnnumbered ? undefined : legalNumbering(idx),
+              numbering:
+                numberSections && !isUnnumbered
+                  ? legalNumbering(idx)
+                  : undefined,
               spacing: { after: 160 },
               children: [
                 new TextRun({
@@ -430,7 +446,6 @@ export async function generateDocx(
         children.push(new Paragraph({ text: "" }));
       }
       if (section.content) {
-        let numberedBodyParagraphs = 0;
         const contentIsSignatureBlock =
           section.heading &&
           normalizeHeadingText(section.heading).includes("signature")
@@ -443,30 +458,33 @@ export async function generateDocx(
           const rawText = bulletMatch ? bulletMatch[1].trim() : trimmed;
           const manualList = parseManualListMarker(rawText);
           const numeric = stripManualNumbering(rawText);
-          const text = bulletMatch
-            ? rawText
-            : manualList.levelOffset !== null
-              ? manualList.text
-              : numeric.text;
           const inferredLevel =
             currentClauseLevel === null || contentIsSignatureBlock
               ? undefined
               : bulletMatch
-                ? currentClauseLevel + 2
+                ? undefined
                 : manualList.levelOffset !== null
                   ? currentClauseLevel + manualList.levelOffset
                   : numeric.levelFromPrefix !== null
                     ? numeric.levelFromPrefix
-                    : numberedBodyParagraphs === 0
-                      ? currentClauseLevel + 1
-                      : currentClauseLevel + 2;
-          if (currentClauseLevel !== null) numberedBodyParagraphs++;
+                    : undefined;
+          // Strip typed list markers only when Word numbering will replace
+          // them. This preserves intentional text such as "1. Final notice"
+          // in an otherwise unnumbered letter or signature block.
+          const text = bulletMatch
+            ? rawText
+            : inferredLevel === undefined
+              ? rawText
+              : manualList.levelOffset !== null
+                ? manualList.text
+                : numeric.text;
           children.push(
             new Paragraph({
               numbering:
                 inferredLevel === undefined
                   ? undefined
                   : legalNumbering(inferredLevel),
+              bullet: bulletMatch ? { level: 0 } : undefined,
               spacing: { after: 120 },
               children: [
                 new TextRun({
@@ -486,14 +504,16 @@ export async function generateDocx(
       : {};
 
     const doc = new Document({
-      numbering: {
-        config: [
-          {
-            reference: LEGAL_NUMBERING_REF,
-            levels: legalNumberingLevels,
-          },
-        ],
-      },
+      numbering: numberSections
+        ? {
+            config: [
+              {
+                reference: LEGAL_NUMBERING_REF,
+                levels: legalNumberingLevels,
+              },
+            ],
+          }
+        : undefined,
       sections: [{ properties: pageSetup, children }],
     });
     const buf = await Packer.toBuffer(doc);

--- a/backend/src/lib/chat/tools/toolDispatcher.ts
+++ b/backend/src/lib/chat/tools/toolDispatcher.ts
@@ -1862,6 +1862,9 @@ export async function runToolCalls(
     } else if (tc.function.name === "generate_docx") {
       const title = args.title as string;
       const landscape = !!args.landscape;
+      // `=== true` is intentional: missing, null, or malformed values must
+      // not enable numbering.
+      const numberSections = args.numberSections === true;
       devLog(
         `[generate_docx] title="${title}" landscape=${landscape} args.landscape=${args.landscape}`,
       );
@@ -1874,7 +1877,7 @@ export async function runToolCalls(
         args.sections as unknown[],
         userId,
         db,
-        { landscape, projectId: projectId ?? null },
+        { landscape, numberSections, projectId: projectId ?? null },
       );
       registerGeneratedDocument(
         tc,

--- a/backend/src/lib/chat/tools/toolSchemas.ts
+++ b/backend/src/lib/chat/tools/toolSchemas.ts
@@ -273,6 +273,11 @@ export const TOOLS = [
             description:
               "Set to true for landscape page orientation. Default is portrait.",
           },
+          numberSections: {
+            type: "boolean",
+            description:
+              "Apply legal numbering to section headings. Default is false. Set true only when the user explicitly requests numbered sections/clauses or a workflow, playbook, or source template requires them. Never use it for demand letters, ordinary letters, notices, memos, or reports unless numbering was requested.",
+          },
           sections: {
             type: "array",
             description:


### PR DESCRIPTION
## Summary

- make generated DOCX section numbering opt-in through an optional `numberSections` tool argument
- leave letters and other prose documents unnumbered by default
- stop assigning inferred legal numbers to ordinary body paragraphs
- preserve explicit bullets and manually typed numbering
- add DOCX XML regression tests for default and opt-in numbering

## Problem

The DOCX generator always configured legal numbering and inferred a numbering level for every paragraph beneath a section heading. This caused ordinary demand-letter prose to render approximately as:

`1. DEMAND FOR PAYMENT`  
`1.1 We represent the claimant.`  
`(a) Payment is required within ten days.`

A prompt-only fix would be insufficient because the renderer itself applied numbering even when the model did not request it.

## Behavior after this change

Documents are unnumbered by default. `numberSections: true` numbers section headings when explicitly requested or required by a workflow/template, while ordinary prose remains unnumbered. Explicit bullets use Word bullet formatting. Manually typed prefixes such as `1. This reference is intentional.` remain literal text when automatic numbering is off.

The dispatcher and renderer both use `=== true`, so missing, null, string, or otherwise malformed values cannot enable numbering accidentally.

## Tests

New regression tests inspect `word/document.xml` (and `word/numbering.xml` for bullets) inside generated DOCX bytes and cover:

- demand-letter headings and body prose unnumbered by default
- opt-in legal numbering on headings only
- preservation of manually typed numbering when numbering is off
- explicit bullets rendered as bullets rather than legal clauses

Validation completed (rebased onto current `main`):

- `tsc --noEmit` in `backend` — clean
- `npm test` in `backend` — **711 passed, 24 skipped**
- The four new `documentGeneration.test.ts` cases all pass

## Rebased onto current main

Re-verified the bug has not been addressed upstream in the meantime: `documentOps.ts` on `main` still calls `legalNumbering(inferredLevel)` for inferred paragraphs and still configures the numbering set unconditionally, and `numberSections` appears nowhere in `backend/src`.

The rebase was clean. Worth noting explicitly because it touches neighbouring code: this does **not** conflict with the docx text-value work merged in #328 — that PR's `preserves numeric-looking text through an unrelated edit` regression test still passes alongside the new numbering tests.

No database, frontend, provider, PDF reconstruction, or product-module changes are included.
