### PR TITLE
fix(mcp): follow redirects with per-hop SSRF re-validation

### DIFF
--- a/backend/src/lib/mcp/__tests__/client.ssrf.test.ts
+++ b/backend/src/lib/mcp/__tests__/client.ssrf.test.ts
@@ -143,3 +143,121 @@ describe("guardedFetch", () => {
         expect(nextInit.dispatcher).toBe(init.dispatcher);
     });
 });
+
+describe("guardedFetch redirect following", () => {
+    function redirectTo(location: string, status = 302) {
+        return new Response(null, { status, headers: { location } });
+    }
+
+    it("follows a redirect and returns the final response", async () => {
+        resolvesTo("93.184.216.34");
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValueOnce(
+                redirectTo("https://public.example.com/mcp/.well-known/x"),
+            )
+            .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+        const res = await guardedFetch(
+            "https://public.example.com/.well-known/x/mcp",
+        );
+
+        expect(res.status).toBe(200);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(fetchSpy.mock.calls[1][0]).toBe(
+            "https://public.example.com/mcp/.well-known/x",
+        );
+    });
+
+    it("resolves a relative Location against the current URL", async () => {
+        resolvesTo("93.184.216.34");
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValueOnce(redirectTo("/elsewhere", 307))
+            .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+        await guardedFetch("https://public.example.com/a/b");
+
+        expect(fetchSpy.mock.calls[1][0]).toBe(
+            "https://public.example.com/elsewhere",
+        );
+    });
+
+    it("re-validates each hop and refuses a redirect to a private address", async () => {
+        lookupMock.mockImplementation(async (hostname: string) =>
+            hostname === "public.example.com"
+                ? [{ address: "93.184.216.34", family: 4 }]
+                : [{ address: "169.254.169.254", family: 4 }],
+        );
+        vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            redirectTo("https://internal.example.com/latest/meta-data/"),
+        );
+
+        await expect(
+            guardedFetch("https://public.example.com/mcp"),
+        ).rejects.toThrow(/blocked network address/);
+    });
+
+    it("drops the Authorization header when the origin changes", async () => {
+        resolvesTo("93.184.216.34");
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValueOnce(redirectTo("https://other.example.com/x"))
+            .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+        await guardedFetch("https://public.example.com/mcp", {
+            headers: { authorization: "Bearer secret", accept: "application/json" },
+        });
+
+        const headers = new Headers(
+            (fetchSpy.mock.calls[1][1] as RequestInit).headers,
+        );
+        expect(headers.get("authorization")).toBeNull();
+        expect(headers.get("accept")).toBe("application/json");
+    });
+
+    it("keeps the Authorization header on a same-origin redirect", async () => {
+        resolvesTo("93.184.216.34");
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValueOnce(redirectTo("https://public.example.com/x"))
+            .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+        await guardedFetch("https://public.example.com/mcp", {
+            headers: { authorization: "Bearer secret" },
+        });
+
+        const headers = new Headers(
+            (fetchSpy.mock.calls[1][1] as RequestInit).headers,
+        );
+        expect(headers.get("authorization")).toBe("Bearer secret");
+    });
+
+    it("does not follow redirects for non-GET requests", async () => {
+        resolvesTo("93.184.216.34");
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue(redirectTo("https://public.example.com/x"));
+
+        const res = await guardedFetch("https://public.example.com/mcp", {
+            method: "POST",
+            body: "{}",
+        });
+
+        expect(res.status).toBe(302);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops after the redirect cap instead of looping forever", async () => {
+        resolvesTo("93.184.216.34");
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue(redirectTo("https://public.example.com/loop"));
+
+        const res = await guardedFetch("https://public.example.com/loop");
+
+        expect(res.status).toBe(302);
+        // 1 initial + MAX_MCP_REDIRECTS follows.
+        expect(fetchSpy).toHaveBeenCalledTimes(6);
+    });
+});

