### PR TITLE
Model routing hardening

### DIFF
--- a/backend/migrations/20260819_01_harden_replace_user_router_models.sql
+++ b/backend/migrations/20260819_01_harden_replace_user_router_models.sql
@@ -52,8 +52,12 @@ begin
   -- An advisory xact lock is keyed by an application-chosen value (here a
   -- hash of user+router), blocks only the matching key, and releases itself
   -- at commit/rollback — no table-wide locking, nothing left behind.
+  -- hashtextextended (int8, the repo's convention for advisory locks) rather
+  -- than hashtext (int4): the wider namespace makes an accidental collision
+  -- with an unrelated lock key vastly less likely, and every other advisory
+  -- lock in this schema is already keyed the same way.
   perform pg_advisory_xact_lock(
-    hashtext(target_user_id::text || ':' || target_router)
+    hashtextextended(target_user_id::text || ':' || target_router, 0)
   );
 
   delete from public.user_router_models

--- a/backend/migrations/20260819_01_harden_replace_user_router_models.sql
+++ b/backend/migrations/20260819_01_harden_replace_user_router_models.sql
@@ -1,0 +1,82 @@
+-- Serialize concurrent replacements of one user's router selection.
+--
+-- WHY THIS IS A SEPARATE MIGRATION RATHER THAN AN EDIT TO 20260818_01:
+-- 20260818_01_user_router_models.sql is already merged, so a deployment may
+-- have run it. A migration that has run is history: editing it in place
+-- changes nothing on the databases that already applied it, while quietly
+-- disagreeing with what they actually contain. The correction therefore
+-- ships forward, as its own dated step, exactly like any other schema
+-- change. 20260818_01 keeps the body it shipped with; this file replaces
+-- the function so that upgraded deployments end up where a fresh install
+-- from schema.sql already is.
+--
+-- WHAT AN ADVISORY TRANSACTION LOCK IS: Postgres lets an application take a
+-- lock on an arbitrary number it chooses (pg_advisory_xact_lock) rather than
+-- on a table or row. Sessions that pick the same number queue behind each
+-- other; everyone else is untouched; the lock releases itself at
+-- commit/rollback, so it cannot leak.
+--
+-- WHY IT'S NEEDED: the function replaces a selection by delete+insert. Two
+-- overlapping PATCHes for the same user+router could interleave — both
+-- delete, both insert — and the second insert dies on the
+-- (user_id, router, model_id) unique constraint as a 500. Locking on a hash
+-- of user_id:router serializes exactly those two requests (last writer
+-- wins) with zero effect on other users or routers.
+--
+-- Nothing else about the function changes, and the table itself is
+-- untouched. `create or replace function` preserves the existing privileges,
+-- but the revoke/grant pair is restated below so this file is self-contained
+-- and re-runnable.
+create or replace function public.replace_user_router_models(
+  target_user_id uuid,
+  target_router text,
+  target_model_ids text[]
+)
+returns void
+language plpgsql
+security invoker
+set search_path = public
+as $$
+begin
+  if target_router !~ '^[a-z0-9][a-z0-9_-]{0,63}$' then
+    raise exception 'Invalid router slug';
+  end if;
+
+  if coalesce(array_length(target_model_ids, 1), 0) > 50 then
+    raise exception 'A router can have at most 50 selected models';
+  end if;
+
+  -- Serialize concurrent replacements of the SAME user+router selection.
+  -- Two overlapping PATCHes would otherwise interleave delete+insert and one
+  -- of them would die on the (user_id, router, model_id) unique constraint.
+  -- An advisory xact lock is keyed by an application-chosen value (here a
+  -- hash of user+router), blocks only the matching key, and releases itself
+  -- at commit/rollback — no table-wide locking, nothing left behind.
+  perform pg_advisory_xact_lock(
+    hashtext(target_user_id::text || ':' || target_router)
+  );
+
+  delete from public.user_router_models
+  where user_id = target_user_id and router = target_router;
+
+  insert into public.user_router_models (
+    user_id,
+    router,
+    model_id,
+    sort_order
+  )
+  select
+    target_user_id,
+    target_router,
+    model_id,
+    ordinality - 1
+  from unnest(coalesce(target_model_ids, '{}'::text[]))
+    with ordinality as selected(model_id, ordinality);
+end;
+$$;
+
+revoke all on function public.replace_user_router_models(uuid, text, text[])
+  from public, anon, authenticated;
+grant execute
+  on function public.replace_user_router_models(uuid, text, text[])
+  to service_role;

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -129,8 +129,12 @@ begin
   -- An advisory xact lock is keyed by an application-chosen value (here a
   -- hash of user+router), blocks only the matching key, and releases itself
   -- at commit/rollback — no table-wide locking, nothing left behind.
+  -- hashtextextended (int8, the repo's convention for advisory locks) rather
+  -- than hashtext (int4): the wider namespace makes an accidental collision
+  -- with an unrelated lock key vastly less likely, and every other advisory
+  -- lock in this schema is already keyed the same way.
   perform pg_advisory_xact_lock(
-    hashtext(target_user_id::text || ':' || target_router)
+    hashtextextended(target_user_id::text || ':' || target_router, 0)
   );
 
   delete from public.user_router_models

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -123,6 +123,16 @@ begin
     raise exception 'A router can have at most 50 selected models';
   end if;
 
+  -- Serialize concurrent replacements of the SAME user+router selection.
+  -- Two overlapping PATCHes would otherwise interleave delete+insert and one
+  -- of them would die on the (user_id, router, model_id) unique constraint.
+  -- An advisory xact lock is keyed by an application-chosen value (here a
+  -- hash of user+router), blocks only the matching key, and releases itself
+  -- at commit/rollback — no table-wide locking, nothing left behind.
+  perform pg_advisory_xact_lock(
+    hashtext(target_user_id::text || ':' || target_router)
+  );
+
   delete from public.user_router_models
   where user_id = target_user_id and router = target_router;
 

--- a/backend/src/lib/__tests__/llmModels.test.ts
+++ b/backend/src/lib/__tests__/llmModels.test.ts
@@ -154,11 +154,32 @@ describe("openRouterModelId", () => {
             "openai/gpt-5.4",
         );
     });
+
+    it("preserves catalog ids that begin with the router's own slug", () => {
+        // "openrouter/auto" is a real OpenRouter catalog id, so the app-level
+        // id is "openrouter/openrouter/auto": resolveModel must accept it and
+        // the adapter must strip exactly one namespace segment.
+        expect(
+            resolveModel("openrouter/openrouter/auto", DEFAULT_MAIN_MODEL),
+        ).toBe("openrouter/openrouter/auto");
+        expect(openRouterModelId("openrouter/openrouter/auto")).toBe(
+            "openrouter/auto",
+        );
+    });
 });
 
 describe("vercelModelId", () => {
     it("removes only the internal provider namespace", () => {
         expect(vercelModelId("vercel/openai/gpt-5.4")).toBe("openai/gpt-5.4");
+    });
+
+    it("preserves catalog ids that begin with the router's own slug", () => {
+        expect(resolveModel("vercel/vercel/v0-1.5-md", DEFAULT_MAIN_MODEL)).toBe(
+            "vercel/vercel/v0-1.5-md",
+        );
+        expect(vercelModelId("vercel/vercel/v0-1.5-md")).toBe(
+            "vercel/v0-1.5-md",
+        );
     });
 });
 

--- a/backend/src/lib/__tests__/llmModels.test.ts
+++ b/backend/src/lib/__tests__/llmModels.test.ts
@@ -126,6 +126,17 @@ describe("resolveModel", () => {
         }
     });
 
