### PR TITLE
[Ask input findings] Ask-inputs caps and failed-submit recovery

### DIFF
--- a/backend/src/lib/chat/__tests__/requestValidation.test.ts
+++ b/backend/src/lib/chat/__tests__/requestValidation.test.ts
@@ -233,6 +233,58 @@ describe("chat request validation", () => {
         });
     });
 
+    it("measures answers against the limit the way it stores them", () => {
+        // The normalizer trims BEFORE it truncates, so an answer of exactly
+        // the limit plus surrounding whitespace persists intact. Measuring the
+        // raw string rejected it with a 400 the storage layer would never have
+        // hit — and on the ask-inputs path a 400 costs the user their answers.
+        const atLimit = "a".repeat(1_000);
+
+        expect(
+            parseOptionalAskInputsResponse({
+                type: "ask_inputs_response",
+                responses: [
+                    {
+                        id: "choice-1",
+                        kind: "choice",
+                        question: "Governing law?",
+                        answer: `${atLimit}\n`,
+                    },
+                ],
+            }),
+        ).toEqual({
+            ok: true,
+            value: {
+                responses: [
+                    {
+                        id: "choice-1",
+                        kind: "choice",
+                        question: "Governing law?",
+                        answer: atLimit,
+                    },
+                ],
+            },
+        });
+
+        // One real character past the limit is still a 400.
+        expect(
+            parseOptionalAskInputsResponse({
+                type: "ask_inputs_response",
+                responses: [
+                    {
+                        id: "choice-1",
+                        kind: "choice",
+                        question: "Governing law?",
+                        answer: `  ${atLimit}a  `,
+                    },
+                ],
+            }),
+        ).toMatchObject({
+            ok: false,
+            detail: "ask_inputs_response.responses[0].answer must be at most 1000 characters",
+        });
+    });
+
     it.each([
         ["answer", "ask_inputs_response must be an object"],
         [

--- a/backend/src/lib/chat/__tests__/requestValidation.test.ts
+++ b/backend/src/lib/chat/__tests__/requestValidation.test.ts
@@ -273,6 +273,19 @@ describe("chat request validation", () => {
             {
                 responses: [
                     {
+                        id: "choice-1",
+                        kind: "choice",
+                        question: "Governing law?",
+                        answer: "a".repeat(1_001),
+                    },
+                ],
+            },
+            "ask_inputs_response.responses[0].answer must be at most 1000 characters",
+        ],
+        [
+            {
+                responses: [
+                    {
                         id: "docs-1",
                         kind: "documents",
                         filenames: ["valid.pdf", 42],

--- a/backend/src/lib/chat/contextBuilders.ts
+++ b/backend/src/lib/chat/contextBuilders.ts
@@ -10,6 +10,7 @@ import {
   type ChatMessage,
   type AskInputsResponseRequest,
   type AskInputResponseItem,
+  MAX_ASK_INPUT_CHOICE_LENGTH,
   MAX_ASK_INPUT_TEXT_LENGTH,
   devLog,
 } from "./types";
@@ -364,7 +365,9 @@ export function parseAskInputsResponsePayload(
                 .trim()
                 .slice(
                   0,
-                  kind === "text" ? MAX_ASK_INPUT_TEXT_LENGTH : 1_000,
+                  kind === "text"
+                    ? MAX_ASK_INPUT_TEXT_LENGTH
+                    : MAX_ASK_INPUT_CHOICE_LENGTH,
                 )
             : "";
         if (!question || (!answer && !skipped)) return null;

--- a/backend/src/lib/chat/requestValidation.ts
+++ b/backend/src/lib/chat/requestValidation.ts
@@ -1,5 +1,6 @@
 import { parseAskInputsResponsePayload } from "./contextBuilders";
 import {
+  MAX_ASK_INPUT_CHOICE_LENGTH,
   MAX_ASK_INPUT_TEXT_LENGTH,
   type AskInputsResponseRequest,
   type ChatMessage,
@@ -336,14 +337,23 @@ export function parseOptionalAskInputsResponse(
           detail: `${field}.answer must be a non-empty string unless skipped`,
         };
       }
+      // Both answer kinds are capped here, at the same limits the
+      // persistence layer truncates to. Without the choice cap, an
+      // oversized choice answer is accepted, echoed into this turn's
+      // prompt in full, and only silently shortened when it is stored
+      // and replayed — so the model sees one answer now and a
+      // different one later.
+      const maxAnswerLength =
+        response.kind === "text"
+          ? MAX_ASK_INPUT_TEXT_LENGTH
+          : MAX_ASK_INPUT_CHOICE_LENGTH;
       if (
-        response.kind === "text" &&
         typeof response.answer === "string" &&
-        response.answer.length > MAX_ASK_INPUT_TEXT_LENGTH
+        response.answer.length > maxAnswerLength
       ) {
         return {
           ok: false,
-          detail: `${field}.answer must be at most ${MAX_ASK_INPUT_TEXT_LENGTH} characters`,
+          detail: `${field}.answer must be at most ${maxAnswerLength} characters`,
         };
       }
       continue;

--- a/backend/src/lib/chat/requestValidation.ts
+++ b/backend/src/lib/chat/requestValidation.ts
@@ -347,9 +347,14 @@ export function parseOptionalAskInputsResponse(
         response.kind === "text"
           ? MAX_ASK_INPUT_TEXT_LENGTH
           : MAX_ASK_INPUT_CHOICE_LENGTH;
+      // Measured on the TRIMMED string, because that is what gets stored:
+      // parseAskInputsResponsePayload trims before it truncates. Comparing the
+      // raw length rejected an answer of exactly the limit that happened to
+      // carry a trailing newline — a 400 the persistence layer would never
+      // have produced, and on this path a 400 costs the user their answers.
       if (
         typeof response.answer === "string" &&
-        response.answer.length > maxAnswerLength
+        response.answer.trim().length > maxAnswerLength
       ) {
         return {
           ok: false,

--- a/backend/src/lib/chat/types.ts
+++ b/backend/src/lib/chat/types.ts
@@ -137,6 +137,7 @@ export type AskInputOption = {
 };
 
 export const MAX_ASK_INPUT_TEXT_LENGTH = 5_000;
+export const MAX_ASK_INPUT_CHOICE_LENGTH = 1_000;
 
 export type AskInputItem =
   | {

--- a/frontend/src/app/components/assistant/AskInputPopup.test.tsx
+++ b/frontend/src/app/components/assistant/AskInputPopup.test.tsx
@@ -58,6 +58,49 @@ describe("AskInputPopup", () => {
         expect(onSubmit.mock.calls[0][2]).toEqual([]);
     });
 
+    it("clamps an 'Other' choice answer to the choice limit", async () => {
+        // A choice answer travels the CHOICE path, whose server limit is 1,000
+        // — not the 5,000 of a text item. Unclamped, a long paste was accepted
+        // by the UI, rejected by the request layer, and then lost: the card is
+        // hidden the moment submit fires and does not come back.
+        const onSubmit = vi.fn();
+        render(
+            <AskInputPopup
+                event={{
+                    type: "ask_inputs",
+                    items: [
+                        {
+                            id: "governing-law",
+                            kind: "choice",
+                            question: "Which governing law?",
+                            options: [{ value: "Singapore" }],
+                            allow_other: true,
+                            other_label: "Other",
+                        },
+                    ],
+                }}
+                onSubmit={onSubmit}
+            />,
+        );
+
+        fireEvent.click(screen.getByText("Other"));
+        const other = screen.getByRole("textbox", { name: "Other" });
+        expect(other).toHaveAttribute("maxlength", "1000");
+        expect(screen.getByText("0 / 1,000")).toBeInTheDocument();
+
+        fireEvent.change(other, { target: { value: "y".repeat(1_400) } });
+        expect(other).toHaveValue("y".repeat(1_000));
+        expect(screen.getByText("1,000 / 1,000")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+        expect(onSubmit.mock.calls[0][0].responses[0]).toMatchObject({
+            id: "governing-law",
+            kind: "choice",
+            answer: "y".repeat(1_000),
+        });
+    });
+
     it("requires confirmation again after a confirmed answer is edited", async () => {
         const onSubmit = vi.fn();
         render(

--- a/frontend/src/app/components/assistant/AskInputPopup.tsx
+++ b/frontend/src/app/components/assistant/AskInputPopup.tsx
@@ -16,6 +16,10 @@ type AskInputsResponse = Extract<
 >;
 
 const OPEN_TEXT_MAX_LENGTH = 5_000;
+// Mirrors the backend's MAX_ASK_INPUT_CHOICE_LENGTH. A choice answer typed
+// into "Other" travels the choice path, not the text path, so it is the
+// 1,000-character limit that applies — not the textarea's 5,000.
+const MAX_CHOICE_LENGTH = 1_000;
 
 export function AskInputPopup({
     event,
@@ -654,8 +658,11 @@ function OptionInput({
                             <span className="min-w-0 flex-1 flex items-start gap-2">
                                 <textarea
                                     name={`other-${item.id}`}
+                                    aria-label={item.other_label || "Other"}
+                                    aria-describedby={`other-${item.id}-limit`}
                                     rows={1}
                                     autoFocus
+                                    maxLength={MAX_CHOICE_LENGTH}
                                     value={otherValue}
                                     disabled={disabled}
                                     onFocus={(e) => {
@@ -665,13 +672,25 @@ function OptionInput({
                                         e.target.style.height = `${e.target.scrollHeight}px`;
                                     }}
                                     onChange={(e) => {
-                                        onOtherValue(e.target.value);
+                                        onOtherValue(
+                                            e.target.value.slice(
+                                                0,
+                                                MAX_CHOICE_LENGTH,
+                                            ),
+                                        );
                                         e.target.style.height = "auto";
                                         e.target.style.height = `${e.target.scrollHeight}px`;
                                     }}
                                     placeholder="Type your answer..."
                                     className="flex-1 resize-none overflow-hidden bg-transparent text-sm leading-5 text-gray-600 outline-none placeholder:text-gray-400"
                                 />
+                                <span
+                                    id={`other-${item.id}-limit`}
+                                    className="mt-0.5 shrink-0 font-sans text-[10px] text-gray-400"
+                                >
+                                    {otherValue.length.toLocaleString()} /{" "}
+                                    {MAX_CHOICE_LENGTH.toLocaleString()}
+                                </span>
                             </span>
                         ) : (
                             <span className="min-w-0 flex-1 text-sm text-gray-700">

--- a/frontend/src/app/components/assistant/ChatView.askInputs.test.tsx
+++ b/frontend/src/app/components/assistant/ChatView.askInputs.test.tsx
@@ -125,6 +125,23 @@ describe("ChatView ask-inputs submission", () => {
         );
     });
 
+    it("restores the questions when the submit resolves null (swallowed transport error)", async () => {
+        // The shipped useAssistantChat.handleChat does not reject on a
+        // transport/stream failure — it catches the error, renders it inline,
+        // and resolves null. A guard that only watched for a rejection would
+        // miss the most common failure (a down backend), leaving the card
+        // hidden and the answers lost. A falsy resolution must restore them too.
+        const handleChat = vi.fn(async () => null);
+        renderChatView(handleChat);
+
+        fireEvent.click(screen.getByTestId("ask-input-popup"));
+        await waitFor(() => expect(handleChat).toHaveBeenCalledTimes(1));
+
+        await waitFor(() =>
+            expect(screen.getByTestId("ask-input-popup")).toBeInTheDocument(),
+        );
+    });
+
     it("keeps the questions hidden when the submit request succeeds", async () => {
         const handleChat = vi.fn(async () => "chat-1");
         renderChatView(handleChat);

--- a/frontend/src/app/components/assistant/ChatView.askInputs.test.tsx
+++ b/frontend/src/app/components/assistant/ChatView.askInputs.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Message } from "../shared/types";
+import { ChatView } from "./ChatView";
+
+vi.mock("./UserMessage", () => ({ UserMessage: () => null }));
+vi.mock("./AssistantMessage", () => ({ AssistantMessage: () => null }));
+vi.mock("./ChatInput", () => ({
+    ChatInput: () => <div data-testid="chat-input" />,
+}));
+vi.mock("./AssistantSidePanel", () => ({
+    AssistantSidePanel: () => null,
+    mergeAssistantSidePanelTab: vi.fn(),
+    reorderAssistantSidePanelTabs: vi.fn(),
+}));
+vi.mock("./AssistantWorkflowModal", () => ({
+    AssistantWorkflowModal: () => null,
+}));
+vi.mock("@/app/contexts/SidebarContext", () => ({
+    useSidebar: () => ({ setSidebarOpen: vi.fn() }),
+}));
+vi.mock("@/app/hooks/useFetchDocxBytes", () => ({
+    invalidateDocxBytes: vi.fn(),
+}));
+
+// Stands in for the real popup so the test is about ChatView's hide/unhide
+// bookkeeping, not about the popup's own form.
+vi.mock("./AskInputPopup", () => ({
+    AskInputPopup: ({
+        onSubmit,
+    }: {
+        onSubmit?: (
+            response: unknown,
+            content: string,
+            files: unknown[],
+        ) => void;
+    }) => (
+        <button
+            type="button"
+            data-testid="ask-input-popup"
+            onClick={() =>
+                onSubmit?.(
+                    {
+                        type: "ask_inputs_response",
+                        responses: [
+                            {
+                                id: "governing-law",
+                                kind: "choice",
+                                question: "Which governing law?",
+                                answer: "y".repeat(1_400),
+                            },
+                        ],
+                    },
+                    "Answers",
+                    [],
+                )
+            }
+        >
+            answer
+        </button>
+    ),
+}));
+
+const messages: Message[] = [
+    { role: "user", content: "Draft it" },
+    {
+        role: "assistant",
+        content: "",
+        events: [
+            {
+                type: "ask_inputs",
+                items: [
+                    {
+                        id: "governing-law",
+                        kind: "choice",
+                        question: "Which governing law?",
+                        options: [{ value: "Singapore" }],
+                        allow_other: true,
+                        other_label: "Other",
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+function renderChatView(handleChat: () => Promise<string | null>) {
+    return render(
+        <ChatView
+            chatId="chat-1"
+            messages={messages}
+            isResponseLoading={false}
+            handleChat={handleChat}
+            cancel={vi.fn()}
+        />,
+    );
+}
+
+class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+}
+
+describe("ChatView ask-inputs submission", () => {
+    beforeEach(() => {
+        vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it("restores the questions when the submit request rejects", async () => {
+        // Hiding the card on submit is optimistic and permanent for the
+        // session. If the request never reached the server, the user's typed
+        // answers are gone with no way back — so a rejection must undo it.
+        const handleChat = vi.fn(async () => {
+            throw new Error("Failed to fetch");
+        });
+        renderChatView(handleChat);
+
+        fireEvent.click(screen.getByTestId("ask-input-popup"));
+        await waitFor(() => expect(handleChat).toHaveBeenCalledTimes(1));
+
+        await waitFor(() =>
+            expect(screen.getByTestId("ask-input-popup")).toBeInTheDocument(),
+        );
+    });
+
+    it("keeps the questions hidden when the submit request succeeds", async () => {
+        const handleChat = vi.fn(async () => "chat-1");
+        renderChatView(handleChat);
+
+        fireEvent.click(screen.getByTestId("ask-input-popup"));
+        await waitFor(() => expect(handleChat).toHaveBeenCalledTimes(1));
+
+        await waitFor(() =>
+            expect(screen.queryByTestId("ask-input-popup")).toBeNull(),
+        );
+        expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+    });
+});

--- a/frontend/src/app/components/assistant/ChatView.tsx
+++ b/frontend/src/app/components/assistant/ChatView.tsx
@@ -804,33 +804,50 @@ export function ChatView({
                                     key={activeInput.key}
                                     event={activeInput.event}
                                     onSubmit={(response, content, files) => {
+                                        const submittedKey = activeInput.key;
                                         setHiddenAskInputKeys((prev) => {
                                             const next = new Set(prev);
-                                            next.add(activeInput.key);
+                                            next.add(submittedKey);
                                             return next;
                                         });
+                                        // Hiding the card is optimistic — it
+                                        // assumes the answers reached the
+                                        // server. If they did not, the hide is
+                                        // permanent for the session and the
+                                        // user's typed answers are lost, so put
+                                        // the questions back.
+                                        //
+                                        // handleChat resolves to the new chat
+                                        // id on success and to null on failure:
+                                        // it catches transport/stream errors,
+                                        // renders them inline, and resolves null
+                                        // rather than rejecting — so a falsy
+                                        // resolution is the failure signal for
+                                        // the common case (down backend, dropped
+                                        // stream). The .catch covers a genuine
+                                        // throw as well. A successful ask-inputs
+                                        // turn always yields a chat id (the
+                                        // chat_id event opens every stream), so
+                                        // null here never means success.
+                                        const restoreQuestions = () => {
+                                            setHiddenAskInputKeys((prev) => {
+                                                if (!prev.has(submittedKey))
+                                                    return prev;
+                                                const next = new Set(prev);
+                                                next.delete(submittedKey);
+                                                return next;
+                                            });
+                                        };
                                         void handleChat(
                                             { role: "user", content, files },
                                             {
                                                 askInputsResponse: response,
                                             },
-                                            // Hiding the card is optimistic —
-                                            // it assumes the answers reached
-                                            // the server. If the request
-                                            // rejects they did not, and the
-                                            // hide is permanent for the
-                                            // session, so the user's typed
-                                            // answers would be unrecoverable.
-                                            // Put the questions back instead.
-                                        ).catch(() => {
-                                            setHiddenAskInputKeys((prev) => {
-                                                if (!prev.has(activeInput.key))
-                                                    return prev;
-                                                const next = new Set(prev);
-                                                next.delete(activeInput.key);
-                                                return next;
-                                            });
-                                        });
+                                        )
+                                            .then((chatId) => {
+                                                if (!chatId) restoreQuestions();
+                                            })
+                                            .catch(restoreQuestions);
                                     }}
                                     onDismiss={() => {
                                         setHiddenAskInputKeys((prev) => {

--- a/frontend/src/app/components/assistant/ChatView.tsx
+++ b/frontend/src/app/components/assistant/ChatView.tsx
@@ -814,7 +814,23 @@ export function ChatView({
                                             {
                                                 askInputsResponse: response,
                                             },
-                                        );
+                                            // Hiding the card is optimistic —
+                                            // it assumes the answers reached
+                                            // the server. If the request
+                                            // rejects they did not, and the
+                                            // hide is permanent for the
+                                            // session, so the user's typed
+                                            // answers would be unrecoverable.
+                                            // Put the questions back instead.
+                                        ).catch(() => {
+                                            setHiddenAskInputKeys((prev) => {
+                                                if (!prev.has(activeInput.key))
+                                                    return prev;
+                                                const next = new Set(prev);
+                                                next.delete(activeInput.key);
+                                                return next;
+                                            });
+                                        });
                                     }}
                                     onDismiss={() => {
                                         setHiddenAskInputKeys((prev) => {


### PR DESCRIPTION
## Summary

Part **2 of 3** of the fix stack for #350 (base: `olp-pr/350-split-2-model-routers`). Fixes the ask-inputs findings from the #350 review + adversarial validation.

- **A1 (backend)**: choice answers get the same request-layer 400 as text answers (cap 1,000 chars, matching the persistence truncation). Previously an oversized choice answer was accepted and used in full for the current turn, but the stored event kept only 1,000 chars — so later turns replayed a *different* answer than the model was originally given. The comparison uses trimmed length so the 400 boundary matches the storage boundary exactly.
- **A1 client half**: the choice "Other" textarea is clamped to 1,000 chars (maxLength + slice + counter, mirroring the text item's 5,000 treatment). Without this, the new 400 was reachable from the shipped UI — and destructively so, because…
- **Recovery on failed submit**: when the ask-inputs submission fails — whether the chat call rejects *or* resolves null (the shipped `handleChat` swallows transport/stream errors and resolves null rather than rejecting) — the question card is un-hidden so the typed answers can be re-submitted instead of being lost for the session. Live testing initially caught that a `.catch`-only guard missed the resolve-null path; that gap is now closed (commit `79c89bd`, see the evidence section). The **A1 clamp above remains the load-bearing data-loss fix** — it stops the oversized-answer 400 from being reachable from the UI at all — and this makes the general failed-submit case non-destructive too.

## Base-case replication (on current `main`, which contains #350)

```bash
curl -i -X POST http://localhost:8000/chat \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d "{\"messages\":[{\"role\":\"user\",\"content\":\"continue\"}],
       \"ask_inputs_response\":{\"responses\":[{\"id\":\"choice-1\",\"kind\":\"choice\",
       \"question\":\"Governing law?\",\"answer\":\"$(python3 -c 'print("a"*1001)')\"}]}}"
```

→ `200`; the 1,001-char answer enters this turn's prompt while the stored event silently keeps 1,000 — replay divergence.

UI: trigger an ask-inputs question with options + "Other" (e.g. "Draft an NDA; ask me for the governing law"), paste a 1,400-char clause into Other, Confirm → on `main` this submits and silently truncates in storage.

## PR replication (this branch)

- Same curl → `400 …answer must be at most 1000 characters`. A 1,000-char answer with a trailing newline still passes (trimmed comparison). `kind:"text"` keeps its 5,000 cap; `POST /projects/:projectId/chat` shares the validator.
- Same UI steps → the Other textarea stops accepting input at 1,000 with a visible `1,000 / 1,000` counter; the request can never hit the 400 from the shipped UI.
- Fault injection: the un-hide guard returns the card whether the submit rejects *or* resolves null (both unit-tested), so a killed-backend submit no longer loses the typed answer. The clamp fix additionally means a valid UI answer never triggers the 400 in the first place.

## Tradeoffs & design decisions

- **Answers reach the model unfenced on the submitting turn — deliberately.** The submission composes a synthesized *user message*: the user speaking, at chat-box trust level. The nonce fence (already in #350) protects the **replay** path on later turns; this PR doesn't change fencing, it only caps lengths.
- **The persistence-layer truncation stays even though the validator now 400s** — the parser also reads rows stored before the cap existed. The browser clamp is a courtesy, not a security control.
- **`MAX_ASK_INPUT_CHOICE_LENGTH = 1_000`** is a new shared constant so the validator, the client clamp, and the storage truncation can't drift.

## Verification

- Backend: `tsc` clean, full vitest green. Frontend: `tsc` clean, full vitest green (re-verified after the post-merge rebase).
- The A1 test was added before the fix and failed exactly on the finding (1,001-char choice answer accepted); the client-clamp and unhide-on-reject tests likewise shown failing pre-fix.

## Before / After evidence

Reproduced live — **before** on `main` @83b5ce0, **after** on this branch. The ask-inputs card was triggered with a real Claude (`claude-sonnet-5`) turn: "draft a mutual NDA; ask me the governing law from options, allow Other".

### A1 — the "Other" choice answer is capped instead of silently truncated

Before: pasting 1,400 chars into Other shows **no counter and no limit**, Confirm submits — and the stored `ask_inputs_response` answer is silently 1,000 chars (the model saw 1,400 this turn, replay sees 1,000). After: the Other textarea clamps at 1,000 with a live `1,000 / 1,000` counter; a 1,001-char choice answer is rejected server-side with a 400.

| Before (main) | After (this PR) |
|---|---|
| <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/354-a1-before.png" width="420"> | <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/354-a1-after.png" width="420"> |
| DB truncation to 1,000: <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/354-a1-before-db.png" width="420"> | Server-layer 400: <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/354-a1-after-curl.png" width="420"> |

### Recovery on failed submit

**A note on how this evolved:** live testing first showed the recovery guard was incomplete — it fired only on a promise *rejection*, but the shipped `useAssistantChat.handleChat` catches transport/stream errors (a down backend's "Failed to fetch"), renders them inline, and *resolves null* instead of rejecting. So the most common failure — backend gone mid-submit — slipped past the guard and the answer was still lost, as the "before" screenshot shows. That gap is now **fixed** (commit `79c89bd`): the guard treats a **falsy resolution** as failure too, not only a throw. A successful ask-inputs turn always resolves to a chat id (the `chat_id` event opens every stream), so a null resolution unambiguously means the submit failed.

The proof is the unit test, which is the precise before/after for this promise-resolution logic: `ChatView.askInputs.test.tsx` gains "restores the questions when the submit resolves null (swallowed transport error)", which **fails** against the old `.catch`-only guard (the card stays hidden) and **passes** with the resolution check. The reject-path and success-path tests are unchanged and still pass.

| Before (main): answer lost on failed submit | The fix, unit-tested (fails on the old guard, passes now) |
|---|---|
| <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/354-recovery-before-2.png" width="420"> | <img src="https://raw.githubusercontent.com/Open-Legal-Products/mike/olp-pr/350-evidence-assets/docs/pr350-evidence/354-recovery-after-test.png" width="420"> |

The fix lives entirely in the ChatView submit handler; `handleChat`'s contract is untouched, so no other chat flow is affected. (The alternative — making `handleChat` reject distinguishably so every caller could branch on error — was rejected as a risky change to widely-used shared plumbing for one caller's benefit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