--- a/backend/src/lib/mcp/client.ts
+++ b/backend/src/lib/mcp/client.ts
@@ -371,22 +371,76 @@ const guardedAgent = new Agent({
 // connection to a connect-time-validated address, and refuses to auto-follow
 // redirects (`redirect: "manual"`) so a 3xx to an internal host cannot smuggle
 // egress past the guard.
+// Redirects are followed here rather than by the runtime so that every hop is
+// re-checked by validateRemoteMcpUrl — `redirect: "follow"` would let a public
+// URL bounce us to a private address the guard never saw. Refusing outright is
+// not an option either: RFC 8414 well-known discovery paths are commonly served
+// as redirects, and the MCP SDK treats any non-4xx as fatal, so a single 302
+// aborts discovery even when a later candidate URL would have worked.
+const MAX_MCP_REDIRECTS = 5;
+
 export async function guardedFetch(
     input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
 ) {
-    const url =
+    const isRequest = typeof input === "object" && input instanceof Request;
+    let url =
         typeof input === "string"
             ? input
             : input instanceof URL
               ? input.toString()
               : input.url;
     await validateRemoteMcpUrl(url);
-    return fetch(input, {
+    let response = await fetch(input, {
         ...init,
         redirect: "manual",
         dispatcher: guardedAgent,
     } as RequestInit);
+
+    const method = (
+        init?.method ??
+        (isRequest ? input.method : null) ??
+        "GET"
+    ).toUpperCase();
+    // Only bodyless methods are followed. Replaying a POST body across a
+    // redirect is not something any MCP flow needs, and skipping it avoids
+    // having to reason about 307/308 body semantics.
+    if (method !== "GET" && method !== "HEAD") return response;
+
+    const baseHeaders = new Headers(
+        (init?.headers as HeadersInit | undefined) ??
+            (isRequest ? input.headers : undefined),
+    );
+
+    for (let hop = 0; hop < MAX_MCP_REDIRECTS; hop++) {
+        if (response.status < 300 || response.status > 399) return response;
+        const location = response.headers.get("location");
+        if (!location) return response;
+
+        let target: string;
+        try {
+            target = new URL(location, url).toString();
+        } catch {
+            return response;
+        }
+        await response.body?.cancel().catch(() => undefined);
+
+        const validated = await validateRemoteMcpUrl(target);
+        const headers = new Headers(baseHeaders);
+        // Never carry credentials to a different origin.
+        if (new URL(validated).origin !== new URL(url).origin) {
+            headers.delete("authorization");
+        }
+        url = validated;
+        response = await fetch(validated, {
+            ...init,
+            method,
+            headers,
+            redirect: "manual",
+            dispatcher: guardedAgent,
+        } as RequestInit);
+    }
+    return response;
 }
 
 export function base64Url(buffer: Buffer) {


### PR DESCRIPTION
## Summary

`guardedFetch` refused to follow HTTP redirects, which made any MCP server whose OAuth
discovery endpoints redirect impossible to connect. This follows redirects while
re-validating every hop against the same SSRF guard, so the protection is preserved
(and is stricter than plain `redirect: "follow"`).

Found while connecting a public MCP server that serves its RFC 8414 metadata via a 302.

## Why

`guardedFetch` set `redirect: "manual"` and returned the 3xx response as-is. That helper
is handed to the MCP SDK as its fetch implementation (`servers.ts:63`), so the SDK saw the
raw redirect during OAuth discovery.

The SDK's `discoverAuthorizationServerMetadata` tries several well-known URLs in order,
but continues **only** on 4xx:

```js
if (response.status >= 400 && response.status < 500) continue; // try next URL
throw new Error(`HTTP ${response.status} trying to load OAuth metadata from ${endpointUrl}`);
```

A 302 is not 4xx, so the first redirecting candidate aborted the whole search — even when
a later candidate would have returned valid metadata. Concretely, for a server whose
protected-resource metadata advertises `https://host/mcp` as its authorization server:

| URL tried | Result |
|---|---|
| `https://host/.well-known/oauth-authorization-server/mcp` | 302 → **fatal, search aborts** |
| `https://host/mcp/.well-known/oauth-authorization-server` | 200, valid metadata — never reached |

The connector could be created but never authorized, so it sat at 0 tools with an opaque
`HTTP 302 trying to load OAuth metadata` error. The same server connects normally in other
MCP clients, which follow the redirect.

## Changes

`backend/src/lib/mcp/client.ts` — `guardedFetch` now follows redirects itself rather than
delegating to the runtime, so each hop is re-checked by `validateRemoteMcpUrl` (HTTPS,
private/reserved IP ranges, DNS re-resolution). `redirect: "manual"` is retained on the
underlying `fetch` so the runtime never follows anything unvalidated.

Deliberately bounded:

- **GET/HEAD only.** A redirected POST would have to replay its body; no MCP flow needs
  that, and skipping it avoids reasoning about 307/308 body semantics.
- **5-hop cap**, so a redirect loop terminates.
- **`Authorization` is dropped when the origin changes**, so credentials can't leak to a
  third-party host via redirect.
- Relative `Location` values are resolved against the current URL before validation.

This is stricter than the `redirect: "follow"` a normal client would use: with `follow`,
the runtime resolves the redirect chain internally and the guard only ever sees the
original URL, so a public hostname could bounce to a private address unchecked. Here every
hop is validated before it is fetched.

## Testing

`backend/src/lib/mcp/__tests__/client.ssrf.test.ts` — 7 new cases:

- follows a redirect and returns the final response
- resolves a relative `Location` against the current URL
- **refuses a redirect pointing at `169.254.169.254`** (the guard still fires mid-chain)
- drops `Authorization` on a cross-origin redirect
- keeps `Authorization` on a same-origin redirect
- does not follow redirects for non-GET requests
- stops at the hop cap instead of looping

Results:

```
vitest run src/lib/mcp/__tests__/client.ssrf.test.ts   16 passed
npm test --prefix backend                              557 passed | 23 skipped
tsc --noEmit                                           clean
```

Manually verified end to end: the connector that previously failed with
`HTTP 302 trying to load OAuth metadata` now completes OAuth and discovers its full tool
list.

---

*The investigation and code in this PR were done by Claude (Opus 5) via Claude Code; I
reviewed and am submitting it.*