+    it("maps renamed legacy ids to their current equivalents", () => {
+        // Stored preferences outlive catalog renames; without the mapping the
+        // saved value silently degrades to the fallback.
+        expect(
+            resolveModel("gemini-3.1-flash-lite-preview", DEFAULT_MAIN_MODEL),
+        ).toBe("gemini-3.5-flash-lite");
+        expect(resolveModel("gpt-5.4-lite", DEFAULT_MAIN_MODEL)).toBe(
+            "gpt-5.4-mini",
+        );
+    });
+
     it("accepts namespaced OpenRouter model ids", () => {
         expect(
             resolveModel(

--- a/backend/src/lib/__tests__/openrouter.test.ts
+++ b/backend/src/lib/__tests__/openrouter.test.ts
@@ -183,6 +183,96 @@ describe("OpenRouter LLM adapter", () => {
         expect(runTools).not.toHaveBeenCalled();
     });
 
+    it("fails the stream when it dies before any argument bytes arrive", async () => {
+        // The name delta landed, then the connection dropped: no arguments at
+        // all, no finish_reason, no [DONE]. Indistinguishable by content from
+        // a parameter-less tool call, so the CLEAN-TERMINATION signal is what
+        // separates them — without it, "" must not be coerced to {}.
+        const body = `data: ${JSON.stringify({
+            choices: [
+                {
+                    delta: {
+                        tool_calls: [
+                            {
+                                index: 0,
+                                id: "call-1",
+                                function: { name: "delete_document" },
+                            },
+                        ],
+                    },
+                },
+            ],
+        })}\n\n`;
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue(
+                new Response(body, {
+                    status: 200,
+                    headers: { "Content-Type": "text/event-stream" },
+                }),
+            ),
+        );
+        const runTools = vi.fn();
+
+        await expect(
+            streamOpenRouter({
+                model: "openrouter/anthropic/claude-sonnet-4.5",
+                systemPrompt: "Help",
+                messages: [{ role: "user", content: "Review" }],
+                apiKeys: { openrouter: "or-user-key" },
+                runTools,
+            }),
+        ).rejects.toThrow(/ended before any arguments .* "delete_document"/);
+        expect(runTools).not.toHaveBeenCalled();
+    });
+
+    it("runs a parameter-less tool with {} when the stream terminated cleanly", async () => {
+        // streamResponse appends [DONE], so the empty arguments string here is
+        // a real parameter-less call and must still execute.
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(
+                streamResponse([
+                    {
+                        choices: [
+                            {
+                                delta: {
+                                    tool_calls: [
+                                        {
+                                            index: 0,
+                                            id: "call-1",
+                                            function: { name: "list_docs" },
+                                        },
+                                    ],
+                                },
+                                finish_reason: "tool_calls",
+                            },
+                        ],
+                    },
+                ]),
+            )
+            .mockResolvedValueOnce(
+                streamResponse([{ choices: [{ delta: { content: "Done" } }] }]),
+            );
+        vi.stubGlobal("fetch", fetchMock);
+        const runTools = vi
+            .fn()
+            .mockResolvedValue([{ tool_use_id: "call-1", content: "[]" }]);
+
+        const result = await streamOpenRouter({
+            model: "openrouter/anthropic/claude-sonnet-4.5",
+            systemPrompt: "Help",
+            messages: [{ role: "user", content: "List them" }],
+            apiKeys: { openrouter: "or-user-key" },
+            runTools,
+        });
+
+        expect(result.fullText).toBe("Done");
+        expect(runTools).toHaveBeenCalledWith([
+            { id: "call-1", name: "list_docs", input: {} },
+        ]);
+    });
+
     it("processes a final SSE line that arrives without a trailing newline", async () => {
         // Some proxies close the stream mid-line; the residual buffer still
         // holds the last delta and must be flushed, not dropped.

--- a/backend/src/lib/__tests__/openrouter.test.ts
+++ b/backend/src/lib/__tests__/openrouter.test.ts
@@ -139,6 +139,82 @@ describe("OpenRouter LLM adapter", () => {
             ]),
         );
     });
+
+    it("fails the stream instead of executing a tool with truncated arguments", async () => {
+        // The upstream connection died mid-arguments: the JSON fragment can
+        // never parse. Coercing it to {} would EXECUTE a side-effecting tool
+        // with empty input; the stream must error like a mid-stream {"error"}.
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue(
+                streamResponse([
+                    {
+                        choices: [
+                            {
+                                delta: {
+                                    tool_calls: [
+                                        {
+                                            index: 0,
+                                            id: "call-1",
+                                            function: {
+                                                name: "delete_document",
+                                                arguments: '{"term":"contr',
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                ]),
+            ),
+        );
+        const runTools = vi.fn();
+
+        await expect(
+            streamOpenRouter({
+                model: "openrouter/anthropic/claude-sonnet-4.5",
+                systemPrompt: "Help",
+                messages: [{ role: "user", content: "Review" }],
+                apiKeys: { openrouter: "or-user-key" },
+                runTools,
+            }),
+        ).rejects.toThrow(/malformed JSON arguments .* "delete_document"/);
+        expect(runTools).not.toHaveBeenCalled();
+    });
+
+    it("processes a final SSE line that arrives without a trailing newline", async () => {
+        // Some proxies close the stream mid-line; the residual buffer still
+        // holds the last delta and must be flushed, not dropped.
+        const body =
+            `data: ${JSON.stringify({
+                choices: [{ delta: { content: "Hello " } }],
+            })}\n\n` +
+            `data: ${JSON.stringify({
+                choices: [{ delta: { content: "world" } }],
+            })}`;
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue(
+                new Response(body, {
+                    status: 200,
+                    headers: { "Content-Type": "text/event-stream" },
+                }),
+            ),
+        );
+        const onContentDelta = vi.fn();
+
+        const result = await streamOpenRouter({
+            model: "openrouter/anthropic/claude-sonnet-4.5",
+            systemPrompt: "Help",
+            messages: [{ role: "user", content: "Say hello" }],
+            apiKeys: { openrouter: "or-user-key" },
+            callbacks: { onContentDelta },
+        });
+
+        expect(result.fullText).toBe("Hello world");
+        expect(onContentDelta).toHaveBeenLastCalledWith("world");
+    });
 });
 
 describe("Vercel AI Gateway LLM adapter", () => {

--- a/backend/src/lib/__tests__/routerModels.test.ts
+++ b/backend/src/lib/__tests__/routerModels.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
     getUserRouterModels,
     replaceUserRouterModels,
+    resolveRequestedModel,
 } from "../routerModels";
 
 function queryResult(data: unknown[], error: unknown = null) {
@@ -110,5 +111,52 @@ describe("router model persistence", () => {
         await expect(
             replaceUserRouterModels("user-1", "openrouter", [], db as never),
         ).rejects.toThrow("write failed");
+    });
+});
+
+describe("resolveRequestedModel outside-selection behaviour", () => {
+    const db = (rows: { model_id: string }[]) => ({
+        from: vi.fn(() => queryResult(rows)),
+    });
+
+    it("returns a model that is in the saved selection", async () => {
+        await expect(
+            resolveRequestedModel(
+                "openrouter/allowed/model",
+                "gemini-3-flash-preview",
+                "user-1",
+                db([{ model_id: "allowed/model" }]) as never,
+                "throw",
+            ),
+        ).resolves.toBe("openrouter/allowed/model");
+    });
+
+    it("throws an actionable error for an explicitly requested non-member", async () => {
+        await expect(
+            resolveRequestedModel(
+                "vercel/pricy/frontier",
+                "gemini-3-flash-preview",
+                "user-1",
+                db([]) as never,
+                "throw",
+            ),
+        ).rejects.toThrow(
+            "Model vercel/pricy/frontier is not in your saved Vercel AI Gateway models — add it in Settings → BYOK → Routers.",
+        );
+    });
+
+    it("still degrades silently for stored preferences", async () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        await expect(
+            resolveRequestedModel(
+                "openrouter/pricy/frontier",
+                "gemini-3-flash-preview",
+                "user-1",
+                db([]) as never,
+            ),
+        ).resolves.toBe("gemini-3-flash-preview");
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
     });
 });

--- a/backend/src/lib/__tests__/routerModels.test.ts
+++ b/backend/src/lib/__tests__/routerModels.test.ts
@@ -70,6 +70,25 @@ describe("router model persistence", () => {
         },
     );
 
+    it("still surfaces an undefined_table error about a different relation", async () => {
+        // 42P01 says "some relation is missing", not "user_router_models is
+        // missing" — a policy or view referencing another dropped table raises
+        // it too. Swallowing that would report an empty selection for a real
+        // schema fault, exactly what the PGRST205 arm already guards against.
+        const db = {
+            from: vi.fn(() =>
+                queryResult([], {
+                    code: "42P01",
+                    message: 'relation "public.user_profiles" does not exist',
+                }),
+            ),
+        };
+
+        await expect(
+            getUserRouterModels("user-1", "openrouter", db as never),
+        ).rejects.toMatchObject({ code: "42P01" });
+    });
+
     it("still surfaces unrelated read errors", async () => {
         const db = {
             from: vi.fn(() =>

--- a/backend/src/lib/__tests__/routerModels.test.ts
+++ b/backend/src/lib/__tests__/routerModels.test.ts
@@ -40,6 +40,47 @@ describe("router model persistence", () => {
         });
     });
 
+    it.each([
+        {
+            label: "Postgres undefined_table",
+            error: {
+                code: "42P01",
+                message: 'relation "public.user_router_models" does not exist',
+            },
+        },
+        {
+            label: "PostgREST missing relation",
+            error: {
+                code: "PGRST205",
+                message:
+                    "Could not find the table 'public.user_router_models' in the schema cache",
+            },
+        },
+    ])(
+        "returns empty selections when the table is missing ($label)",
+        async ({ error }) => {
+            const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+            const db = { from: vi.fn(() => queryResult([], error)) };
+
+            await expect(
+                getUserRouterModels("user-1", "openrouter", db as never),
+            ).resolves.toEqual([]);
+            warn.mockRestore();
+        },
+    );
+
+    it("still surfaces unrelated read errors", async () => {
+        const db = {
+            from: vi.fn(() =>
+                queryResult([], { code: "57014", message: "canceled" }),
+            ),
+        };
+
+        await expect(
+            getUserRouterModels("user-1", "openrouter", db as never),
+        ).rejects.toMatchObject({ code: "57014" });
+    });
+
     it("uses the atomic router-neutral replacement function", async () => {
         const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
         const db = { rpc };

--- a/backend/src/lib/__tests__/userSettings.test.ts
+++ b/backend/src/lib/__tests__/userSettings.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getUserApiKeys, getUserRouterModels } = vi.hoisted(() => ({
+    getUserApiKeys: vi.fn(),
+    getUserRouterModels: vi.fn(),
+}));
+
+vi.mock("../userApiKeys", () => ({
+    getUserApiKeys: (...args: unknown[]) => getUserApiKeys(...args),
+}));
+
+vi.mock("../routerModels", async () => ({
+    ...(await vi.importActual<typeof import("../routerModels")>(
+        "../routerModels",
+    )),
+    getUserRouterModels: (...args: unknown[]) => getUserRouterModels(...args),
+}));
+
+vi.mock("../supabase", () => ({ createServerSupabase: vi.fn() }));
+
+import { getUserModelSettings } from "../userSettings";
+
+function profileDb(row: Record<string, unknown> | null) {
+    const chain: Record<string, unknown> = {};
+    for (const method of ["from", "select", "eq"]) {
+        chain[method] = vi.fn(() => chain);
+    }
+    chain.single = vi.fn(async () => ({ data: row, error: null }));
+    return chain as never;
+}
+
+const NO_KEYS = {
+    claude: null,
+    gemini: "env-gemini-key",
+    openai: null,
+    openrouter: "env-openrouter-key",
+    vercel: null,
+    courtlistener: null,
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    getUserApiKeys.mockResolvedValue(NO_KEYS);
+    getUserRouterModels.mockImplementation(async (_user, router) =>
+        router === "openrouter" ? ["allowed/model"] : [],
+    );
+});
+
+describe("getUserModelSettings router-model allowlist", () => {
+    it("keeps a stored router preference that is in the saved selection", async () => {
+        const settings = await getUserModelSettings(
+            "user-1",
+            profileDb({
+                title_model: "openrouter/allowed/model",
+                tabular_model: "openrouter/allowed/model",
+                legal_research_us: true,
+            }),
+        );
+
+        expect(settings.title_model).toBe("openrouter/allowed/model");
+        expect(settings.tabular_model).toBe("openrouter/allowed/model");
+    });
+
+    it("falls back when a stored router preference is outside the saved selection", async () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const settings = await getUserModelSettings(
+            "user-1",
+            profileDb({
+                title_model: "openrouter/pricy/frontier-model",
+                tabular_model: "vercel/pricy/frontier-model",
+                legal_research_us: true,
+            }),
+        );
+
+        // Gemini env key present → cheap default title model; tabular default.
+        expect(settings.title_model).toBe("gemini-3.5-flash-lite");
+        expect(settings.tabular_model).toBe("gemini-3-flash-preview");
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it("keeps first-party preferences untouched", async () => {
+        const settings = await getUserModelSettings(
+            "user-1",
+            profileDb({
+                title_model: "claude-haiku-4-5",
+                tabular_model: "claude-sonnet-5",
+                legal_research_us: true,
+            }),
+        );
+
+        expect(settings.title_model).toBe("claude-haiku-4-5");
+        expect(settings.tabular_model).toBe("claude-sonnet-5");
+    });
+});

--- a/backend/src/lib/chat/__tests__/streamingModelAllowlist.test.ts
+++ b/backend/src/lib/chat/__tests__/streamingModelAllowlist.test.ts
@@ -74,29 +74,46 @@ describe("runLLMStream router-model allowlist", () => {
         expect(tablesQueried(db)).toContain("user_router_models");
     });
 
-    it("falls back to the default for a router model the user never saved", async () => {
-        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    it("fails the request for a router model the user never saved", async () => {
+        // The request NAMED this model. Answering with a different one would
+        // silently attribute the reply to a model the user did not choose, so
+        // the stream errors with an actionable message instead.
         const db = routerModelsDb([{ model_id: "allowed/model" }]);
-        await runStreamWithModel(db, "openrouter/pricy/frontier-model");
 
-        expect(streamChatWithTools).toHaveBeenCalledWith(
-            expect.objectContaining({ model: "gemini-3-flash-preview" }),
+        await expect(
+            runStreamWithModel(db, "openrouter/pricy/frontier-model"),
+        ).rejects.toThrow(
+            /openrouter\/pricy\/frontier-model is not in your saved OpenRouter models .* Settings → BYOK → Routers/,
         );
-        expect(warn).toHaveBeenCalled();
-        warn.mockRestore();
+        expect(streamChatWithTools).not.toHaveBeenCalled();
     });
 
-    it("also falls back for non-members when the user brings their own key", async () => {
-        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    it("also fails for non-members when the user brings their own key", async () => {
         const db = routerModelsDb([]);
-        await runStreamWithModel(db, "vercel/pricy/frontier-model", {
-            vercel: "user-byok-key",
-        });
 
-        expect(streamChatWithTools).toHaveBeenCalledWith(
-            expect.objectContaining({ model: "gemini-3-flash-preview" }),
+        await expect(
+            runStreamWithModel(db, "vercel/pricy/frontier-model", {
+                vercel: "user-byok-key",
+            }),
+        ).rejects.toThrow(
+            /is not in your saved Vercel AI Gateway models/,
         );
-        warn.mockRestore();
+        expect(streamChatWithTools).not.toHaveBeenCalled();
+    });
+
+    it("surfaces the rejection through the stream's error event", async () => {
+        const error = await runStreamWithModel(
+            routerModelsDb([]),
+            "openrouter/pricy/frontier-model",
+        ).catch((err: unknown) => err as AssistantStreamError);
+
+        expect(error).toBeInstanceOf(AssistantStreamError);
+        expect(error.events).toContainEqual(
+            expect.objectContaining({
+                type: "error",
+                message: expect.stringContaining("Settings → BYOK → Routers"),
+            }),
+        );
     });
 
     it("reports a selection-lookup failure through the stream's error path", async () => {

--- a/backend/src/lib/chat/__tests__/streamingModelAllowlist.test.ts
+++ b/backend/src/lib/chat/__tests__/streamingModelAllowlist.test.ts
@@ -15,10 +15,13 @@ vi.mock("../../mcpConnectors", () => ({
     buildUserMcpTools: vi.fn(async () => []),
 }));
 
-import { runLLMStream } from "../streaming";
+import { AssistantStreamError, runLLMStream } from "../streaming";
 
 // Supabase mock that only has to serve getUserRouterModels' query chain.
-function routerModelsDb(rows: { model_id: string }[]) {
+function routerModelsDb(
+    rows: { model_id: string }[],
+    error: unknown = null,
+) {
     const chain: Record<string, unknown> = {};
     for (const method of ["from", "select", "eq", "order"]) {
         chain[method] = vi.fn(() => chain);
@@ -26,7 +29,7 @@ function routerModelsDb(rows: { model_id: string }[]) {
     chain.then = (
         resolve: (value: unknown) => unknown,
         reject?: (reason: unknown) => unknown,
-    ) => Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+    ) => Promise.resolve({ data: rows, error }).then(resolve, reject);
     return chain;
 }
 
@@ -94,6 +97,32 @@ describe("runLLMStream router-model allowlist", () => {
             expect.objectContaining({ model: "gemini-3-flash-preview" }),
         );
         warn.mockRestore();
+    });
+
+    it("reports a selection-lookup failure through the stream's error path", async () => {
+        // A database blip while reading user_router_models must surface as a
+        // normal SSE stream error (error event + AssistantStreamError), not as
+        // a bare rejection thrown before the stream's error machinery exists.
+        const db = routerModelsDb([], {
+            code: "57014",
+            message: "canceling statement due to statement timeout",
+        });
+
+        await expect(
+            runStreamWithModel(db, "openrouter/allowed/model"),
+        ).rejects.toBeInstanceOf(AssistantStreamError);
+        expect(streamChatWithTools).not.toHaveBeenCalled();
+
+        const error = await runStreamWithModel(
+            routerModelsDb([], {
+                code: "57014",
+                message: "canceling statement due to statement timeout",
+            }),
+            "openrouter/allowed/model",
+        ).catch((err: unknown) => err as AssistantStreamError);
+        expect(error.events).toContainEqual(
+            expect.objectContaining({ type: "error" }),
+        );
     });
 
     it("does not consult the router selection for first-party models", async () => {

--- a/backend/src/lib/chat/__tests__/streamingModelAllowlist.test.ts
+++ b/backend/src/lib/chat/__tests__/streamingModelAllowlist.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { streamChatWithTools } = vi.hoisted(() => ({
+    streamChatWithTools: vi.fn(async () => ({ fullText: "" })),
+}));
+
+// Keep the real model catalog/constants but stub the adapter dispatch so no
+// provider SDK is touched; the assertion is which model reaches the adapter.
+vi.mock("../../llm", async () => ({
+    ...(await vi.importActual<Record<string, unknown>>("../../llm/models")),
+    streamChatWithTools: (...args: unknown[]) => streamChatWithTools(...args),
+}));
+
+vi.mock("../../mcpConnectors", () => ({
+    buildUserMcpTools: vi.fn(async () => []),
+}));
+
+import { runLLMStream } from "../streaming";
+
+// Supabase mock that only has to serve getUserRouterModels' query chain.
+function routerModelsDb(rows: { model_id: string }[]) {
+    const chain: Record<string, unknown> = {};
+    for (const method of ["from", "select", "eq", "order"]) {
+        chain[method] = vi.fn(() => chain);
+    }
+    chain.then = (
+        resolve: (value: unknown) => unknown,
+        reject?: (reason: unknown) => unknown,
+    ) => Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+    return chain;
+}
+
+// NOTE: the chain mock is thenable, so an async function must never `return`
+// it directly (await would unwrap it). Callers build the db and pass it in.
+async function runStreamWithModel(
+    db: Record<string, unknown>,
+    model: string,
+    apiKeys?: Record<string, string | null>,
+) {
+    await runLLMStream({
+        apiMessages: [{ role: "user", content: "hello" }],
+        docStore: {},
+        docIndex: {},
+        userId: "user-1",
+        db: db as never,
+        write: vi.fn(),
+        model,
+        apiKeys: apiKeys as never,
+    });
+}
+
+function tablesQueried(db: Record<string, unknown>): unknown[] {
+    return (db.from as ReturnType<typeof vi.fn>).mock.calls.map(
+        (call) => call[0],
+    );
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    streamChatWithTools.mockResolvedValue({ fullText: "" });
+});
+
+describe("runLLMStream router-model allowlist", () => {
+    it("passes a saved router model through to the adapter", async () => {
+        const db = routerModelsDb([{ model_id: "allowed/model" }]);
+        await runStreamWithModel(db, "openrouter/allowed/model");
+
+        expect(streamChatWithTools).toHaveBeenCalledWith(
+            expect.objectContaining({ model: "openrouter/allowed/model" }),
+        );
+        expect(tablesQueried(db)).toContain("user_router_models");
+    });
+
+    it("falls back to the default for a router model the user never saved", async () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const db = routerModelsDb([{ model_id: "allowed/model" }]);
+        await runStreamWithModel(db, "openrouter/pricy/frontier-model");
+
+        expect(streamChatWithTools).toHaveBeenCalledWith(
+            expect.objectContaining({ model: "gemini-3-flash-preview" }),
+        );
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it("also falls back for non-members when the user brings their own key", async () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const db = routerModelsDb([]);
+        await runStreamWithModel(db, "vercel/pricy/frontier-model", {
+            vercel: "user-byok-key",
+        });
+
+        expect(streamChatWithTools).toHaveBeenCalledWith(
+            expect.objectContaining({ model: "gemini-3-flash-preview" }),
+        );
+        warn.mockRestore();
+    });
+
+    it("does not consult the router selection for first-party models", async () => {
+        const db = routerModelsDb([]);
+        await runStreamWithModel(db, "claude-fable-5");
+
+        expect(streamChatWithTools).toHaveBeenCalledWith(
+            expect.objectContaining({ model: "claude-fable-5" }),
+        );
+        expect(tablesQueried(db)).not.toContain("user_router_models");
+    });
+});

--- a/backend/src/lib/chat/streaming.ts
+++ b/backend/src/lib/chat/streaming.ts
@@ -350,18 +350,24 @@ export async function runLLMStream(params: {
     throwIfAborted(signal);
     // Single request-time choke point for every runLLMStream caller (chat,
     // project chat, Word chat, tabular): router-prefixed models must be in the
-    // user's saved selection or the request degrades to the default model.
+    // user's saved selection.
     //
     // This lives INSIDE the try because it touches the database. Above it, a
     // read failure escaped as a bare rejection — before any error event was
     // pushed and before AssistantStreamError could carry the partial turn — so
     // the SSE client saw the socket end with no explanation. Inside, a blip
     // takes the same path as any other mid-stream failure.
+    //
+    // "throw" (not silent fallback) because `model` here is what the caller
+    // asked for in THIS request. Tabular's stored preference has already been
+    // normalized by getUserModelSettings, so what arrives here is either an
+    // in-selection router model or a first-party id.
     const selectedModel = await resolveRequestedModel(
       model,
       DEFAULT_MAIN_MODEL,
       userId,
       db,
+      "throw",
     );
     await streamChatWithTools({
       model: selectedModel,

--- a/backend/src/lib/chat/streaming.ts
+++ b/backend/src/lib/chat/streaming.ts
@@ -1,10 +1,10 @@
 import {
   streamChatWithTools,
-  resolveModel,
   DEFAULT_MAIN_MODEL,
   type LlmMessage,
   type OpenAIToolSchema,
 } from "../llm";
+import { resolveRequestedModel } from "../routerModels";
 import { safeErrorMessage } from "../safeError";
 import { createServerSupabase } from "../supabase";
 import { buildUserMcpTools, type McpToolEvent } from "../mcpConnectors";
@@ -346,7 +346,15 @@ export async function runLLMStream(params: {
     }
   };
 
-  const selectedModel = resolveModel(model, DEFAULT_MAIN_MODEL);
+  // Single request-time choke point for every runLLMStream caller (chat,
+  // project chat, Word chat, tabular): router-prefixed models must be in the
+  // user's saved selection or the request degrades to the default model.
+  const selectedModel = await resolveRequestedModel(
+    model,
+    DEFAULT_MAIN_MODEL,
+    userId,
+    db,
+  );
 
   try {
     throwIfAborted(signal);

--- a/backend/src/lib/chat/streaming.ts
+++ b/backend/src/lib/chat/streaming.ts
@@ -346,18 +346,23 @@ export async function runLLMStream(params: {
     }
   };
 
-  // Single request-time choke point for every runLLMStream caller (chat,
-  // project chat, Word chat, tabular): router-prefixed models must be in the
-  // user's saved selection or the request degrades to the default model.
-  const selectedModel = await resolveRequestedModel(
-    model,
-    DEFAULT_MAIN_MODEL,
-    userId,
-    db,
-  );
-
   try {
     throwIfAborted(signal);
+    // Single request-time choke point for every runLLMStream caller (chat,
+    // project chat, Word chat, tabular): router-prefixed models must be in the
+    // user's saved selection or the request degrades to the default model.
+    //
+    // This lives INSIDE the try because it touches the database. Above it, a
+    // read failure escaped as a bare rejection — before any error event was
+    // pushed and before AssistantStreamError could carry the partial turn — so
+    // the SSE client saw the socket end with no explanation. Inside, a blip
+    // takes the same path as any other mid-stream failure.
+    const selectedModel = await resolveRequestedModel(
+      model,
+      DEFAULT_MAIN_MODEL,
+      userId,
+      db,
+    );
     await streamChatWithTools({
       model: selectedModel,
       systemPrompt,

--- a/backend/src/lib/llm/models.ts
+++ b/backend/src/lib/llm/models.ts
@@ -81,17 +81,26 @@ export function providerForModel(model: string): Provider {
     throw new Error(`Unknown model id: ${model}`);
 }
 
+// Renamed/retired static ids → their current equivalents. Stored preferences
+// and localStorage selections outlive catalog renames; mapping here keeps an
+// old saved value working instead of silently kicking it to the fallback.
+export const LEGACY_MODEL_IDS: Record<string, string> = {
+    "gemini-3.1-flash-lite-preview": "gemini-3.5-flash-lite",
+    "gpt-5.4-lite": "gpt-5.4-mini",
+};
+
 export function resolveModel(
     id: string | null | undefined,
     fallback: string,
 ): string {
+    const canonical = id ? (LEGACY_MODEL_IDS[id] ?? id) : id;
     if (
-        id &&
-        (ALL_MODELS.has(id) ||
-            id.startsWith("ollama/") ||
-            /^(?:openrouter|vercel)\/[^\s/]+\/[^\s]+$/.test(id))
+        canonical &&
+        (ALL_MODELS.has(canonical) ||
+            canonical.startsWith("ollama/") ||
+            /^(?:openrouter|vercel)\/[^\s/]+\/[^\s]+$/.test(canonical))
     )
-        return id;
+        return canonical;
     return fallback;
 }
 

--- a/backend/src/lib/llm/openrouter.ts
+++ b/backend/src/lib/llm/openrouter.ts
@@ -118,14 +118,26 @@ async function postChat(args: {
 function parseToolCalls(
     partials: Map<number, PartialToolCall>,
     provider: RouterProvider,
+    endedCleanly: boolean,
 ) {
     return [...partials.values()].map((partial): NormalizedToolCall => {
-        // No arguments at all is legitimate (parameter-less tools stream "");
-        // arguments that are PRESENT but unparseable mean the stream was
+        // Arguments that are PRESENT but unparseable mean the stream was
         // truncated or corrupted mid-call. Coercing those to {} would run a
         // side-effecting tool with empty input, so fail the stream instead —
         // the same path a mid-stream {"error"} chunk takes.
+        //
+        // No arguments AT ALL is ambiguous by content: a parameter-less tool
+        // streams "", and so does a call whose connection died between the
+        // name delta and the first argument byte. Only the upstream's own
+        // termination signal (finish_reason "tool_calls", or the [DONE]
+        // sentinel) separates them, so the "" → {} carve-out is keyed on that
+        // rather than on the empty string.
         let input: Record<string, unknown> = {};
+        if (!partial.arguments.trim() && !endedCleanly) {
+            throw new Error(
+                `${routerLabel(provider)} stream ended before any arguments arrived for tool "${partial.name}"; refusing to execute it with empty input.`,
+            );
+        }
         if (partial.arguments.trim()) {
             let parsed: unknown;
             try {
@@ -227,12 +239,20 @@ export async function streamOpenRouter(
             let assistantText = "";
             let assistantReasoning = "";
             let buffer = "";
+            // Did the upstream tell us WHY it stopped, or did the socket just
+            // go quiet? Only the former makes an empty tool-argument string
+            // trustworthy — see parseToolCalls.
+            let endedCleanly = false;
 
             const processSseLine = (rawLine: string) => {
                 const line = rawLine.trim();
                 if (!line.startsWith("data:")) return;
                 const data = line.slice(5).trim();
-                if (!data || data === "[DONE]") return;
+                if (data === "[DONE]") {
+                    endedCleanly = true;
+                    return;
+                }
+                if (!data) return;
 
                 let chunk: Record<string, unknown>;
                 try {
@@ -270,9 +290,15 @@ export async function streamOpenRouter(
 
                 const choice = (
                     chunk.choices as
-                        | Array<{ delta?: Record<string, unknown> }>
+                        | Array<{
+                              delta?: Record<string, unknown>;
+                              finish_reason?: unknown;
+                          }>
                         | undefined
                 )?.[0];
+                if (choice?.finish_reason === "tool_calls") {
+                    endedCleanly = true;
+                }
                 const delta = choice?.delta;
                 if (!delta) return;
 
@@ -343,7 +369,7 @@ export async function streamOpenRouter(
             }
 
             if (assistantReasoning) callbacks.onReasoningBlockEnd?.();
-            const toolCalls = parseToolCalls(partials, provider);
+            const toolCalls = parseToolCalls(partials, provider, endedCleanly);
             if (!toolCalls.length || !runTools) break;
 
             messages.push({

--- a/backend/src/lib/llm/openrouter.ts
+++ b/backend/src/lib/llm/openrouter.ts
@@ -115,22 +115,36 @@ async function postChat(args: {
     return response;
 }
 
-function parseToolCalls(partials: Map<number, PartialToolCall>) {
+function parseToolCalls(
+    partials: Map<number, PartialToolCall>,
+    provider: RouterProvider,
+) {
     return [...partials.values()].map((partial): NormalizedToolCall => {
+        // No arguments at all is legitimate (parameter-less tools stream "");
+        // arguments that are PRESENT but unparseable mean the stream was
+        // truncated or corrupted mid-call. Coercing those to {} would run a
+        // side-effecting tool with empty input, so fail the stream instead —
+        // the same path a mid-stream {"error"} chunk takes.
         let input: Record<string, unknown> = {};
-        try {
-            const parsed = partial.arguments
-                ? JSON.parse(partial.arguments)
-                : {};
-            if (
-                parsed &&
-                typeof parsed === "object" &&
-                !Array.isArray(parsed)
-            ) {
-                input = parsed as Record<string, unknown>;
+        if (partial.arguments.trim()) {
+            let parsed: unknown;
+            try {
+                parsed = JSON.parse(partial.arguments);
+            } catch {
+                throw new Error(
+                    `${routerLabel(provider)} stream ended with malformed JSON arguments for tool "${partial.name}"; refusing to execute it with empty input.`,
+                );
             }
-        } catch {
-            input = {};
+            if (
+                !parsed ||
+                typeof parsed !== "object" ||
+                Array.isArray(parsed)
+            ) {
+                throw new Error(
+                    `${routerLabel(provider)} stream produced non-object arguments for tool "${partial.name}"; refusing to execute it with empty input.`,
+                );
+            }
+            input = parsed as Record<string, unknown>;
         }
         return {
             id: partial.id || partial.name,
@@ -214,110 +228,122 @@ export async function streamOpenRouter(
             let assistantReasoning = "";
             let buffer = "";
 
+            const processSseLine = (rawLine: string) => {
+                const line = rawLine.trim();
+                if (!line.startsWith("data:")) return;
+                const data = line.slice(5).trim();
+                if (!data || data === "[DONE]") return;
+
+                let chunk: Record<string, unknown>;
+                try {
+                    chunk = JSON.parse(data) as Record<string, unknown>;
+                } catch {
+                    return;
+                }
+                logRawLlmStream({
+                    provider,
+                    model,
+                    iteration,
+                    label: "chunk",
+                    payload: chunk,
+                });
+                rawStreamRecorder?.record({
+                    iteration,
+                    label: "chunk",
+                    payload: chunk,
+                });
+
+                const error = chunk.error as
+                    | { code?: unknown; message?: unknown }
+                    | undefined;
+                if (error) {
+                    const message =
+                        typeof error.message === "string"
+                            ? error.message
+                            : `${routerLabel(provider)} stream failed.`;
+                    throw new Error(
+                        error.code
+                            ? `${routerLabel(provider)} error (${String(error.code)}): ${message}`
+                            : `${routerLabel(provider)} error: ${message}`,
+                    );
+                }
+
+                const choice = (
+                    chunk.choices as
+                        | Array<{ delta?: Record<string, unknown> }>
+                        | undefined
+                )?.[0];
+                const delta = choice?.delta;
+                if (!delta) return;
+
+                if (typeof delta.content === "string" && delta.content) {
+                    assistantText += delta.content;
+                    fullText += delta.content;
+                    callbacks.onContentDelta?.(delta.content);
+                }
+                if (typeof delta.reasoning === "string" && delta.reasoning) {
+                    assistantReasoning += delta.reasoning;
+                    callbacks.onReasoningDelta?.(delta.reasoning);
+                }
+                if (Array.isArray(delta.reasoning_details)) {
+                    reasoningDetails.push(...delta.reasoning_details);
+                }
+
+                const toolCallDeltas = Array.isArray(delta.tool_calls)
+                    ? (delta.tool_calls as Array<Record<string, unknown>>)
+                    : [];
+                for (const toolCall of toolCallDeltas) {
+                    const index =
+                        typeof toolCall.index === "number" ? toolCall.index : 0;
+                    const accumulated = partials.get(index) ?? {
+                        id: "",
+                        name: "",
+                        arguments: "",
+                    };
+                    if (typeof toolCall.id === "string") {
+                        accumulated.id = toolCall.id;
+                    }
+                    const fn = toolCall.function as
+                        | { name?: unknown; arguments?: unknown }
+                        | undefined;
+                    if (typeof fn?.name === "string") {
+                        accumulated.name = fn.name;
+                    }
+                    if (typeof fn?.arguments === "string") {
+                        accumulated.arguments += fn.arguments;
+                    }
+                    partials.set(index, accumulated);
+                }
+            };
+
             while (true) {
                 throwIfAborted(params.abortSignal);
                 const { done, value } = await reader.read();
-                if (done) break;
+                if (done) {
+                    // A proxy may close the stream without a trailing newline:
+                    // flush what the decoder still buffers and process the
+                    // residual line so the final delta is not dropped.
+                    buffer += decoder.decode();
+                    if (buffer.trim()) {
+                        for (const line of buffer.split("\n")) {
+                            processSseLine(line);
+                        }
+                    }
+                    buffer = "";
+                    break;
+                }
                 buffer += decoder.decode(value, { stream: true });
 
                 let newlineIndex: number;
                 while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
-                    const line = buffer.slice(0, newlineIndex).trim();
+                    const line = buffer.slice(0, newlineIndex);
                     buffer = buffer.slice(newlineIndex + 1);
-                    if (!line.startsWith("data:")) continue;
-                    const data = line.slice(5).trim();
-                    if (!data || data === "[DONE]") continue;
-
-                    let chunk: Record<string, unknown>;
-                    try {
-                        chunk = JSON.parse(data) as Record<string, unknown>;
-                    } catch {
-                        continue;
-                    }
-                    logRawLlmStream({
-                        provider,
-                        model,
-                        iteration,
-                        label: "chunk",
-                        payload: chunk,
-                    });
-                    rawStreamRecorder?.record({
-                        iteration,
-                        label: "chunk",
-                        payload: chunk,
-                    });
-
-                    const error = chunk.error as
-                        | { code?: unknown; message?: unknown }
-                        | undefined;
-                    if (error) {
-                        const message =
-                            typeof error.message === "string"
-                                ? error.message
-                                : `${routerLabel(provider)} stream failed.`;
-                        throw new Error(
-                            error.code
-                                ? `${routerLabel(provider)} error (${String(error.code)}): ${message}`
-                                : `${routerLabel(provider)} error: ${message}`,
-                        );
-                    }
-
-                    const choice = (
-                        chunk.choices as
-                            | Array<{ delta?: Record<string, unknown> }>
-                            | undefined
-                    )?.[0];
-                    const delta = choice?.delta;
-                    if (!delta) continue;
-
-                    if (typeof delta.content === "string" && delta.content) {
-                        assistantText += delta.content;
-                        fullText += delta.content;
-                        callbacks.onContentDelta?.(delta.content);
-                    }
-                    if (
-                        typeof delta.reasoning === "string" &&
-                        delta.reasoning
-                    ) {
-                        assistantReasoning += delta.reasoning;
-                        callbacks.onReasoningDelta?.(delta.reasoning);
-                    }
-                    if (Array.isArray(delta.reasoning_details)) {
-                        reasoningDetails.push(...delta.reasoning_details);
-                    }
-
-                    const toolCallDeltas = Array.isArray(delta.tool_calls)
-                        ? (delta.tool_calls as Array<Record<string, unknown>>)
-                        : [];
-                    for (const toolCall of toolCallDeltas) {
-                        const index =
-                            typeof toolCall.index === "number"
-                                ? toolCall.index
-                                : 0;
-                        const accumulated = partials.get(index) ?? {
-                            id: "",
-                            name: "",
-                            arguments: "",
-                        };
-                        if (typeof toolCall.id === "string") {
-                            accumulated.id = toolCall.id;
-                        }
-                        const fn = toolCall.function as
-                            | { name?: unknown; arguments?: unknown }
-                            | undefined;
-                        if (typeof fn?.name === "string") {
-                            accumulated.name = fn.name;
-                        }
-                        if (typeof fn?.arguments === "string") {
-                            accumulated.arguments += fn.arguments;
-                        }
-                        partials.set(index, accumulated);
-                    }
+                    processSseLine(line);
                 }
             }
 
             if (assistantReasoning) callbacks.onReasoningBlockEnd?.();
-            const toolCalls = parseToolCalls(partials);
+            const toolCalls = parseToolCalls(partials, provider);
             if (!toolCalls.length || !runTools) break;
 
             messages.push({

--- a/backend/src/lib/routerModels.ts
+++ b/backend/src/lib/routerModels.ts
@@ -58,6 +58,27 @@ export async function resolveRequestedModel(
     return fallback;
 }
 
+// Deploy-before-migrate tolerance: on a database that predates the
+// user_router_models migration, reads report "no selections" instead of
+// exploding every profile/chat/title/tabular request into a 500. Postgres
+// raises undefined_table (42P01); PostgREST reports a relation missing from
+// its schema cache as PGRST205 (the analog of the 42703 missing-column shape
+// selectProfile already tolerates).
+function isMissingRouterModelsTable(error: unknown): boolean {
+    const record =
+        error && typeof error === "object"
+            ? (error as { code?: unknown; message?: unknown })
+            : {};
+    const code = typeof record.code === "string" ? record.code : "";
+    const message = typeof record.message === "string" ? record.message : "";
+    return (
+        code === "42P01" ||
+        (code === "PGRST205" && message.includes("user_router_models"))
+    );
+}
+
+let warnedMissingTable = false;
+
 export async function getUserRouterModels(
     userId: string,
     router: string,
@@ -70,7 +91,20 @@ export async function getUserRouterModels(
         .eq("router", router)
         .order("sort_order", { ascending: true })
         .order("created_at", { ascending: true });
-    if (error) throw error;
+    if (error) {
+        if (isMissingRouterModelsTable(error)) {
+            if (!warnedMissingTable) {
+                warnedMissingTable = true;
+                console.warn(
+                    "[router-models] user_router_models table is missing; " +
+                        "treating router selections as empty until the " +
+                        "20260818_01 migration is applied",
+                );
+            }
+            return [];
+        }
+        throw error;
+    }
 
     return (data ?? []).flatMap((row) =>
         typeof row.model_id === "string" && row.model_id.trim()

--- a/backend/src/lib/routerModels.ts
+++ b/backend/src/lib/routerModels.ts
@@ -83,6 +83,12 @@ export async function resolveRequestedModel(
 // raises undefined_table (42P01); PostgREST reports a relation missing from
 // its schema cache as PGRST205 (the analog of the 42703 missing-column shape
 // selectProfile already tolerates).
+//
+// BOTH arms require the message to name user_router_models. Neither code
+// means "THIS table is missing" on its own — a policy, view or trigger that
+// references some other dropped relation raises 42P01 from this query too,
+// and answering that with an empty selection would turn a schema fault into
+// a silent "you have no router models".
 function isMissingRouterModelsTable(error: unknown): boolean {
     const record =
         error && typeof error === "object"
@@ -91,8 +97,8 @@ function isMissingRouterModelsTable(error: unknown): boolean {
     const code = typeof record.code === "string" ? record.code : "";
     const message = typeof record.message === "string" ? record.message : "";
     return (
-        code === "42P01" ||
-        (code === "PGRST205" && message.includes("user_router_models"))
+        (code === "42P01" || code === "PGRST205") &&
+        message.includes("user_router_models")
     );
 }
 

--- a/backend/src/lib/routerModels.ts
+++ b/backend/src/lib/routerModels.ts
@@ -1,6 +1,62 @@
 import { createServerSupabase } from "./supabase";
+import { resolveModel } from "./llm/models";
 
 type Db = ReturnType<typeof createServerSupabase>;
+
+export type RouterSlug = "openrouter" | "vercel";
+
+/** The router a namespaced app-level model id routes through, if any. */
+export function routerForModelId(model: string): RouterSlug | null {
+    if (model.startsWith("openrouter/")) return "openrouter";
+    if (model.startsWith("vercel/")) return "vercel";
+    return null;
+}
+
+/**
+ * True when a router-prefixed model id is in the user's saved selection for
+ * that router (selections store the raw catalog id, without the slug prefix).
+ * Non-router models are always allowed here — their gating happens elsewhere.
+ */
+export function isRouterModelSelected(
+    model: string,
+    openRouterModels: string[],
+    vercelModels: string[],
+): boolean {
+    const router = routerForModelId(model);
+    if (!router) return true;
+    const catalogId = model.slice(router.length + 1);
+    const selection =
+        router === "openrouter" ? openRouterModels : vercelModels;
+    return selection.includes(catalogId);
+}
+
+/**
+ * Request-time model resolution for chat-style requests. Router-prefixed ids
+ * are accepted by SHAPE in resolveModel, so on their own they would let any
+ * authenticated user hand-craft a request that runs an arbitrary, arbitrarily
+ * expensive gateway model on the operator's env key. This choke point
+ * additionally requires a router model to be in the requesting user's saved
+ * selection; anything else degrades exactly like an invalid model id — fall
+ * back to the caller's default — with a warning for operators.
+ */
+export async function resolveRequestedModel(
+    requested: string | null | undefined,
+    fallback: string,
+    userId: string,
+    db: Db = createServerSupabase(),
+): Promise<string> {
+    const resolved = resolveModel(requested, fallback);
+    const router = routerForModelId(resolved);
+    if (!router) return resolved;
+    const selection = await getUserRouterModels(userId, router, db);
+    if (selection.includes(resolved.slice(router.length + 1))) {
+        return resolved;
+    }
+    console.warn(
+        `[router-models] user ${userId} requested ${router} model "${resolved}" outside their saved selection; using ${fallback}`,
+    );
+    return fallback;
+}
 
 export async function getUserRouterModels(
     userId: string,

--- a/backend/src/lib/routerModels.ts
+++ b/backend/src/lib/routerModels.ts
@@ -30,20 +30,34 @@ export function isRouterModelSelected(
     return selection.includes(catalogId);
 }
 
+/** Router labels as the settings UI names them, for user-facing messages. */
+const ROUTER_LABELS: Record<RouterSlug, string> = {
+    openrouter: "OpenRouter",
+    vercel: "Vercel AI Gateway",
+};
+
 /**
  * Request-time model resolution for chat-style requests. Router-prefixed ids
  * are accepted by SHAPE in resolveModel, so on their own they would let any
  * authenticated user hand-craft a request that runs an arbitrary, arbitrarily
  * expensive gateway model on the operator's env key. This choke point
  * additionally requires a router model to be in the requesting user's saved
- * selection; anything else degrades exactly like an invalid model id — fall
- * back to the caller's default — with a warning for operators.
+ * selection.
+ *
+ * `onOutsideSelection` picks what "not in the selection" means to the caller:
+ * - "throw" (the request path): the user named this model in THIS request, so
+ *   quietly answering with a different one is a lie about which model wrote
+ *   the response. Fail loudly with an actionable message instead.
+ * - "fallback" (the default, for stored preferences): a preference the user
+ *   set long ago must not brick every request; degrade to the caller's
+ *   default exactly like an invalid model id, with a warning for operators.
  */
 export async function resolveRequestedModel(
     requested: string | null | undefined,
     fallback: string,
     userId: string,
     db: Db = createServerSupabase(),
+    onOutsideSelection: "throw" | "fallback" = "fallback",
 ): Promise<string> {
     const resolved = resolveModel(requested, fallback);
     const router = routerForModelId(resolved);
@@ -51,6 +65,11 @@ export async function resolveRequestedModel(
     const selection = await getUserRouterModels(userId, router, db);
     if (selection.includes(resolved.slice(router.length + 1))) {
         return resolved;
+    }
+    if (onOutsideSelection === "throw") {
+        throw new Error(
+            `Model ${resolved} is not in your saved ${ROUTER_LABELS[router]} models — add it in Settings → BYOK → Routers.`,
+        );
     }
     console.warn(
         `[router-models] user ${userId} requested ${router} model "${resolved}" outside their saved selection; using ${fallback}`,

--- a/backend/src/lib/userSettings.ts
+++ b/backend/src/lib/userSettings.ts
@@ -7,7 +7,11 @@ import {
     type UserApiKeys,
 } from "./llm";
 import { getUserApiKeys as getStoredUserApiKeys } from "./userApiKeys";
-import { getUserRouterModels } from "./routerModels";
+import {
+    getUserRouterModels,
+    isRouterModelSelected,
+    routerForModelId,
+} from "./routerModels";
 
 export type UserModelSettings = {
     title_model: string;
@@ -56,12 +60,38 @@ export async function getUserModelSettings(
         ]);
     const data = profileResult.data;
 
+    // A stored preference can name a router model the user has since removed
+    // from (or never had in) their saved selection — e.g. a hand-crafted
+    // profile PATCH. Treat that exactly like an invalid model id and fall
+    // back, so the env-key spend path can't be steered onto arbitrary
+    // gateway models.
+    const guardRouterModel = (model: string, fallback: string): string => {
+        if (
+            !routerForModelId(model) ||
+            isRouterModelSelected(model, openRouterModels, vercelModels)
+        ) {
+            return model;
+        }
+        console.warn(
+            `[router-models] user ${userId} preference "${model}" is outside their saved selection; using ${fallback}`,
+        );
+        return fallback;
+    };
+    const titleFallback = resolveTitleModel(
+        api_keys,
+        openRouterModels,
+        vercelModels,
+    );
+
     return {
-        title_model: resolveModel(
-            data?.title_model,
-            resolveTitleModel(api_keys, openRouterModels, vercelModels),
+        title_model: guardRouterModel(
+            resolveModel(data?.title_model, titleFallback),
+            titleFallback,
         ),
-        tabular_model: resolveModel(data?.tabular_model, DEFAULT_TABULAR_MODEL),
+        tabular_model: guardRouterModel(
+            resolveModel(data?.tabular_model, DEFAULT_TABULAR_MODEL),
+            DEFAULT_TABULAR_MODEL,
+        ),
         legal_research_us:
             (data as { legal_research_us?: boolean | null } | null)
                 ?.legal_research_us !== false,

--- a/backend/src/routes/__tests__/models.test.ts
+++ b/backend/src/routes/__tests__/models.test.ts
@@ -38,6 +38,24 @@ describe("GET /models/openrouter", () => {
     afterEach(() => {
         vi.unstubAllGlobals();
         vi.clearAllMocks();
+        delete process.env.OPENROUTER_BASE_URL;
+    });
+
+    it("honors OPENROUTER_BASE_URL like the chat adapter", async () => {
+        process.env.OPENROUTER_BASE_URL = "http://localhost:4141/api/v1/";
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValue(
+                new Response(JSON.stringify({ data: [] }), { status: 200 }),
+            );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await request(app).get("/models/openrouter");
+
+        expect(response.status).toBe(200);
+        expect(String(fetchMock.mock.calls[0]?.[0])).toMatch(
+            /^http:\/\/localhost:4141\/api\/v1\/models\?/,
+        );
     });
 
     it("requires a configured OpenRouter key", async () => {

--- a/backend/src/routes/__tests__/userRouterModels.test.ts
+++ b/backend/src/routes/__tests__/userRouterModels.test.ts
@@ -1,0 +1,215 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+    getUserApiKeyStatus,
+    getUserRouterModels,
+    replaceUserRouterModels,
+} = vi.hoisted(() => ({
+    getUserApiKeyStatus: vi.fn(),
+    getUserRouterModels: vi.fn(),
+    replaceUserRouterModels: vi.fn(),
+}));
+
+vi.mock("../../middleware/auth", () => ({
+    requireAuth: (
+        _req: unknown,
+        res: { locals: Record<string, unknown> },
+        next: () => void,
+    ) => {
+        res.locals.userId = "user-1";
+        next();
+    },
+    requireMfaIfEnrolled: (_req: unknown, _res: unknown, next: () => void) =>
+        next(),
+}));
+
+// user.ts only needs the model constants + resolveModel from the llm barrel;
+// importing the real barrel would load every provider adapter.
+vi.mock("../../lib/llm", async () => vi.importActual("../../lib/llm/models"));
+
+vi.mock("../../lib/audit", () => ({ recordAudit: vi.fn() }));
+vi.mock("../../lib/userLookup", () => ({ findProfileUserByEmail: vi.fn() }));
+vi.mock("../../lib/userDataCleanup", () => ({
+    deleteAllUserChats: vi.fn(),
+    deleteAllUserTabularReviews: vi.fn(),
+    deleteUserAccountData: vi.fn(),
+    deleteUserProjects: vi.fn(),
+}));
+vi.mock("../../lib/userDataExport", () => ({
+    buildUserAccountExport: vi.fn(),
+    buildUserChatsExport: vi.fn(),
+    buildUserTabularReviewsExport: vi.fn(),
+    userExportFilename: vi.fn(),
+}));
+vi.mock("../../lib/mcpConnectors", () => ({
+    completeUserMcpConnectorOAuth: vi.fn(),
+    createUserMcpConnector: vi.fn(),
+    deleteUserMcpConnector: vi.fn(),
+    getUserMcpConnector: vi.fn(),
+    listUserMcpConnectors: vi.fn(),
+    McpOAuthRequiredError: class McpOAuthRequiredError extends Error {},
+    refreshUserMcpConnectorTools: vi.fn(),
+    setUserMcpToolEnabled: vi.fn(),
+    startUserMcpConnectorOAuth: vi.fn(),
+    updateUserMcpConnector: vi.fn(),
+}));
+vi.mock("../../lib/userApiKeys", () => ({
+    getUserApiKeyStatus: (...args: unknown[]) => getUserApiKeyStatus(...args),
+    hasEnvApiKey: vi.fn(() => false),
+    normalizeApiKeyProvider: vi.fn(),
+    saveUserApiKey: vi.fn(),
+}));
+vi.mock("../../lib/routerModels", () => ({
+    getUserRouterModels: (...args: unknown[]) => getUserRouterModels(...args),
+    replaceUserRouterModels: (...args: unknown[]) =>
+        replaceUserRouterModels(...args),
+}));
+
+const PROFILE_ROW = {
+    display_name: "Dev",
+    organisation: null,
+    message_credits_used: 0,
+    // Far future so loadProfile's credit-reset branch never runs in tests.
+    credits_reset_date: "2999-01-01T00:00:00.000Z",
+    tier: "Free",
+    title_model: null,
+    tabular_model: "gemini-3-flash-preview",
+    mfa_on_login: false,
+    legal_research_us: true,
+    quick_actions_visible: true,
+};
+
+// A permissive supabase mock: every query-builder call chains, awaiting the
+// chain resolves { data, error }, and maybeSingle/single resolve the profile
+// row. That covers ensureProfileRow (upsert), the profile update, and
+// selectProfile without modelling PostgREST.
+function chainDb() {
+    const chain: Record<string, unknown> = {};
+    for (const method of ["from", "select", "eq", "update", "upsert"]) {
+        chain[method] = vi.fn(() => chain);
+    }
+    chain.maybeSingle = vi.fn(async () => ({ data: PROFILE_ROW, error: null }));
+    chain.single = vi.fn(async () => ({ data: PROFILE_ROW, error: null }));
+    chain.then = (
+        resolve: (value: unknown) => unknown,
+        reject?: (reason: unknown) => unknown,
+    ) => Promise.resolve({ data: null, error: null }).then(resolve, reject);
+    return chain;
+}
+
+vi.mock("../../lib/supabase", () => ({
+    createServerSupabase: vi.fn(() => chainDb()),
+}));
+
+import { userRouter, normalizeRouterModels } from "../user";
+
+const app = express();
+app.use(express.json());
+app.use("/user", userRouter);
+
+const API_KEY_STATUS = {
+    claude: false,
+    gemini: false,
+    openai: false,
+    openrouter: true,
+    vercel: true,
+    courtlistener: false,
+    sources: {
+        claude: null,
+        gemini: null,
+        openai: null,
+        openrouter: "user",
+        vercel: "user",
+        courtlistener: null,
+    },
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    getUserApiKeyStatus.mockResolvedValue(API_KEY_STATUS);
+    getUserRouterModels.mockResolvedValue([]);
+    replaceUserRouterModels.mockResolvedValue(undefined);
+});
+
+describe("PATCH /user/profile router model selections", () => {
+    it("accepts a catalog id that begins with the router's own slug", async () => {
+        // OpenRouter's catalog really contains "openrouter/auto". Stripping
+        // the router prefix before validating would leave "auto", fail the
+        // vendor/model shape check, and 400 the whole profile PATCH.
+        const response = await request(app)
+            .patch("/user/profile")
+            .send({ openRouterModels: ["openrouter/auto"] });
+
+        expect(response.status).toBe(200);
+        expect(replaceUserRouterModels).toHaveBeenCalledWith(
+            "user-1",
+            "openrouter",
+            ["openrouter/auto"],
+            expect.anything(),
+        );
+    });
+
+    it("accepts Vercel catalog ids that begin with the vercel slug", async () => {
+        const response = await request(app)
+            .patch("/user/profile")
+            .send({ vercelModels: ["vercel/v0-1.5-md"] });
+
+        expect(response.status).toBe(200);
+        expect(replaceUserRouterModels).toHaveBeenCalledWith(
+            "user-1",
+            "vercel",
+            ["vercel/v0-1.5-md"],
+            expect.anything(),
+        );
+    });
+
+    it("still canonicalizes composer-form ids to the raw catalog id", async () => {
+        const response = await request(app)
+            .patch("/user/profile")
+            .send({
+                openRouterModels: [
+                    "openrouter/anthropic/claude-sonnet-4.5",
+                    "openai/gpt-5.4",
+                ],
+            });
+
+        expect(response.status).toBe(200);
+        expect(replaceUserRouterModels).toHaveBeenCalledWith(
+            "user-1",
+            "openrouter",
+            ["anthropic/claude-sonnet-4.5", "openai/gpt-5.4"],
+            expect.anything(),
+        );
+    });
+
+    it("rejects ids that are not vendor/model shaped", async () => {
+        const response = await request(app)
+            .patch("/user/profile")
+            .send({ openRouterModels: ["not a model"] });
+
+        expect(response.status).toBe(400);
+        expect(replaceUserRouterModels).not.toHaveBeenCalled();
+    });
+});
+
+describe("normalizeRouterModels", () => {
+    it("keeps router-slug catalog ids verbatim", () => {
+        expect(
+            normalizeRouterModels(["openrouter/auto"], "openrouter"),
+        ).toEqual(["openrouter/auto"]);
+        expect(normalizeRouterModels(["vercel/v0-1.5-md"], "vercel")).toEqual([
+            "vercel/v0-1.5-md",
+        ]);
+    });
+
+    it("strips the router prefix only when the remainder is a full id", () => {
+        expect(
+            normalizeRouterModels(
+                ["openrouter/deepseek/deepseek-v3", "deepseek/deepseek-v3"],
+                "openrouter",
+            ),
+        ).toEqual(["deepseek/deepseek-v3"]);
+    });
+});

--- a/backend/src/routes/__tests__/userRouterModels.test.ts
+++ b/backend/src/routes/__tests__/userRouterModels.test.ts
@@ -184,6 +184,23 @@ describe("PATCH /user/profile router model selections", () => {
         );
     });
 
+    it("reports the 50-model cap instead of 'invalid or duplicate'", async () => {
+        const models = Array.from(
+            { length: 51 },
+            (_, index) => `vendor/model-${index}`,
+        );
+
+        const response = await request(app)
+            .patch("/user/profile")
+            .send({ openRouterModels: models });
+
+        expect(response.status).toBe(400);
+        expect(response.body.detail).toBe(
+            "openRouterModels can include at most 50 models",
+        );
+        expect(replaceUserRouterModels).not.toHaveBeenCalled();
+    });
+
     it("rejects ids that are not vendor/model shaped", async () => {
         const response = await request(app)
             .patch("/user/profile")

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -68,8 +68,15 @@ modelsRouter.get("/openrouter", requireAuth, async (_req, res) => {
             });
         }
 
+        // Honor the same base-URL override as the chat adapter so a proxy or
+        // test double sees the catalog request too (read per request, like
+        // the Vercel route below, so tests and re-configuration work).
+        const baseUrl = (
+            process.env.OPENROUTER_BASE_URL?.trim() ||
+            "https://openrouter.ai/api/v1"
+        ).replace(/\/+$/, "");
         const response = await fetch(
-            "https://openrouter.ai/api/v1/models?output_modalities=text&supported_parameters=tools&sort=most-popular&limit=1000",
+            `${baseUrl}/models?output_modalities=text&supported_parameters=tools&sort=most-popular&limit=1000`,
             { headers: { Authorization: `Bearer ${key}` } },
         );
         if (!response.ok) {

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -305,7 +305,9 @@ async function selectProfileLegacy(
     return legacy;
 }
 
-function normalizeRouterModels(
+const CATALOG_MODEL_ID_RE = /^[^\s/]+\/[^\s]+$/;
+
+export function normalizeRouterModels(
     value: unknown,
     provider: "openrouter" | "vercel",
 ): string[] {
@@ -314,11 +316,19 @@ function normalizeRouterModels(
     const seen = new Set<string>();
     for (const item of value) {
         if (typeof item !== "string") continue;
-        const model = item.trim().replace(new RegExp(`^${provider}/`), "");
+        const trimmed = item.trim();
+        // Strip a leading router slug ("openrouter/deepseek/deepseek-v3" →
+        // "deepseek/deepseek-v3") only when what remains is still a full
+        // vendor/model catalog id. Some catalog ids legitimately begin with
+        // the router's own slug (OpenRouter's "openrouter/auto", Vercel's
+        // "vercel/v0-1.5-md"); for those the raw id IS the canonical form
+        // and stripping would destroy it.
+        const stripped = trimmed.replace(new RegExp(`^${provider}/`), "");
+        const model = CATALOG_MODEL_ID_RE.test(stripped) ? stripped : trimmed;
         if (
             !model ||
             model.length > 200 ||
-            !/^[^\s/]+\/[^\s]+$/.test(model) ||
+            !CATALOG_MODEL_ID_RE.test(model) ||
             seen.has(model)
         ) {
             continue;

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -478,6 +478,15 @@ function validateProfilePayload(body: unknown):
                 detail: "openRouterModels must be an array of model IDs",
             };
         }
+        // Check the cap before normalizing: normalizeRouterModels truncates
+        // at 50, so a longer payload would otherwise surface as the
+        // misleading "invalid or duplicate model ID".
+        if (raw.openRouterModels.length > 50) {
+            return {
+                ok: false,
+                detail: "openRouterModels can include at most 50 models",
+            };
+        }
         const models = normalizeRouterModels(
             raw.openRouterModels,
             "openrouter",
@@ -496,6 +505,12 @@ function validateProfilePayload(body: unknown):
             return {
                 ok: false,
                 detail: "vercelModels must be an array of model IDs",
+            };
+        }
+        if (raw.vercelModels.length > 50) {
+            return {
+                ok: false,
+                detail: "vercelModels can include at most 50 models",
             };
         }
         const models = normalizeRouterModels(raw.vercelModels, "vercel");

--- a/frontend/src/app/(pages)/settings/models/page.test.tsx
+++ b/frontend/src/app/(pages)/settings/models/page.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/hooks/useOllamaModels", () => ({
+    useOllamaModels: () => [],
+}));
+
+vi.mock("@/app/contexts/UserProfileContext", () => ({
+    useUserProfile: () => ({
+        profile: {
+            // Legacy id stored before the catalog rename.
+            titleModel: "gemini-3.1-flash-lite-preview",
+            tabularModel: "gemini-3-flash-preview",
+            openRouterModels: [],
+            vercelModels: [],
+            apiKeys: {
+                claude: { configured: false, source: null },
+                gemini: { configured: true, source: "user" },
+                openai: { configured: true, source: "user" },
+                openrouter: { configured: false, source: null },
+                vercel: { configured: false, source: null },
+                courtlistener: { configured: false, source: null },
+            },
+        },
+        updateModelPreference: vi.fn(),
+    }),
+}));
+
+import ModelPreferencesPage from "./page";
+
+describe("model preferences page legacy ids", () => {
+    it("shows the renamed model for a stored legacy preference", () => {
+        render(<ModelPreferencesPage />);
+
+        // Without the LEGACY_MODEL_IDS mapping the stored title value
+        // matches no option and the dropdown falls back to "Select a model".
+        expect(screen.getByText("Gemini 3.5 Flash-Lite")).toBeInTheDocument();
+        expect(screen.queryByText("Select a model")).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/app/(pages)/settings/models/page.tsx
+++ b/frontend/src/app/(pages)/settings/models/page.tsx
@@ -17,6 +17,7 @@ import { type ApiKeyState } from "@/app/lib/mikeApi";
 import {
     MODELS,
     SETTINGS_MODELS,
+    canonicalModelId,
     openRouterModelOptions,
     vercelModelOptions,
     type ModelOption,
@@ -95,11 +96,11 @@ export default function ModelPreferencesPage() {
                             Used for naming chats and other lightweight titles.
                         </p>
                         <ModelPreferenceDropdown
-                            value={
+                            value={canonicalModelId(
                                 optimisticValues.titleModel ??
-                                profile?.titleModel ??
-                                "gemini-3.5-flash-lite"
-                            }
+                                    profile?.titleModel ??
+                                    "gemini-3.5-flash-lite",
+                            )}
                             options={[
                                 ...SETTINGS_MODELS,
                                 ...selectedOpenRouterOptions,
@@ -123,11 +124,11 @@ export default function ModelPreferencesPage() {
                             reviews to reduce token costs.
                         </p>
                         <ModelPreferenceDropdown
-                            value={
+                            value={canonicalModelId(
                                 optimisticValues.tabularModel ??
-                                profile?.tabularModel ??
-                                "gemini-3-flash-preview"
-                            }
+                                    profile?.tabularModel ??
+                                    "gemini-3-flash-preview",
+                            )}
                             options={[
                                 ...MODELS,
                                 ...selectedOpenRouterOptions,

--- a/frontend/src/app/components/assistant/ChatInput.modelSelection.test.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.modelSelection.test.tsx
@@ -1,0 +1,122 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUserProfile } from "@/app/contexts/UserProfileContext";
+import { ChatInput } from "./ChatInput";
+
+vi.mock("@/app/lib/mikeApi", () => ({
+    listWorkflows: vi.fn(async () => []),
+    uploadProjectDocument: vi.fn(),
+    uploadStandaloneDocument: vi.fn(),
+}));
+
+vi.mock("@/app/contexts/UserProfileContext", () => ({
+    useUserProfile: vi.fn(),
+}));
+
+vi.mock("@/app/lib/modelAvailability", () => ({
+    getModelProvider: vi.fn(),
+    isModelAvailable: vi.fn(() => true),
+}));
+
+// The real module is kept for its constants — useSelectedModel imports
+// ALLOWED_MODEL_IDS/DEFAULT_MODEL_ID/canonicalModelId from it, and this test
+// exercises the real hook.
+vi.mock("./ModelToggle", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("./ModelToggle")>()),
+    ModelToggle: () => null,
+}));
+
+vi.mock("./AddDocButton", () => ({ AddDocButton: () => null }));
+vi.mock("./UploadOverlay", () => ({ UploadOverlay: () => null }));
+vi.mock("../shared/FileTypeIcon", () => ({ FileTypeIcon: () => null }));
+vi.mock("../modals/AddDocumentsModal", () => ({
+    AddDocumentsModal: () => null,
+}));
+vi.mock("./AssistantWorkflowModal", () => ({
+    AssistantWorkflowModal: () => null,
+}));
+vi.mock("../popups/ApiKeyMissingPopup", () => ({
+    ApiKeyMissingPopup: () => null,
+}));
+
+const STORAGE_KEY = "mike.selectedModel";
+const STORED = "openrouter/pricy/frontier";
+
+class ResizeObserverMock {
+    observe() {}
+    disconnect() {}
+}
+
+function emptyApiKeys() {
+    return {
+        claude: { configured: false, source: null },
+        gemini: { configured: false, source: null },
+        openai: { configured: false, source: null },
+        openrouter: { configured: false, source: null },
+        vercel: { configured: false, source: null },
+        courtlistener: { configured: false, source: null },
+    };
+}
+
+function mockProfile(apiKeysDegraded: boolean) {
+    vi.mocked(useUserProfile).mockReturnValue({
+        profile: {
+            openRouterModels: [],
+            vercelModels: [],
+            apiKeys: emptyApiKeys(),
+        },
+        loading: false,
+        apiKeysDegraded,
+    } as unknown as ReturnType<typeof useUserProfile>);
+}
+
+describe("ChatInput model selection vs. a degraded profile", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        window.localStorage.clear();
+        vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    });
+
+    it("keeps the stored router selection when the profile is degraded", async () => {
+        // A dropped /user/profile request answers with the local fallback,
+        // whose router lists are empty because the truth is UNKNOWN — not
+        // because the user deselected everything. Resetting on that would
+        // permanently rewrite localStorage from one failed request.
+        window.localStorage.setItem(STORAGE_KEY, STORED);
+        mockProfile(true);
+
+        render(
+            <ChatInput
+                onSubmit={vi.fn()}
+                onCancel={vi.fn()}
+                isLoading={false}
+            />,
+        );
+
+        await waitFor(() =>
+            expect(window.localStorage.getItem(STORAGE_KEY)).toBe(STORED),
+        );
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe(STORED);
+    });
+
+    it("still resets a stale router selection on a healthy empty profile", async () => {
+        // A real profile that reports no saved router models is authoritative:
+        // the stale selection must reset, exactly as before.
+        window.localStorage.setItem(STORAGE_KEY, STORED);
+        mockProfile(false);
+
+        render(
+            <ChatInput
+                onSubmit={vi.fn()}
+                onCancel={vi.fn()}
+                isLoading={false}
+            />,
+        );
+
+        await waitFor(() =>
+            expect(window.localStorage.getItem(STORAGE_KEY)).toBe(
+                "gemini-3-flash-preview",
+            ),
+        );
+    });
+});

--- a/frontend/src/app/components/assistant/ChatInput.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.tsx
@@ -103,8 +103,13 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
         loading: profileLoading,
         apiKeysDegraded,
     } = useUserProfile();
+    // A degraded profile is the local fallback, whose router lists are empty
+    // because the truth is UNKNOWN. Passing them on would let one dropped
+    // /user/profile request rewrite the saved composer selection to the
+    // default — permanently. null means "not loaded", which the hook leaves
+    // the stored selection alone for.
     const [model, setModel] = useSelectedModel(
-        profile
+        profile && !apiKeysDegraded
             ? {
                   openRouterModels: profile.openRouterModels,
                   vercelModels: profile.vercelModels,

--- a/frontend/src/app/components/assistant/ChatInput.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.tsx
@@ -99,8 +99,15 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
         title: string;
     } | null>(null);
     const [model, setModel] = useSelectedModel();
-    const { profile } = useUserProfile();
-    const apiKeys = profile?.apiKeys;
+    const {
+        profile,
+        loading: profileLoading,
+        apiKeysDegraded,
+    } = useUserProfile();
+    // Degraded profile → key availability is UNKNOWN; undefined here makes
+    // every key gate (submit check + model toggle) fail open instead of
+    // treating "we couldn't ask" as "no keys configured".
+    const apiKeys = apiKeysDegraded ? undefined : profile?.apiKeys;
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const controlsRef = useRef<HTMLDivElement>(null);
     const [compactControls, setCompactControls] = useState(false);
@@ -593,6 +600,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                                 value={model}
                                 onChange={setModel}
                                 apiKeys={apiKeys}
+                                apiKeysLoading={profileLoading && !profile}
                                 openRouterModels={profile?.openRouterModels}
                                 vercelModels={profile?.vercelModels}
                                 compact={compactControls}

--- a/frontend/src/app/components/assistant/ChatInput.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.tsx
@@ -98,12 +98,19 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
         id: string;
         title: string;
     } | null>(null);
-    const [model, setModel] = useSelectedModel();
     const {
         profile,
         loading: profileLoading,
         apiKeysDegraded,
     } = useUserProfile();
+    const [model, setModel] = useSelectedModel(
+        profile
+            ? {
+                  openRouterModels: profile.openRouterModels,
+                  vercelModels: profile.vercelModels,
+              }
+            : null,
+    );
     // Degraded profile → key availability is UNKNOWN; undefined here makes
     // every key gate (submit check + model toggle) fail open instead of
     // treating "we couldn't ask" as "no keys configured".

--- a/frontend/src/app/components/assistant/ModelToggle.render.test.tsx
+++ b/frontend/src/app/components/assistant/ModelToggle.render.test.tsx
@@ -1,10 +1,31 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ModelToggle } from "./ModelToggle";
+import type { ApiKeyState } from "@/app/lib/mikeApi";
 
 vi.mock("@/app/hooks/useOllamaModels", () => ({
     useOllamaModels: () => [],
 }));
+
+function keys(configured: Partial<Record<keyof ApiKeyState, boolean>>) {
+    const providers = [
+        "claude",
+        "gemini",
+        "openai",
+        "openrouter",
+        "vercel",
+        "courtlistener",
+    ] as const;
+    return Object.fromEntries(
+        providers.map((provider) => [
+            provider,
+            {
+                configured: configured[provider] ?? false,
+                source: configured[provider] ? "user" : null,
+            },
+        ]),
+    ) as ApiKeyState;
+}
 
 describe("ModelToggle responsive trigger", () => {
     it("uses the Settings2 icon in a compact chat input", () => {
@@ -27,9 +48,72 @@ describe("ModelToggle responsive trigger", () => {
             <ModelToggle
                 value="gemini-3-flash-preview"
                 onChange={vi.fn()}
+                apiKeys={keys({ gemini: true })}
             />,
         );
 
-        expect(screen.getByText("No API Key")).toHaveClass("max-w-[200px]");
+        expect(screen.getByText("Gemini 3 Flash")).toHaveClass("max-w-[200px]");
+    });
+});
+
+describe("ModelToggle availability states", () => {
+    it("renders a neutral disabled trigger while keys are loading", () => {
+        render(
+            <ModelToggle
+                value="gemini-3-flash-preview"
+                onChange={vi.fn()}
+                apiKeysLoading
+            />,
+        );
+
+        const trigger = screen.getByRole("button", { name: "Choose model" });
+        expect(trigger).toBeDisabled();
+        // The load-time flash: never claim "No API Key" before we know.
+        expect(trigger).not.toHaveTextContent("No API Key");
+        expect(trigger).toHaveTextContent("Gemini 3 Flash");
+    });
+
+    it("fails open when key state is unknown after a failed load", () => {
+        render(
+            <ModelToggle
+                value="gemini-3-flash-preview"
+                onChange={vi.fn()}
+            />,
+        );
+
+        const trigger = screen.getByRole("button", { name: "Choose model" });
+        expect(trigger).toBeEnabled();
+        expect(trigger).not.toHaveTextContent("No API Key");
+        expect(trigger).toHaveTextContent("Gemini 3 Flash");
+    });
+
+    it("still reports No API Key when a LOADED state has no keys", () => {
+        render(
+            <ModelToggle
+                value="gemini-3-flash-preview"
+                onChange={vi.fn()}
+                apiKeys={keys({})}
+            />,
+        );
+
+        const trigger = screen.getByRole("button", { name: "Choose model" });
+        expect(trigger).toBeDisabled();
+        expect(trigger).toHaveTextContent("No API Key");
+    });
+
+    it("filters to configured providers when keys are loaded", () => {
+        render(
+            <ModelToggle
+                value="claude-fable-5"
+                onChange={vi.fn()}
+                apiKeys={keys({ gemini: true })}
+            />,
+        );
+
+        // Claude has no key: the stored selection is not offered, so the
+        // trigger falls back to the picker prompt.
+        expect(
+            screen.getByRole("button", { name: "Choose model" }),
+        ).toHaveTextContent("Select model");
     });
 });

--- a/frontend/src/app/components/assistant/ModelToggle.tsx
+++ b/frontend/src/app/components/assistant/ModelToggle.tsx
@@ -116,7 +116,15 @@ const itemClassName =
 interface Props {
     value: string;
     onChange: (id: string) => void;
+    /**
+     * Loaded key state, or undefined when it is UNKNOWN (profile still
+     * loading, or the fetch failed and the app degrades). Unknown state fails
+     * open — the backend authoritatively rejects models it cannot serve.
+     */
     apiKeys?: ApiKeyState;
+    /** True while the profile is still loading: render a neutral disabled
+     *  trigger instead of flashing "No API Key" on every page load. */
+    apiKeysLoading?: boolean;
     openRouterModels?: string[];
     vercelModels?: string[];
     compact?: boolean;
@@ -142,6 +150,7 @@ export function ModelToggle({
     value,
     onChange,
     apiKeys,
+    apiKeysLoading = false,
     openRouterModels = [],
     vercelModels = [],
     compact = false,
@@ -162,12 +171,15 @@ export function ModelToggle({
     ];
     const availableModels = models.filter((model) => {
         if (model.group === "Local") return true;
-        return apiKeys ? isModelAvailable(model.id, apiKeys) : false;
+        if (apiKeysLoading) return false; // nothing offered until known
+        if (!apiKeys) return true; // unknown after a failed load → fail open
+        return isModelAvailable(model.id, apiKeys);
     });
     const selected = availableModels.find((model) => model.id === value);
-    const selectedLabel =
-        selected?.label ??
-        (availableModels.length > 0 ? "Select model" : "No API Key");
+    const selectedLabel = apiKeysLoading
+        ? (models.find((model) => model.id === value)?.label ?? "Select model")
+        : (selected?.label ??
+          (availableModels.length > 0 ? "Select model" : "No API Key"));
     const availableGroups = GROUP_ORDER.flatMap((group) => {
         const items = availableModels.filter((model) => model.group === group);
         return items.length ? [{ group, items }] : [];
@@ -193,12 +205,14 @@ export function ModelToggle({
                 <button
                     type="button"
                     aria-label="Choose model"
-                    disabled={availableModels.length === 0}
+                    disabled={apiKeysLoading || availableModels.length === 0}
                     className={`flex h-8 items-center rounded-full text-sm text-gray-400 transition-colors enabled:cursor-pointer enabled:hover:text-gray-700 disabled:cursor-default ${compact ? "w-8 justify-center px-0" : "gap-1.5 px-2"} ${isOpen ? "text-gray-700" : ""}`}
                     title={
-                        availableModels.length
-                            ? "Choose model"
-                            : "No API key configured"
+                        apiKeysLoading
+                            ? "Checking API keys"
+                            : availableModels.length
+                              ? "Choose model"
+                              : "No API key configured"
                     }
                 >
                     {compact ? (

--- a/frontend/src/app/components/assistant/ModelToggle.tsx
+++ b/frontend/src/app/components/assistant/ModelToggle.tsx
@@ -67,6 +67,19 @@ export const DEFAULT_MODEL_ID = "gemini-3-flash-preview";
 
 export const ALLOWED_MODEL_IDS = new Set(MODELS.map((m) => m.id));
 
+// Renamed/retired static ids → their current equivalents. Stored preferences
+// (profile fields, localStorage selections) outlive catalog renames; mapping
+// them on read keeps an old saved value working instead of orphaning it.
+// Kept in sync with backend/src/lib/llm/models.ts LEGACY_MODEL_IDS.
+export const LEGACY_MODEL_IDS: Record<string, string> = {
+    "gemini-3.1-flash-lite-preview": "gemini-3.5-flash-lite",
+    "gpt-5.4-lite": "gpt-5.4-mini",
+};
+
+export function canonicalModelId(id: string): string {
+    return LEGACY_MODEL_IDS[id] ?? id;
+}
+
 const MODEL_NAME_ACRONYMS: Record<string, string> = {
     ai: "AI",
     gpt: "GPT",

--- a/frontend/src/app/components/settings/RouterSettingsSection.test.tsx
+++ b/frontend/src/app/components/settings/RouterSettingsSection.test.tsx
@@ -26,7 +26,10 @@ vi.mock("@/app/contexts/UserProfileContext", () => ({
     }),
 }));
 
-import { RouterSettingsSection } from "./RouterSettingsSection";
+import {
+    RouterSettingsSection,
+    normalizeTypedModelId,
+} from "./RouterSettingsSection";
 
 describe("RouterSettingsSection", () => {
     beforeEach(() => {
@@ -114,6 +117,28 @@ describe("RouterSettingsSection", () => {
         );
     });
 
+    it("adds a router-slug catalog id verbatim instead of rejecting it", async () => {
+        // OpenRouter's catalog contains "openrouter/auto". Stripping the
+        // router prefix before validating leaves "auto", which is not
+        // vendor/model shaped, so the add used to fail with an error.
+        updateOpenRouterModels.mockResolvedValue(true);
+        render(<RouterSettingsSection />);
+        const input = screen.getByRole("combobox", {
+            name: "OpenRouter models",
+        });
+        await waitFor(() => expect(getOpenRouterModels).toHaveBeenCalled());
+
+        fireEvent.change(input, { target: { value: "openrouter/auto" } });
+        fireEvent.keyDown(input, { key: "Enter" });
+
+        await waitFor(() =>
+            expect(updateOpenRouterModels).toHaveBeenCalledWith([
+                "anthropic/claude-sonnet-4.5",
+                "openrouter/auto",
+            ]),
+        );
+    });
+
     it("renders saved models with the small pill button primitive", () => {
         render(<RouterSettingsSection />);
 
@@ -121,5 +146,34 @@ describe("RouterSettingsSection", () => {
             name: "Remove anthropic/claude-sonnet-4.5",
         });
         expect(pill).toHaveClass("rounded-full", "text-xs");
+    });
+});
+
+describe("normalizeTypedModelId", () => {
+    it("keeps router-slug catalog ids verbatim", () => {
+        expect(normalizeTypedModelId("openrouter/auto", "openrouter")).toBe(
+            "openrouter/auto",
+        );
+        expect(normalizeTypedModelId("vercel/v0-1.5-md", "vercel")).toBe(
+            "vercel/v0-1.5-md",
+        );
+    });
+
+    it("strips the router prefix only when the remainder is a full id", () => {
+        expect(
+            normalizeTypedModelId(
+                " openrouter/deepseek/deepseek-v3 ",
+                "openrouter",
+            ),
+        ).toBe("deepseek/deepseek-v3");
+        expect(normalizeTypedModelId("openai/gpt-5.4", "openrouter")).toBe(
+            "openai/gpt-5.4",
+        );
+    });
+
+    it("returns null for text that is not id-shaped", () => {
+        expect(normalizeTypedModelId("auto", "openrouter")).toBeNull();
+        expect(normalizeTypedModelId("two words/x", "openrouter")).toBeNull();
+        expect(normalizeTypedModelId("", "openrouter")).toBeNull();
     });
 });

--- a/frontend/src/app/components/settings/RouterSettingsSection.test.tsx
+++ b/frontend/src/app/components/settings/RouterSettingsSection.test.tsx
@@ -150,7 +150,7 @@ describe("RouterSettingsSection", () => {
         );
     });
 
-    it("treats Enter as a no-op while the text is not id-shaped", async () => {
+    it("explains why Enter did nothing while the text is not id-shaped", async () => {
         render(<RouterSettingsSection />);
         const input = screen.getByRole("combobox", {
             name: "OpenRouter models",
@@ -161,8 +161,52 @@ describe("RouterSettingsSection", () => {
         fireEvent.keyDown(input, { key: "Enter" });
 
         expect(updateOpenRouterModels).not.toHaveBeenCalled();
-        // The search text stays so the user can keep narrowing the catalog.
+        // The search text stays so the user can keep narrowing the catalog…
         expect(input).toHaveValue("qwen");
+        // …but silence would read as a broken key. Say what is wrong.
+        expect(
+            screen.getByText(/is not a model ID/),
+        ).toBeInTheDocument();
+    });
+
+    it("rejects an over-long typed id client-side with a length message", async () => {
+        render(<RouterSettingsSection />);
+        const input = screen.getByRole("combobox", {
+            name: "OpenRouter models",
+        });
+        await waitFor(() => expect(getOpenRouterModels).toHaveBeenCalled());
+
+        fireEvent.change(input, {
+            target: { value: `vendor/${"m".repeat(220)}` },
+        });
+        fireEvent.keyDown(input, { key: "Enter" });
+
+        expect(updateOpenRouterModels).not.toHaveBeenCalled();
+        expect(
+            screen.getByText("Model IDs are at most 200 characters."),
+        ).toBeInTheDocument();
+    });
+
+    it("keeps the add-verbatim hint outside the listbox", async () => {
+        // ARIA: a listbox may only contain option/group children. A stray div
+        // inside it makes the option count and index reported to assistive
+        // tech disagree with what aria-activedescendant points at.
+        render(<RouterSettingsSection />);
+        const input = screen.getByRole("combobox", {
+            name: "OpenRouter models",
+        });
+        await waitFor(() => expect(getOpenRouterModels).toHaveBeenCalled());
+
+        fireEvent.change(input, { target: { value: "qwen/qwen-2" } });
+
+        const listbox = screen.getByRole("listbox", {
+            name: "OpenRouter model catalog",
+        });
+        const hint = screen.getByText("Press Enter to add this model ID.");
+        expect(listbox.contains(hint)).toBe(false);
+        for (const child of Array.from(listbox.children)) {
+            expect(child.getAttribute("role")).toBe("option");
+        }
     });
 
     it("adds a router-slug catalog id verbatim instead of rejecting it", async () => {
@@ -223,5 +267,17 @@ describe("normalizeTypedModelId", () => {
         expect(normalizeTypedModelId("auto", "openrouter")).toBeNull();
         expect(normalizeTypedModelId("two words/x", "openrouter")).toBeNull();
         expect(normalizeTypedModelId("", "openrouter")).toBeNull();
+    });
+
+    it("enforces the backend's 200-character model_id limit", () => {
+        // user_router_models CHECKs char_length(model_id) between 1 and 200,
+        // so anything longer is a guaranteed 400 — catch it where the user is
+        // still looking at the box they typed it into.
+        const at200 = `vendor/${"m".repeat(193)}`;
+        expect(at200).toHaveLength(200);
+        expect(normalizeTypedModelId(at200, "openrouter")).toBe(at200);
+        expect(
+            normalizeTypedModelId(`${at200}m`, "openrouter"),
+        ).toBeNull();
     });
 });

--- a/frontend/src/app/components/settings/RouterSettingsSection.test.tsx
+++ b/frontend/src/app/components/settings/RouterSettingsSection.test.tsx
@@ -47,6 +47,10 @@ describe("RouterSettingsSection", () => {
                 id: "anthropic/claude-sonnet-4.5",
                 label: "Claude Sonnet 4.5",
             },
+            {
+                id: "qwen/qwen-2.5-72b-instruct",
+                label: "Qwen 2.5 72B Instruct",
+            },
         ]);
     });
 
@@ -115,6 +119,50 @@ describe("RouterSettingsSection", () => {
                 "openai/gpt-5.4",
             ]),
         );
+    });
+
+    it("adds the typed id verbatim even when it substring-matches a catalog row", async () => {
+        // Typing the full valid id "qwen/qwen-2" also matches the catalog's
+        // "qwen/qwen-2.5-72b-instruct". Enter must add what was typed, not
+        // the highlighted lookalike.
+        updateOpenRouterModels.mockResolvedValue(true);
+        render(<RouterSettingsSection />);
+        const input = screen.getByRole("combobox", {
+            name: "OpenRouter models",
+        });
+        await waitFor(() => expect(getOpenRouterModels).toHaveBeenCalled());
+
+        fireEvent.change(input, { target: { value: "qwen/qwen-2" } });
+        // Typing never claims a highlight …
+        expect(input).not.toHaveAttribute("aria-activedescendant");
+        // … and the add-verbatim hint shows although catalog rows match.
+        expect(screen.getByText("Qwen 2.5 72B Instruct")).toBeInTheDocument();
+        expect(
+            screen.getByText("Press Enter to add this model ID."),
+        ).toBeInTheDocument();
+
+        fireEvent.keyDown(input, { key: "Enter" });
+        await waitFor(() =>
+            expect(updateOpenRouterModels).toHaveBeenCalledWith([
+                "anthropic/claude-sonnet-4.5",
+                "qwen/qwen-2",
+            ]),
+        );
+    });
+
+    it("treats Enter as a no-op while the text is not id-shaped", async () => {
+        render(<RouterSettingsSection />);
+        const input = screen.getByRole("combobox", {
+            name: "OpenRouter models",
+        });
+        await waitFor(() => expect(getOpenRouterModels).toHaveBeenCalled());
+
+        fireEvent.change(input, { target: { value: "qwen" } });
+        fireEvent.keyDown(input, { key: "Enter" });
+
+        expect(updateOpenRouterModels).not.toHaveBeenCalled();
+        // The search text stays so the user can keep narrowing the catalog.
+        expect(input).toHaveValue("qwen");
     });
 
     it("adds a router-slug catalog id verbatim instead of rejecting it", async () => {

--- a/frontend/src/app/components/settings/RouterSettingsSection.tsx
+++ b/frontend/src/app/components/settings/RouterSettingsSection.tsx
@@ -46,6 +46,25 @@ function modelCostLabel(model: RouterCatalogModel): string | null {
     return costs.join(" · ");
 }
 
+const CATALOG_MODEL_ID_RE = /^[^\s/]+\/[^\s]+$/;
+
+/**
+ * Canonical form of a hand-typed model id, or null when it isn't id-shaped.
+ * The router slug is stripped only when the remainder is still a full
+ * vendor/model id: some catalog ids legitimately start with the router's own
+ * slug (OpenRouter's "openrouter/auto", Vercel's "vercel/v0-1.5-md") and must
+ * be kept verbatim — mirrors the backend's normalizeRouterModels.
+ */
+export function normalizeTypedModelId(
+    input: string,
+    provider: "openrouter" | "vercel",
+): string | null {
+    const raw = input.trim();
+    const stripped = raw.replace(new RegExp(`^${provider}/`), "");
+    const model = CATALOG_MODEL_ID_RE.test(stripped) ? stripped : raw;
+    return CATALOG_MODEL_ID_RE.test(model) ? model : null;
+}
+
 function catalogModelMatches(model: RouterCatalogModel, query: string) {
     return (
         !query ||
@@ -177,8 +196,8 @@ function RouterModelsSetting({
     };
 
     const add = () => {
-        const model = input.trim().replace(new RegExp(`^${provider}/`), "");
-        if (!/^[^\s/]+\/[^\s]+$/.test(model)) {
+        const model = normalizeTypedModelId(input, provider);
+        if (!model) {
             setError(
                 `Enter a ${label} model ID such as anthropic/claude-sonnet-5.`,
             );
@@ -186,6 +205,7 @@ function RouterModelsSetting({
         }
         setInput("");
         setCatalogOpen(false);
+        setActiveCatalogIndex(-1);
         if (!selection.includes(model)) void save([...selection, model]);
     };
 

--- a/frontend/src/app/components/settings/RouterSettingsSection.tsx
+++ b/frontend/src/app/components/settings/RouterSettingsSection.tsx
@@ -49,19 +49,35 @@ function modelCostLabel(model: RouterCatalogModel): string | null {
 const CATALOG_MODEL_ID_RE = /^[^\s/]+\/[^\s]+$/;
 
 /**
- * Canonical form of a hand-typed model id, or null when it isn't id-shaped.
- * The router slug is stripped only when the remainder is still a full
- * vendor/model id: some catalog ids legitimately start with the router's own
- * slug (OpenRouter's "openrouter/auto", Vercel's "vercel/v0-1.5-md") and must
- * be kept verbatim — mirrors the backend's normalizeRouterModels.
+ * user_router_models CHECKs `char_length(model_id) between 1 and 200`, so a
+ * longer id is a guaranteed 400 from the profile PATCH. Enforcing it here
+ * turns that round trip into an immediate, specific message.
  */
+export const MAX_MODEL_ID_LENGTH = 200;
+
+/**
+ * The id a typed string would become, before it is validated. The router slug
+ * is stripped only when the remainder is still a full vendor/model id: some
+ * catalog ids legitimately start with the router's own slug (OpenRouter's
+ * "openrouter/auto", Vercel's "vercel/v0-1.5-md") and must be kept verbatim —
+ * mirrors the backend's normalizeRouterModels.
+ */
+function typedModelCandidate(
+    input: string,
+    provider: "openrouter" | "vercel",
+): string {
+    const raw = input.trim();
+    const stripped = raw.replace(new RegExp(`^${provider}/`), "");
+    return CATALOG_MODEL_ID_RE.test(stripped) ? stripped : raw;
+}
+
+/** Canonical form of a hand-typed model id, or null when it is not usable. */
 export function normalizeTypedModelId(
     input: string,
     provider: "openrouter" | "vercel",
 ): string | null {
-    const raw = input.trim();
-    const stripped = raw.replace(new RegExp(`^${provider}/`), "");
-    const model = CATALOG_MODEL_ID_RE.test(stripped) ? stripped : raw;
+    const model = typedModelCandidate(input, provider);
+    if (model.length > MAX_MODEL_ID_LENGTH) return null;
     return CATALOG_MODEL_ID_RE.test(model) ? model : null;
 }
 
@@ -195,12 +211,24 @@ function RouterModelsSetting({
         if (!ok) setError(`${label} model preferences could not be saved.`);
     };
 
-    // Enter with no explicit highlight adds exactly what the user typed —
-    // and is a silent no-op while the text is not yet id-shaped, so pressing
-    // Enter mid-search never errors and never adds a lookalike.
+    // Enter with no explicit highlight adds exactly what the user typed — and
+    // never a lookalike. When the text is not usable as an id, Enter explains
+    // why: a keypress that does nothing and says nothing reads as a broken
+    // control, and the user has no way to learn what shape is expected.
     const add = () => {
+        const candidate = typedModelCandidate(input, provider);
+        // An empty box is the one silent case — nothing was asked for.
+        if (!candidate) return;
         const model = normalizeTypedModelId(input, provider);
-        if (!model) return;
+        if (!model) {
+            setError(
+                candidate.length > MAX_MODEL_ID_LENGTH
+                    ? `Model IDs are at most ${MAX_MODEL_ID_LENGTH} characters.`
+                    : `"${candidate}" is not a model ID — pick one from the list, or type it as vendor/model.`,
+            );
+            return;
+        }
+        setError(null);
         setInput("");
         setCatalogOpen(false);
         setActiveCatalogIndex(-1);
@@ -258,20 +286,25 @@ function RouterModelsSetting({
             >
                 {catalogOpen && (
                     <LiquidDropdownSurface
-                        id={catalogId}
                         data-testid={`${provider}-model-catalog`}
-                        role="listbox"
-                        aria-multiselectable="true"
-                        aria-label={`${label} model catalog`}
                         className="absolute bottom-full left-0 z-50 mb-1.5 max-h-72 w-full overflow-y-auto p-1.5"
                     >
+                        {/* Outside the listbox below: ARIA allows a listbox
+                            only option/group children, and a stray div makes
+                            the option indices a screen reader announces
+                            disagree with aria-activedescendant. */}
                         {typedModelId && (
                             <div className="px-3 py-2 text-xs text-gray-400">
                                 Press Enter to add this model ID.
                             </div>
                         )}
-                        {visibleCatalog.length > 0 ? (
-                            visibleCatalog.map((model, index) => {
+                        <div
+                            id={catalogId}
+                            role="listbox"
+                            aria-multiselectable="true"
+                            aria-label={`${label} model catalog`}
+                        >
+                            {visibleCatalog.map((model, index) => {
                                 const selected = selection.includes(model.id);
                                 const active = index === activeCatalogIndex;
                                 const costLabel = modelCostLabel(model);
@@ -313,8 +346,9 @@ function RouterModelsSetting({
                                         )}
                                     </LiquidDropdownButton>
                                 );
-                            })
-                        ) : (
+                            })}
+                        </div>
+                        {visibleCatalog.length === 0 && (
                             <div className="px-3 py-2 text-xs text-gray-400">
                                 No matching models.
                             </div>

--- a/frontend/src/app/components/settings/RouterSettingsSection.tsx
+++ b/frontend/src/app/components/settings/RouterSettingsSection.tsx
@@ -195,14 +195,12 @@ function RouterModelsSetting({
         if (!ok) setError(`${label} model preferences could not be saved.`);
     };
 
+    // Enter with no explicit highlight adds exactly what the user typed —
+    // and is a silent no-op while the text is not yet id-shaped, so pressing
+    // Enter mid-search never errors and never adds a lookalike.
     const add = () => {
         const model = normalizeTypedModelId(input, provider);
-        if (!model) {
-            setError(
-                `Enter a ${label} model ID such as anthropic/claude-sonnet-5.`,
-            );
-            return;
-        }
+        if (!model) return;
         setInput("");
         setCatalogOpen(false);
         setActiveCatalogIndex(-1);
@@ -213,6 +211,7 @@ function RouterModelsSetting({
         const query = input.trim().toLowerCase();
         return catalogModelMatches(model, query);
     });
+    const typedModelId = normalizeTypedModelId(input, provider);
 
     const selectCatalogModel = (model: string) => {
         setInput("");
@@ -266,6 +265,11 @@ function RouterModelsSetting({
                         aria-label={`${label} model catalog`}
                         className="absolute bottom-full left-0 z-50 mb-1.5 max-h-72 w-full overflow-y-auto p-1.5"
                     >
+                        {typedModelId && (
+                            <div className="px-3 py-2 text-xs text-gray-400">
+                                Press Enter to add this model ID.
+                            </div>
+                        )}
                         {visibleCatalog.length > 0 ? (
                             visibleCatalog.map((model, index) => {
                                 const selected = selection.includes(model.id);
@@ -312,8 +316,7 @@ function RouterModelsSetting({
                             })
                         ) : (
                             <div className="px-3 py-2 text-xs text-gray-400">
-                                No matching models. Press Enter to add this
-                                model ID.
+                                No matching models.
                             </div>
                         )}
                     </LiquidDropdownSurface>
@@ -339,16 +342,14 @@ function RouterModelsSetting({
                         placeholder="e.g. anthropic/claude-sonnet-5"
                         className="h-full min-w-0 flex-1 bg-transparent text-sm text-gray-900 outline-none placeholder:text-gray-400 disabled:cursor-not-allowed"
                         onChange={(event) => {
-                            const nextInput = event.target.value;
-                            setInput(nextInput);
-                            if (catalog.length > 0) {
-                                const query = nextInput.trim().toLowerCase();
-                                const hasMatches = catalog.some((model) =>
-                                    catalogModelMatches(model, query),
-                                );
-                                setCatalogOpen(true);
-                                setActiveCatalogIndex(hasMatches ? 0 : -1);
-                            }
+                            setInput(event.target.value);
+                            // Typing never claims a highlight: Enter must add
+                            // the typed id verbatim unless the user points at
+                            // a row (arrow keys or hover). A default top-row
+                            // highlight made Enter after typing a full valid
+                            // id add a substring-matching catalog row instead.
+                            setActiveCatalogIndex(-1);
+                            if (catalog.length > 0) setCatalogOpen(true);
                         }}
                         onKeyDown={(event) => {
                             if (event.key === "ArrowDown") {
@@ -392,9 +393,10 @@ function RouterModelsSetting({
                         onClick={() => {
                             const nextOpen = !catalogOpen;
                             setCatalogOpen(nextOpen);
-                            setActiveCatalogIndex(
-                                nextOpen && visibleCatalog.length > 0 ? 0 : -1,
-                            );
+                            // Highlight only ever follows an explicit arrow
+                            // key or pointer hover — opening the list doesn't
+                            // pre-claim a row for Enter.
+                            setActiveCatalogIndex(-1);
                             if (nextOpen) inputRef.current?.focus();
                         }}
                         className="flex h-full shrink-0 items-center justify-end text-gray-400 transition-colors hover:text-gray-700 disabled:cursor-default disabled:opacity-40"

--- a/frontend/src/app/components/tabular/TRChatPanel.tsx
+++ b/frontend/src/app/components/tabular/TRChatPanel.tsx
@@ -435,6 +435,7 @@ function TRChatInput({
     model,
     onModelChange,
     apiKeys,
+    apiKeysLoading,
     openRouterModels,
     vercelModels,
     onHeightChange,
@@ -445,6 +446,7 @@ function TRChatInput({
     model: string;
     onModelChange: (id: string) => void;
     apiKeys?: ApiKeyState;
+    apiKeysLoading?: boolean;
     openRouterModels?: string[];
     vercelModels?: string[];
     onHeightChange: (height: number) => void;
@@ -531,6 +533,7 @@ function TRChatInput({
                         value={model}
                         onChange={onModelChange}
                         apiKeys={apiKeys}
+                        apiKeysLoading={apiKeysLoading}
                         openRouterModels={openRouterModels}
                         vercelModels={vercelModels}
                     />
@@ -760,8 +763,16 @@ export function TRChatPanel({
     initialChatId,
     onChatIdChange,
 }: Props) {
-    const { profile, updateModelPreference } = useUserProfile();
-    const apiKeys = profile?.apiKeys;
+    const {
+        profile,
+        loading: profileLoading,
+        apiKeysDegraded,
+        updateModelPreference,
+    } = useUserProfile();
+    // Unknown key state (still loading, or degraded after a failed profile
+    // fetch) fails open — see ModelToggle.
+    const apiKeys = apiKeysDegraded ? undefined : profile?.apiKeys;
+    const apiKeysLoading = profileLoading && !profile;
     const currentModel = profile?.tabularModel ?? "gemini-3-flash-preview";
     const [apiKeyModalProvider, setApiKeyModalProvider] =
         useState<ModelProvider | null>(null);
@@ -1917,6 +1928,7 @@ export function TRChatPanel({
                     updateModelPreference("tabularModel", id)
                 }
                 apiKeys={apiKeys}
+                apiKeysLoading={apiKeysLoading}
                 openRouterModels={profile?.openRouterModels}
                 vercelModels={profile?.vercelModels}
                 onHeightChange={setInputHeight}

--- a/frontend/src/app/components/tabular/TabularReviewView.tsx
+++ b/frontend/src/app/components/tabular/TabularReviewView.tsx
@@ -131,8 +131,10 @@ export function TRView({ reviewId, projectId }: Props) {
     const actionsRef = useRef<HTMLDivElement>(null);
     const tableRef = useRef<TRTableHandle>(null);
     const router = useRouter();
-    const { profile } = useUserProfile();
-    const apiKeys = profile?.apiKeys;
+    const { profile, apiKeysDegraded } = useUserProfile();
+    // Unknown key state fails open; the submit gates below already skip when
+    // apiKeys is undefined.
+    const apiKeys = apiKeysDegraded ? undefined : profile?.apiKeys;
     const tabularModel = profile?.tabularModel ?? "gemini-3-flash-preview";
 
     useEffect(() => {

--- a/frontend/src/app/contexts/UserProfileContext.tsx
+++ b/frontend/src/app/contexts/UserProfileContext.tsx
@@ -42,9 +42,12 @@ interface UserProfileContextType {
     loading: boolean;
     /**
      * True when the profile fetch failed (after a retry) and `profile` holds
-     * the local fallback. Its apiKeys then say "nothing configured" only
-     * because the truth is unknown — key-gated UI should fail open rather
-     * than treat that as a real all-keys-missing state.
+     * the local fallback. Every field on it is a placeholder, not an answer:
+     * apiKeys say "nothing configured" and the router model lists are empty
+     * only because the truth is unknown. Consumers must distinguish this from
+     * a real profile that loaded with the same values — key-gated UI fails
+     * open, and destructive normalization (e.g. resetting a saved composer
+     * selection that is absent from the router lists) must not run at all.
      */
     apiKeysDegraded: boolean;
     updateDisplayName: (name: string) => Promise<boolean>;

--- a/frontend/src/app/contexts/UserProfileContext.tsx
+++ b/frontend/src/app/contexts/UserProfileContext.tsx
@@ -40,6 +40,13 @@ interface UserProfile {
 interface UserProfileContextType {
     profile: UserProfile | null;
     loading: boolean;
+    /**
+     * True when the profile fetch failed (after a retry) and `profile` holds
+     * the local fallback. Its apiKeys then say "nothing configured" only
+     * because the truth is unknown — key-gated UI should fail open rather
+     * than treat that as a real all-keys-missing state.
+     */
+    apiKeysDegraded: boolean;
     updateDisplayName: (name: string) => Promise<boolean>;
     updateOrganisation: (organisation: string) => Promise<boolean>;
     updateModelPreference: (
@@ -112,13 +119,28 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
     const { user, isAuthenticated } = useAuth();
     const [profile, setProfile] = useState<UserProfile | null>(null);
     const [loading, setLoading] = useState(true);
+    const [apiKeysDegraded, setApiKeysDegraded] = useState(false);
     const userId = user?.id ?? null;
 
     const loadProfile = useCallback(async () => {
         try {
-            const profileData = await getUserProfile();
+            let profileData: ApiUserProfile;
+            try {
+                profileData = await getUserProfile();
+            } catch {
+                // One retry with a short backoff absorbs a transient network
+                // blip before the app falls back to the degraded profile.
+                await new Promise((resolve) => setTimeout(resolve, 750));
+                profileData = await getUserProfile();
+            }
             setProfile(toProfile(profileData));
-        } catch {
+            setApiKeysDegraded(false);
+        } catch (error) {
+            console.warn(
+                "[profile] fetch failed after retry; API key availability is unknown and fails open",
+                error,
+            );
+            setApiKeysDegraded(true);
             // Calculate a default future reset date for fallback
             const futureResetDate = new Date();
             futureResetDate.setDate(futureResetDate.getDate() + 30);
@@ -353,6 +375,7 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
             value={{
                 profile,
                 loading,
+                apiKeysDegraded,
                 updateDisplayName,
                 updateOrganisation,
                 updateModelPreference,

--- a/frontend/src/app/hooks/useSelectedModel.test.ts
+++ b/frontend/src/app/hooks/useSelectedModel.test.ts
@@ -1,0 +1,81 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSelectedModel } from "./useSelectedModel";
+import { canonicalModelId } from "../components/assistant/ModelToggle";
+
+const STORAGE_KEY = "mike.selectedModel";
+
+beforeEach(() => {
+    window.localStorage.clear();
+});
+
+describe("useSelectedModel", () => {
+    it("canonicalizes stored ids before validating them", () => {
+        // The current LEGACY_MODEL_IDS targets are settings-tier models, so
+        // after mapping they still resolve to the composer default here — the
+        // mapping's user-visible effect lives on the settings page. This
+        // pins that reads go through canonicalModelId (a future rename of a
+        // composer-tier model is then handled for free).
+        window.localStorage.setItem(STORAGE_KEY, "gpt-5.4-lite");
+
+        const { result } = renderHook(() => useSelectedModel());
+
+        expect(result.current[0]).toBe("gemini-3-flash-preview");
+    });
+
+    it("persists a valid explicit selection", () => {
+        const { result } = renderHook(() => useSelectedModel());
+
+        act(() => result.current[1]("claude-fable-5"));
+
+        expect(result.current[0]).toBe("claude-fable-5");
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe("claude-fable-5");
+    });
+
+    it("keeps a router selection that is in the loaded saved lists", () => {
+        window.localStorage.setItem(STORAGE_KEY, "openrouter/openai/gpt-5.4");
+
+        const { result } = renderHook(() =>
+            useSelectedModel({
+                openRouterModels: ["openai/gpt-5.4"],
+                vercelModels: [],
+            }),
+        );
+
+        expect(result.current[0]).toBe("openrouter/openai/gpt-5.4");
+    });
+
+    it("resets a router selection missing from the loaded saved lists", () => {
+        window.localStorage.setItem(STORAGE_KEY, "openrouter/pricy/frontier");
+
+        const { result } = renderHook(() =>
+            useSelectedModel({
+                openRouterModels: ["openai/gpt-5.4"],
+                vercelModels: [],
+            }),
+        );
+
+        expect(result.current[0]).toBe("gemini-3-flash-preview");
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe(
+            "gemini-3-flash-preview",
+        );
+    });
+
+    it("leaves a router selection alone while the lists are still loading", () => {
+        window.localStorage.setItem(STORAGE_KEY, "openrouter/openai/gpt-5.4");
+
+        const { result } = renderHook(() => useSelectedModel(null));
+
+        expect(result.current[0]).toBe("openrouter/openai/gpt-5.4");
+    });
+});
+
+describe("canonicalModelId", () => {
+    it("maps only known legacy ids", () => {
+        expect(canonicalModelId("gemini-3.1-flash-lite-preview")).toBe(
+            "gemini-3.5-flash-lite",
+        );
+        expect(canonicalModelId("gpt-5.4-lite")).toBe("gpt-5.4-mini");
+        expect(canonicalModelId("claude-fable-5")).toBe("claude-fable-5");
+    });
+});

--- a/frontend/src/app/hooks/useSelectedModel.ts
+++ b/frontend/src/app/hooks/useSelectedModel.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import {
     ALLOWED_MODEL_IDS,
     DEFAULT_MODEL_ID,
+    canonicalModelId,
 } from "../components/assistant/ModelToggle";
 
 const STORAGE_KEY = "mike.selectedModel";
@@ -20,24 +21,66 @@ function isAllowed(id: string): boolean {
 function readStored(): string {
     if (typeof window === "undefined") return DEFAULT_MODEL_ID;
     const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (raw && isAllowed(raw)) return raw;
+    // Map renamed static ids to their current equivalents before validating,
+    // so a selection stored before a catalog rename keeps working.
+    const canonical = raw ? canonicalModelId(raw) : null;
+    if (canonical && isAllowed(canonical)) return canonical;
     return DEFAULT_MODEL_ID;
 }
 
-export function useSelectedModel(): [string, (id: string) => void] {
+function persist(id: string) {
+    if (typeof window !== "undefined") {
+        window.localStorage.setItem(STORAGE_KEY, id);
+    }
+}
+
+/**
+ * @param routerSelections The user's saved router model lists once the
+ * profile is loaded, or null/undefined while it is not. When loaded, a stored
+ * `openrouter/*` / `vercel/*` selection that is no longer in the saved lists
+ * resets to the default model — mirroring how an unavailable first-party id
+ * is replaced on read — instead of being silently sent to the backend (which
+ * would reject it and degrade the request to the default anyway).
+ */
+export function useSelectedModel(
+    routerSelections?: {
+        openRouterModels: string[];
+        vercelModels: string[];
+    } | null,
+): [string, (id: string) => void] {
     const [model, setModelState] = useState<string>(DEFAULT_MODEL_ID);
+    const openRouterModels = routerSelections?.openRouterModels;
+    const vercelModels = routerSelections?.vercelModels;
 
     useEffect(() => {
         // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration-safe localStorage read; SSR must render the default model
         setModelState(readStored());
     }, []);
 
+    useEffect(() => {
+        if (!openRouterModels || !vercelModels) return;
+        setModelState((current) => {
+            const router = current.startsWith("openrouter/")
+                ? "openrouter"
+                : current.startsWith("vercel/")
+                  ? "vercel"
+                  : null;
+            if (!router) return current;
+            const selection =
+                router === "openrouter" ? openRouterModels : vercelModels;
+            if (selection.includes(current.slice(router.length + 1))) {
+                return current;
+            }
+            persist(DEFAULT_MODEL_ID);
+            return DEFAULT_MODEL_ID;
+        });
+    }, [openRouterModels, vercelModels]);
+
     const setModel = useCallback((id: string) => {
-        const next = isAllowed(id) ? id : DEFAULT_MODEL_ID;
+        const canonical = canonicalModelId(id);
+        const next = isAllowed(canonical) ? canonical : DEFAULT_MODEL_ID;
         setModelState(next);
-        if (typeof window !== "undefined") {
-            window.localStorage.setItem(STORAGE_KEY, next);
-        }
+        persist(next);
     }, []);
 
     return [model, setModel];

--- a/frontend/src/app/hooks/useSelectedModel.ts
+++ b/frontend/src/app/hooks/useSelectedModel.ts
@@ -9,7 +9,12 @@ import {
 
 const STORAGE_KEY = "mike.selectedModel";
 
-function isAllowed(id: string): boolean {
+/**
+ * The composer's accepted-id surface. Exported so the Word add-in drift guard
+ * (frontend/src/wordAddin/catalogParity.test.ts) can compare it against the
+ * add-in's hand-mirrored copy instead of restating the rule.
+ */
+export function isAllowedModelId(id: string): boolean {
     return (
         ALLOWED_MODEL_IDS.has(id) ||
         id.startsWith("ollama/") ||
@@ -24,7 +29,7 @@ function readStored(): string {
     // Map renamed static ids to their current equivalents before validating,
     // so a selection stored before a catalog rename keeps working.
     const canonical = raw ? canonicalModelId(raw) : null;
-    if (canonical && isAllowed(canonical)) return canonical;
+    if (canonical && isAllowedModelId(canonical)) return canonical;
     return DEFAULT_MODEL_ID;
 }
 
@@ -78,7 +83,7 @@ export function useSelectedModel(
 
     const setModel = useCallback((id: string) => {
         const canonical = canonicalModelId(id);
-        const next = isAllowed(canonical) ? canonical : DEFAULT_MODEL_ID;
+        const next = isAllowedModelId(canonical) ? canonical : DEFAULT_MODEL_ID;
         setModelState(next);
         persist(next);
     }, []);

--- a/frontend/src/app/hooks/useSelectedModel.ts
+++ b/frontend/src/app/hooks/useSelectedModel.ts
@@ -64,6 +64,7 @@ export function useSelectedModel(
 
     useEffect(() => {
         if (!openRouterModels || !vercelModels) return;
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- reconciles state with data that arrives asynchronously (the loaded router lists); the functional update is a no-op unless the stored selection is genuinely stale, so it cannot cascade
         setModelState((current) => {
             const router = current.startsWith("openrouter/")
                 ? "openrouter"

--- a/frontend/src/wordAddin/catalogParity.test.ts
+++ b/frontend/src/wordAddin/catalogParity.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Cross-package drift guard: the Word add-in mirrors the web app's model
+ * catalog by hand (word-addin/src/taskpane/lib/modelCatalog.ts) until both
+ * clients share one package. These tests import BOTH copies so a hand-edit
+ * that drifts them apart fails CI instead of shipping two different pickers.
+ */
+import { describe, expect, it } from "vitest";
+import {
+    MODELS,
+    DEFAULT_MODEL_ID,
+    modelDisplayName,
+    openRouterModelOptions,
+    vercelModelOptions,
+} from "../app/components/assistant/ModelToggle";
+import {
+    STATIC_MODELS,
+    DEFAULT_MODEL_ID as ADDIN_DEFAULT_MODEL_ID,
+    modelDisplayName as addinModelDisplayName,
+    openRouterModelOptions as addinOpenRouterModelOptions,
+    vercelModelOptions as addinVercelModelOptions,
+} from "../../../word-addin/src/taskpane/lib/modelCatalog";
+
+describe("word add-in catalog parity", () => {
+    it("offers exactly the web app's static models (id, label, group)", () => {
+        const webModels = MODELS.map(({ id, label, group }) => ({
+            id,
+            label,
+            group,
+        }));
+        const addinModels = STATIC_MODELS.map(({ id, label, group }) => ({
+            id,
+            label,
+            group,
+        }));
+        expect(addinModels).toEqual(webModels);
+    });
+
+    it("shares the web app's default model", () => {
+        expect(ADDIN_DEFAULT_MODEL_ID).toBe(DEFAULT_MODEL_ID);
+    });
+
+    it("renders identical display names for every shared id", () => {
+        const sharedIds = [
+            ...MODELS.map((model) => model.id),
+            "openrouter/anthropic/claude-sonnet-4.5",
+            "openrouter/meta-llama/llama-3-3-70b-instruct",
+            "openrouter/openrouter/auto",
+            "vercel/openai/gpt-5.4",
+            "vercel/vercel/v0-1.5-md",
+            "ollama/llama3:8b",
+        ];
+        for (const id of sharedIds) {
+            expect(addinModelDisplayName(id)).toBe(modelDisplayName(id));
+        }
+    });
+
+    it("builds the same composer model id from a stored selection", () => {
+        // A stored selection is the router's raw catalog id. Both clients must
+        // send `router/<catalog-id>` verbatim — including ids that begin with
+        // the router's own slug, where a defensive inner strip would make the
+        // add-in send a different model than the web app for the same row.
+        const stored = [
+            "anthropic/claude-sonnet-4.5",
+            "openrouter/auto",
+            "vercel/v0-1.5-md",
+        ];
+        expect(
+            addinOpenRouterModelOptions(stored).map((option) => option.id),
+        ).toEqual(openRouterModelOptions(stored).map((option) => option.id));
+        expect(
+            addinVercelModelOptions(stored).map((option) => option.id),
+        ).toEqual(vercelModelOptions(stored).map((option) => option.id));
+        expect(
+            addinOpenRouterModelOptions(["openrouter/auto"])[0]?.id,
+        ).toBe("openrouter/openrouter/auto");
+    });
+});

--- a/frontend/src/wordAddin/catalogParity.test.ts
+++ b/frontend/src/wordAddin/catalogParity.test.ts
@@ -15,10 +15,14 @@ import {
 import {
     STATIC_MODELS,
     DEFAULT_MODEL_ID as ADDIN_DEFAULT_MODEL_ID,
+    isModelAvailable as addinIsModelAvailable,
     modelDisplayName as addinModelDisplayName,
     openRouterModelOptions as addinOpenRouterModelOptions,
     vercelModelOptions as addinVercelModelOptions,
 } from "../../../word-addin/src/taskpane/lib/modelCatalog";
+import type { ApiKeyStatus } from "../../../word-addin/src/taskpane/api/client";
+import { isModelAvailable as webIsModelAvailable } from "../app/lib/modelAvailability";
+import type { ApiKeyState } from "../app/lib/mikeApi";
 
 describe("word add-in catalog parity", () => {
     it("offers exactly the web app's static models (id, label, group)", () => {
@@ -73,5 +77,48 @@ describe("word add-in catalog parity", () => {
         expect(
             addinOpenRouterModelOptions(["openrouter/auto"])[0]?.id,
         ).toBe("openrouter/openrouter/auto");
+    });
+
+    it("gates every shared model on the same provider key in both clients", () => {
+        const providers = [
+            "claude",
+            "gemini",
+            "openai",
+            "openrouter",
+            "vercel",
+        ] as const;
+        const sharedIds = [
+            ...MODELS.map((model) => model.id),
+            "openrouter/openai/gpt-5.4",
+            "vercel/openai/gpt-5.4",
+        ];
+        for (const configured of providers) {
+            const addinStatus = {
+                claude: false,
+                gemini: false,
+                openai: false,
+                openrouter: false,
+                vercel: false,
+                courtlistener: false,
+                [configured]: true,
+            } as unknown as ApiKeyStatus;
+            const webState = Object.fromEntries(
+                [...providers, "courtlistener"].map((provider) => [
+                    provider,
+                    {
+                        configured: provider === configured,
+                        source: provider === configured ? "user" : null,
+                    },
+                ]),
+            ) as ApiKeyState;
+            for (const id of sharedIds) {
+                expect
+                    .soft(
+                        addinIsModelAvailable(id, addinStatus),
+                        `${id} with only ${configured} configured`,
+                    )
+                    .toBe(webIsModelAvailable(id, webState));
+            }
+        }
     });
 });

--- a/frontend/src/wordAddin/catalogParity.test.ts
+++ b/frontend/src/wordAddin/catalogParity.test.ts
@@ -8,6 +8,8 @@ import { describe, expect, it } from "vitest";
 import {
     MODELS,
     DEFAULT_MODEL_ID,
+    LEGACY_MODEL_IDS,
+    canonicalModelId,
     modelDisplayName,
     openRouterModelOptions,
     vercelModelOptions,
@@ -15,6 +17,9 @@ import {
 import {
     STATIC_MODELS,
     DEFAULT_MODEL_ID as ADDIN_DEFAULT_MODEL_ID,
+    LEGACY_MODEL_IDS as ADDIN_LEGACY_MODEL_IDS,
+    canonicalModelId as addinCanonicalModelId,
+    isAllowedModelId as addinIsAllowedModelId,
     isModelAvailable as addinIsModelAvailable,
     modelDisplayName as addinModelDisplayName,
     openRouterModelOptions as addinOpenRouterModelOptions,
@@ -22,6 +27,7 @@ import {
 } from "../../../word-addin/src/taskpane/lib/modelCatalog";
 import type { ApiKeyStatus } from "../../../word-addin/src/taskpane/api/client";
 import { isModelAvailable as webIsModelAvailable } from "../app/lib/modelAvailability";
+import { isAllowedModelId as webIsAllowedModelId } from "../app/hooks/useSelectedModel";
 import type { ApiKeyState } from "../app/lib/mikeApi";
 
 describe("word add-in catalog parity", () => {
@@ -41,6 +47,47 @@ describe("word add-in catalog parity", () => {
 
     it("shares the web app's default model", () => {
         expect(ADDIN_DEFAULT_MODEL_ID).toBe(DEFAULT_MODEL_ID);
+    });
+
+    it("maps the same retired ids to the same current ids", () => {
+        // A rename is only survivable if BOTH clients map the old id. The web
+        // app maps it and the add-in did not, so the same localStorage value
+        // ("mike.selectedModel" is shared by key name) resolved differently
+        // depending on which client read it.
+        expect(ADDIN_LEGACY_MODEL_IDS).toEqual(LEGACY_MODEL_IDS);
+        for (const id of [
+            ...Object.keys(LEGACY_MODEL_IDS),
+            ...Object.values(LEGACY_MODEL_IDS),
+            ...MODELS.map((model) => model.id),
+            "openrouter/openai/gpt-5.4",
+            "ollama/llama3:8b",
+            "not-a-model",
+        ]) {
+            expect.soft(addinCanonicalModelId(id), id).toBe(
+                canonicalModelId(id),
+            );
+        }
+    });
+
+    it("accepts exactly the same set of stored selection ids", () => {
+        const probes = [
+            ...MODELS.map((model) => model.id),
+            ...Object.keys(LEGACY_MODEL_IDS),
+            ...Object.values(LEGACY_MODEL_IDS),
+            "claude-haiku-4-5",
+            "openrouter/openai/gpt-5.4",
+            "openrouter/openrouter/auto",
+            "vercel/openai/gpt-5.4",
+            "ollama/llama3:8b",
+            "openrouter",
+            "",
+            "gpt-5.4-turbo-imaginary",
+        ];
+        for (const id of probes) {
+            expect
+                .soft(addinIsAllowedModelId(id), id)
+                .toBe(webIsAllowedModelId(id));
+        }
     });
 
     it("renders identical display names for every shared id", () => {

--- a/frontend/src/wordAddin/composerAvailability.test.ts
+++ b/frontend/src/wordAddin/composerAvailability.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Word add-in composer availability semantics, exercised from the frontend
+ * test runner (the add-in package has no unit-test runner of its own).
+ */
+import { describe, expect, it, vi } from "vitest";
+import { isModelAvailable } from "../../../word-addin/src/taskpane/lib/modelCatalog";
+import { loadWithRetry } from "../../../word-addin/src/taskpane/lib/composerPreflight";
+import type { ApiKeyStatus } from "../../../word-addin/src/taskpane/api/client";
+
+const NO_KEYS: ApiKeyStatus = {
+    claude: false,
+    gemini: false,
+    openai: false,
+    openrouter: false,
+    vercel: false,
+    courtlistener: false,
+} as ApiKeyStatus;
+
+describe("isModelAvailable fail-open", () => {
+    it("allows sends while key status is unknown (null)", () => {
+        // A flaky WKWebView preflight must not brick the composer: the
+        // backend still rejects models it cannot serve.
+        expect(isModelAvailable("gemini-3-flash-preview", null)).toBe(true);
+        expect(isModelAvailable("claude-fable-5", null)).toBe(true);
+        expect(isModelAvailable("openrouter/openai/gpt-5.4", null)).toBe(true);
+        expect(isModelAvailable("vercel/openai/gpt-5.4", null)).toBe(true);
+    });
+
+    it("still gates on a LOADED status", () => {
+        expect(isModelAvailable("gemini-3-flash-preview", NO_KEYS)).toBe(false);
+        expect(isModelAvailable("openrouter/openai/gpt-5.4", NO_KEYS)).toBe(
+            false,
+        );
+        expect(
+            isModelAvailable("gemini-3-flash-preview", {
+                ...NO_KEYS,
+                gemini: true,
+            }),
+        ).toBe(true);
+    });
+});
+
+describe("loadWithRetry", () => {
+    it("returns the value from a successful retry", async () => {
+        const load = vi
+            .fn()
+            .mockRejectedValueOnce(new Error("transient"))
+            .mockResolvedValueOnce("loaded");
+
+        await expect(
+            loadWithRetry(load, { delayMs: 0 }),
+        ).resolves.toBe("loaded");
+        expect(load).toHaveBeenCalledTimes(2);
+    });
+
+    it("resolves null and reports the error after the final failure", async () => {
+        const boom = new Error("still down");
+        const load = vi.fn().mockRejectedValue(boom);
+        const onFinalFailure = vi.fn();
+
+        await expect(
+            loadWithRetry(load, { delayMs: 0, onFinalFailure }),
+        ).resolves.toBeNull();
+        expect(load).toHaveBeenCalledTimes(2);
+        expect(onFinalFailure).toHaveBeenCalledWith(boom);
+    });
+
+    it("does not retry after a success", async () => {
+        const load = vi.fn().mockResolvedValue("ok");
+
+        await expect(loadWithRetry(load, { delayMs: 0 })).resolves.toBe("ok");
+        expect(load).toHaveBeenCalledTimes(1);
+    });
+});

--- a/word-addin/src/taskpane/components/assistant/ChatInput.tsx
+++ b/word-addin/src/taskpane/components/assistant/ChatInput.tsx
@@ -31,6 +31,7 @@ import type {
   WordChatSubmitOptions,
 } from "../../lib/wordChatTypes";
 import { isModelAvailable, missingModelProvider } from "../../lib/modelCatalog";
+import { loadWithRetry } from "../../lib/composerPreflight";
 
 export interface ChatInputHandle {
   setDraft: (prompt: string) => void;
@@ -79,6 +80,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     const [workflowModalOpen, setWorkflowModalOpen] = useState(false);
     const [model, setModel] = useSelectedModel();
     const [keyStatus, setKeyStatus] = useState<ApiKeyStatus | null>(null);
+    const [keyStatusLoading, setKeyStatusLoading] = useState(true);
     const [openRouterModels, setOpenRouterModels] = useState<string[]>([]);
     const [vercelModels, setVercelModels] = useState<string[]>([]);
     const [modelError, setModelError] = useState<string | null>(null);
@@ -105,18 +107,34 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
 
     useEffect(() => {
       let cancelled = false;
-      void Promise.allSettled([getApiKeyStatus(), getUserProfile()]).then(
-        ([statusResult, profileResult]) => {
-          if (cancelled) return;
-          if (statusResult.status === "fulfilled") {
-            setKeyStatus(statusResult.value);
-          }
-          if (profileResult.status === "fulfilled") {
-            setOpenRouterModels(profileResult.value.openRouterModels ?? []);
-            setVercelModels(profileResult.value.vercelModels ?? []);
-          }
-        },
-      );
+      // Three-state preflight: while it runs the model toggle stays neutral
+      // (no "No API Key"); each request retries once with backoff; after a
+      // final failure keyStatus stays null and availability FAILS OPEN (the
+      // backend still authoritatively rejects models it cannot serve).
+      void Promise.all([
+        loadWithRetry(getApiKeyStatus, {
+          onFinalFailure: (error) =>
+            console.warn(
+              "[word-addin] API key status unavailable after retry; model availability fails open",
+              error,
+            ),
+        }),
+        loadWithRetry(getUserProfile, {
+          onFinalFailure: (error) =>
+            console.warn(
+              "[word-addin] user profile unavailable after retry; router models hidden this session",
+              error,
+            ),
+        }),
+      ]).then(([status, profile]) => {
+        if (cancelled) return;
+        setKeyStatus(status);
+        if (profile) {
+          setOpenRouterModels(profile.openRouterModels ?? []);
+          setVercelModels(profile.vercelModels ?? []);
+        }
+        setKeyStatusLoading(false);
+      });
       return () => {
         cancelled = true;
       };
@@ -340,6 +358,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                   setModel(next);
                 }}
                 keyStatus={keyStatus}
+                keyStatusLoading={keyStatusLoading}
                 openRouterModels={openRouterModels}
                 vercelModels={vercelModels}
               />

--- a/word-addin/src/taskpane/components/assistant/ModelToggle.tsx
+++ b/word-addin/src/taskpane/components/assistant/ModelToggle.tsx
@@ -4,6 +4,8 @@ import { getOllamaModels, type ApiKeyStatus } from "../../api/mikeApi";
 import {
   isModelAvailable,
   modelDisplayName,
+  openRouterModelOptions,
+  vercelModelOptions,
   STATIC_MODELS,
   type ModelGroup,
   type ModelOption,
@@ -55,16 +57,8 @@ export function ModelToggle({
   }, []);
 
   const models = useMemo(() => {
-    const openRouterOptions: ModelOption[] = openRouterModels.map((model) => ({
-      id: `openrouter/${model.replace(/^openrouter\//, "")}`,
-      label: modelDisplayName(model),
-      group: "OpenRouter",
-    }));
-    const vercelOptions: ModelOption[] = vercelModels.map((model) => ({
-      id: `vercel/${model.replace(/^vercel\//, "")}`,
-      label: modelDisplayName(model),
-      group: "Vercel AI Gateway",
-    }));
+    const openRouterOptions = openRouterModelOptions(openRouterModels);
+    const vercelOptions = vercelModelOptions(vercelModels);
     const localOptions = ollamaModels.map((model) => ({
       ...model,
       label: modelDisplayName(model.id),

--- a/word-addin/src/taskpane/components/assistant/ModelToggle.tsx
+++ b/word-addin/src/taskpane/components/assistant/ModelToggle.tsx
@@ -31,12 +31,16 @@ export function ModelToggle({
   value,
   onChange,
   keyStatus,
+  keyStatusLoading = false,
   openRouterModels,
   vercelModels,
 }: {
   value: string;
   onChange: (model: string) => void;
   keyStatus: ApiKeyStatus | null;
+  /** True while the key-status preflight is in flight: render a neutral
+   *  disabled trigger instead of flashing "No API Key". */
+  keyStatusLoading?: boolean;
   openRouterModels: string[];
   vercelModels: string[];
 }): React.ReactElement {
@@ -97,16 +101,24 @@ export function ModelToggle({
         <button
           type="button"
           aria-label="Choose model"
-          title={models.length === 0 ? "No API key configured" : "Choose model"}
-          disabled={models.length === 0}
+          title={
+            keyStatusLoading
+              ? "Checking API keys"
+              : models.length === 0
+                ? "No API key configured"
+                : "Choose model"
+          }
+          disabled={keyStatusLoading || models.length === 0}
           className={`flex h-8 items-center gap-1.5 rounded-full px-2 text-sm text-gray-400 transition-colors hover:text-gray-700 ${
             open ? "text-gray-700" : ""
           } disabled:cursor-not-allowed disabled:hover:text-gray-400`}
         >
           <span className="max-w-[200px] truncate">
-            {models.length === 0
-              ? "No API Key"
-              : selected?.label ?? "Select model"}
+            {keyStatusLoading
+              ? (selected?.label ?? "Select model")
+              : models.length === 0
+                ? "No API Key"
+                : (selected?.label ?? "Select model")}
           </span>
           <ChevronDown
             className={`h-3 w-3 shrink-0 transition-transform duration-200 ${

--- a/word-addin/src/taskpane/hooks/useSelectedModel.ts
+++ b/word-addin/src/taskpane/hooks/useSelectedModel.ts
@@ -1,5 +1,9 @@
 import { useCallback, useState } from "react";
-import { DEFAULT_MODEL_ID, isAllowedModelId } from "../lib/modelCatalog";
+import {
+  DEFAULT_MODEL_ID,
+  canonicalModelId,
+  isAllowedModelId,
+} from "../lib/modelCatalog";
 
 const STORAGE_KEY = "mike.selectedModel";
 // Substituted at bundle time; a `typeof process` guard is false in the browser
@@ -11,7 +15,11 @@ const DEFAULT_MODEL = isAllowedModelId(CONFIGURED_DEFAULT_MODEL)
 
 function readStoredModel(): string {
   try {
-    const stored = window.localStorage.getItem(STORAGE_KEY);
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    // Map renamed static ids to their current equivalents before validating,
+    // so a selection stored before a catalog rename keeps working — matching
+    // the web composer, which reads the same storage key.
+    const stored = raw ? canonicalModelId(raw) : null;
     return stored && isAllowedModelId(stored) ? stored : DEFAULT_MODEL;
   } catch {
     return DEFAULT_MODEL;
@@ -20,7 +28,8 @@ function readStoredModel(): string {
 
 export function useSelectedModel(): [string, (model: string) => void] {
   const [model, setModelState] = useState(readStoredModel);
-  const setModel = useCallback((next: string): void => {
+  const setModel = useCallback((raw: string): void => {
+    const next = canonicalModelId(raw);
     const validated = isAllowedModelId(next) ? next : DEFAULT_MODEL;
     setModelState(validated);
     try {

--- a/word-addin/src/taskpane/lib/composerPreflight.ts
+++ b/word-addin/src/taskpane/lib/composerPreflight.ts
@@ -1,0 +1,32 @@
+/**
+ * Retry-once loader for the composer's preflight requests (API key status and
+ * user profile). Word's WKWebView drops requests often enough that a single
+ * failed fetch used to leave the composer stuck on "No API Key" until the
+ * pane reloaded; one retry with a short backoff absorbs the common transient,
+ * and a final failure resolves to null so callers can fail open instead of
+ * blocking sends the backend would accept.
+ */
+export async function loadWithRetry<T>(
+  load: () => Promise<T>,
+  options: {
+    retries?: number;
+    delayMs?: number;
+    onFinalFailure?: (error: unknown) => void;
+  } = {},
+): Promise<T | null> {
+  const retries = options.retries ?? 1;
+  const delayMs = options.delayMs ?? 750;
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0 && delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs * attempt));
+    }
+    try {
+      return await load();
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  options.onFinalFailure?.(lastError);
+  return null;
+}

--- a/word-addin/src/taskpane/lib/modelCatalog.ts
+++ b/word-addin/src/taskpane/lib/modelCatalog.ts
@@ -1,4 +1,7 @@
-import type { ApiKeyStatus } from "../api/mikeApi";
+// Imported from the base client (not the ../api/mikeApi barrel) so this
+// module's compile graph stays free of Office globals: the drift-guard test in
+// frontend/src/wordAddin imports this file across packages.
+import type { ApiKeyStatus } from "../api/client";
 
 /**
  * Keep this catalog, its labels, and DEFAULT_MODEL_ID in sync with
@@ -74,6 +77,29 @@ export function modelDisplayName(modelId: string): string {
     .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
     .join(" ");
   return `${label} (${variantLabel})`;
+}
+
+/**
+ * The stored selection is the router's raw catalog id (e.g.
+ * "anthropic/claude-sonnet-4.5" or "openrouter/auto"); the app-level model id
+ * always prefixes the router slug verbatim, with no inner stripping, so both
+ * this client and the web app send the identical string for the same stored
+ * selection ("openrouter/openrouter/auto" for OpenRouter's "openrouter/auto").
+ */
+export function openRouterModelOptions(models: string[]): ModelOption[] {
+  return models.map((model) => ({
+    id: `openrouter/${model}`,
+    label: modelDisplayName(model),
+    group: "OpenRouter",
+  }));
+}
+
+export function vercelModelOptions(models: string[]): ModelOption[] {
+  return models.map((model) => ({
+    id: `vercel/${model}`,
+    label: modelDisplayName(model),
+    group: "Vercel AI Gateway",
+  }));
 }
 
 export function isAllowedModelId(id: string): boolean {

--- a/word-addin/src/taskpane/lib/modelCatalog.ts
+++ b/word-addin/src/taskpane/lib/modelCatalog.ts
@@ -46,6 +46,23 @@ export const ALLOWED_MODEL_IDS = new Set(
   STATIC_MODELS.map((model) => model.id),
 );
 
+/**
+ * Renamed/retired static ids → their current equivalents. The pane stores its
+ * selection under the same "mike.selectedModel" key the web app uses, so a
+ * value written before a catalog rename must resolve the same way in both
+ * clients. Kept in sync with backend/src/lib/llm/models.ts LEGACY_MODEL_IDS
+ * and frontend ModelToggle.tsx — the drift guard in
+ * frontend/src/wordAddin/catalogParity.test.ts pins it.
+ */
+export const LEGACY_MODEL_IDS: Record<string, string> = {
+  "gemini-3.1-flash-lite-preview": "gemini-3.5-flash-lite",
+  "gpt-5.4-lite": "gpt-5.4-mini",
+};
+
+export function canonicalModelId(id: string): string {
+  return LEGACY_MODEL_IDS[id] ?? id;
+}
+
 const MODEL_NAME_ACRONYMS: Record<string, string> = {
   ai: "AI",
   gpt: "GPT",

--- a/word-addin/src/taskpane/lib/modelCatalog.ts
+++ b/word-addin/src/taskpane/lib/modelCatalog.ts
@@ -116,9 +116,13 @@ export function isModelAvailable(
   status: ApiKeyStatus | null,
 ): boolean {
   if (modelId.startsWith("ollama/")) return true;
-  if (modelId.startsWith("openrouter/")) return !!status?.openrouter;
-  if (modelId.startsWith("vercel/")) return !!status?.vercel;
-  if (!status) return false;
+  // Unknown status (the key-status preflight failed even after a retry) fails
+  // OPEN: the backend authoritatively rejects a model it cannot serve, so
+  // blocking sends here on a flaky WKWebView request would brick the composer
+  // for requests the backend would happily accept.
+  if (!status) return true;
+  if (modelId.startsWith("openrouter/")) return !!status.openrouter;
+  if (modelId.startsWith("vercel/")) return !!status.vercel;
   const model = STATIC_MODELS.find((item) => item.id === modelId);
   if (!model || model.group === "Local") return false;
   if (model.group === "Anthropic") return !!status.claude;


### PR DESCRIPTION
## Summary

Part **1 of 3** of a fix stack for #350 (model routing), which merged before these review findings were addressed. A 4-agent review + adversarial validation of #350 found the issues below; this PR fixes the model-router ones. (Parts 2 and 3 fix the ask-inputs and document-version findings; each is based on the branch before it.)

Each fix is one commit with a test demonstrated to fail before the fix:

| # | Severity | Fix |
|---|---|---|
| F1 | high | Catalog ids beginning with the router's own slug (`openrouter/auto`, `vercel/v0-*`) no longer 400 the entire profile save; web and Word add-in now send identical composer model strings (the add-in's divergent inner-prefix strip is removed) |
| F2 | medium | Router models are validated against the user's saved selection at request time — closes the "any authenticated user spends the operator's env key on any model" hole. Explicitly-requested unselected models get a visible stream error; stored title/tabular prefs degrade silently with a server warn |
| F3 | medium | A missing `user_router_models` table (deploy-before-migrate) degrades reads to empty selections instead of 500ing profile + every chat |
| F5 | medium | Combobox Enter adds the typed model id verbatim; catalog rows require explicit highlight — typing `qwen/qwen-2` no longer silently adds `qwen/qwen-2.5-72b-instruct` |
| F6 | high | Three-state availability (loading / loaded / failed-open): no "No API Key" flash on load; a failed key-status fetch retries once then fails open instead of bricking the composer. (A companion commit guards the stale-selection reset introduced *by this PR* so a degraded profile can't wipe the saved model — that hazard was caught by pre-push adversarial review and never existed on main) |
| F7 | low×5 | Catalog route honors `OPENROUTER_BASE_URL`; truncated tool-call JSON errors instead of executing the tool with `{}` (keyed on clean stream termination); SSE tail flushed on unclean close; `LEGACY_MODEL_IDS` for #350's renamed models (`gemini-3.1-flash-lite-preview`→`gemini-3.5-flash-lite`, `gpt-5.4-lite`→`gpt-5.4-mini`) so stored prefs don't orphan; stale localStorage router selection reset on healthy profile load |
| F8 | low | DB hardening via a **new migration** (see below): advisory xact lock in `replace_user_router_models` (concurrent-save unique-violation race); honest >50-models error message |
| F9 | high (scoped) | Cross-package drift-guard test pinning the add-in's hand-mirrored catalog (ids, groups, display names, composer strings, legacy map) to the web's — hand-edits that drift now fail CI |

## Migration

#350's `20260818_01` is merged and may be deployed, so the hardening lands as a **new migration** rather than an edit:

```
psql "$DB" -v ON_ERROR_STOP=1 -f backend/migrations/20260819_01_harden_replace_user_router_models.sql
```

`schema.sql` carries the final hardened definition; the fresh-vs-upgraded drift check passes.

## Base-case replication (on current `main`, which contains #350)

1. **F1**: `curl -X PATCH $API/user/profile -H "Authorization: Bearer $JWT" -H 'Content-Type: application/json' -d '{"openRouterModels":["openrouter/auto"]}'` → `400 "invalid or duplicate model ID"` — OpenRouter's real `openrouter/auto` (Auto Router) cannot be saved. In the UI: the tools-capability filter keeps Auto Router out of the dropdown, so the path a user actually hits is *typing* the id — the field's own hint says "Press Enter to add this model ID", and Enter then rejects it client-side too.
2. **F2** (deployment with `OPENROUTER_API_KEY` env set; model NOT saved in your selection): `curl -N -X POST $API/chat/stream … -d '{"messages":[…],"model":"openrouter/openai/o3-pro"}'` → streams from o3-pro on the operator's key.
3. **F5**: Settings → Routers, type the full valid id `qwen/qwen-2`, press Enter → the pill shows `qwen/qwen-2.5-72b-instruct`, not what you typed.
4. **F6**: kill the backend (or block `/user/profile`), reload the assistant → composer stuck on disabled "No API Key"; the same label flashes on every healthy load while the profile fetch is in flight. (The localStorage-wipe scenario is *not* reproducible on main — it was a hazard of this PR's own stale-selection reset, caught before push; no before/after on main exists for it.)
5. **F7b**: kill the connection mid-tool-call (or point `OPENROUTER_BASE_URL` at a stub that truncates after the tool-call name delta) → the side-effecting tool executes with empty `{}` input.

## PR replication (this branch)

1. **F1**: same PATCH → `200`, echoes `["openrouter/auto"]`; both clients send `openrouter/openrouter/auto`; the adapter forwards `openrouter/auto` upstream.
2. **F2**: same request → a clear stream error ("not in your saved OpenRouter models — add it in Settings"); after saving the model it runs as requested. Stored title/tabular prefs degrade silently to the default with a `[router-models]` server warn.
3. **F5**: the pill reads `qwen/qwen-2`; catalog rows need explicit ArrowDown/hover highlight; the "Press Enter to add this model ID." hint shows whenever the text is id-shaped; non-id text on Enter gives feedback instead of a silent no-op.
4. **F6**: loading shows a neutral disabled trigger; failure retries once (~750 ms) then fails open with a console.warn — the backend stays the authority. A genuinely loaded no-key status still shows "No API Key". The PR's new stale-selection reset only ever runs on a *healthy* profile load, never a degraded or loading one.
5. **F7b**: the turn errors ("truncated tool call") and the tool does not execute.

## Tradeoffs & design decisions

- **F2 blocks BYOK users too**: even with your own key, an unselected router model errors — uniform "your selection is the allowlist" semantics over a per-key carve-out.
- **Not included — BYOK-vs-env key precedence (considered, deliberately dropped).** A review finding proposed making the two router providers "user-key-first" so a saved BYOK key would outrank the operator's env key. On inspection this is inert: `PUT /user/api-keys/:provider` already returns 409 ("configured by the server environment and cannot be changed from the browser") whenever an env key is set, so a user can never create the stored row the precedence change would prefer. Making it functional means letting the browser override a server-configured key — a security/product decision this stack does not make unilaterally. The commit was therefore dropped; if you want it, it needs to be paired with a router-scoped exception to that 409 guard, and would carry two follow-ups (a saved-but-revoked router key would then outrank a working env key until fixed; the key-status `source` field would need to report "user" for it).
- **F3 makes reads tolerant only** — a Settings save on an un-migrated DB still fails loudly (writes shouldn't silently no-op).
- **Catalog ids of shape `<router>/<a>/<b>` are structurally lossy** (indistinguishable from composer form; normalized to `<a>/<b>`). None exist in today's catalogs.
- **Combobox pointer hover still claims the Enter highlight** (standard combobox mouse behavior); only *typing* no longer auto-claims it.
- **The advisory lock uses `hashtextextended(…, 0)`** matching the repo's existing advisory-lock convention.
- **The legacy-copy sanitization reviewed earlier was dropped, not shipped**: `20260818_01` (merged) guards its `openrouter_models` copy behind a column-exists check, and no migration ever creates that column — the block is a shim for an unreleased intermediate state and is unreachable on every real deployment. A DB that somehow carries the column with malformed values would fail `20260818_01` itself and needs data cleanup, not a follow-up migration.
- **Shared-package extraction of the duplicated web/add-in catalog is not done** — the F9 parity test is the interim enforcement; a real `packages/` extraction is the follow-up that removes the duplication F1 had to align by hand.

## Verification

- Backend + frontend: `tsc` clean, full vitest suites green; word add-in typecheck (app + e2e) clean — at this branch's tip and re-verified after the post-merge rebase.
- Every fix commit's test was shown failing against the unfixed code (stash-and-run or commit-order proof).
- F8's SQL was exercised against a live Postgres in a rolled-back transaction.
- Migration ↔ `schema.sql` parity: table + function definitions byte-identical.
- Drift guard proven live: hand-editing one add-in catalog label fails the suite.

## Before / After evidence

Reproduced live on the local stack — **before** on `main` @83b5ce0 (which contains #350), **after** on this branch. GIFs ≤20 s.

### F1 — real catalog id `openrouter/auto` can be saved

The Auto Router is filtered out of the dropdown by the tools-capability query, so the real path is *typing* the id. Before: Enter is rejected client-side (and the PATCH 400s server-side). After: the typed id is accepted and saved.

| Before (main) | After (this PR) |
|---|---|
| <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f1-before.gif" width="420"> | <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f1-after.gif" width="420"> |

Server-side half of the before: <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f1-before-curl.png" width="640"> — `PATCH /user/profile {"openRouterModels":["openrouter/auto"]}` → 400 "invalid or duplicate model ID".

### F2 — an unselected router model no longer spends the operator's env key

Identical hand-crafted `POST /chat` for `openrouter/openai/o3-pro` (never saved). Before: the request reaches openrouter.ai on the operator's env key (proven by the upstream 401). After: refused before any upstream call.

| Before (main) | After (this PR) |
|---|---|
| <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f2-before.png" width="420"> | <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f2-after.png" width="420"> |

### F3 — missing `user_router_models` table degrades gracefully

The table is renamed away (deploy-before-migrate). Before: `/user/profile` 500s → the whole composer is disabled ("No API key configured"). After: the app loads, the composer stays enabled and the message dispatches. (The trailing "Gemini 400" in the after clip is an unrelated dummy/no-credit env-key artifact, not the fault.)

| Before (main) | After (this PR) |
|---|---|
| <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f3-before.png" width="420"> | <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f3-after.gif" width="420"> |

### F5 — typing an exact catalog id + Enter adds *that* id

Type `z-ai/glm-5`, press Enter with no highlight. Before: the longer look-alike `z-ai/glm-5.2` is added. After: the typed `z-ai/glm-5` is added.

| Before (main) | After (this PR) |
|---|---|
| <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f5-before.gif" width="420"> | <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f5-after.gif" width="420"> |

### F6 — composer fails open, not to a "No API Key" brick

Backend killed mid-clip, then reload. Before: the composer trigger is a disabled "No API Key" and history/quick-actions are gone. After: it fails open — the real model trigger and picker stay usable.

| Before (main) | After (this PR) |
|---|---|
| <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f6-brick-before.gif" width="420"> | <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f6-brick-after.gif" width="420"> |

### F7 (legacy ids) — a stored `gpt-5.4-lite` maps to its successor instead of silently swapping vendor

Same stored pref (`gpt-5.4-lite`, the user's OpenAI pick, a pre-rename id). Before: the backend discards the unknown id and substitutes the *default* — `/user/profile` returns `gemini-3.5-flash-lite` and Settings shows it as if chosen (a silent OpenAI→Google swap). After: the legacy map resolves it to `gpt-5.4-mini`; Settings shows "GPT-5.4 Mini".

| Before (main) | After (this PR) |
|---|---|
| <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f7d-before.png" width="420"><br><img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f7d-before-ui.png" width="420"> | <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f7d-after.png" width="420"><br><img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f7d-after-ui.png" width="420"> |

### F7b / F8 — non-UI fixes (test evidence)

These are backend behaviors, shown as the passing suites that pin them.

| F7b — truncated tool-call arguments fail the stream | F8 — router concurrency + honest 50-model cap |
|---|---|
| <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f7b-tests.png" width="420"> | <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-f8-tests.png" width="420"> |

### Happy path (b-roll, main)

Searching a real id and clicking the row saves it — the intended flow, working on main: <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/353-routers-happy.gif" width="480">

> Honesty notes carried from the review: **F1** is demonstrated by *typing* the id (the Auto Router is not a clickable dropdown row on either side, because the catalog query filters it out). The **F6 localStorage-wipe** scenario is not reproducible on `main` (it was a hazard of this PR's own stale-selection reset, caught pre-push) — no before/after exists for it. **F7d**'s harm is the visible OpenAI→Gemini swap; the Gemini rename masks itself because the default equals its successor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
