### PR TITLE
feat: formalize design system on existing shadcn/Tailwind foundation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,22 @@ Thanks for helping improve Mike. Please keep contributions small, focused, and e
   infrastructure or migration requirements in the same PR.
 - Do not commit secrets, API keys, private documents, or local `.env` files.
 
+## Frontend UI Work
+
+Before writing a new component, check whether one already exists. Look first in
+`frontend/src/app/components/ui/` (and `frontend/src/shared/ui/` for anything the
+Word add-in also renders), then in the [shadcn/ui](https://ui.shadcn.com)
+registry — the project is configured for it in `frontend/components.json`, so
+`npx shadcn@latest add <component>` lands a component in the right place with
+the right style and tokens. Write a one-off in the feature directory only when
+the markup is genuinely specific to that feature; once the same markup shows up
+in a second feature file, promote it into `components/ui/` with a test and
+replace the copies. Use the documented color, typography, spacing and radius
+tokens rather than raw hex values, and keep the accessibility baseline (visible
+focus ring, accessible name on icon-only controls, `type="button"`, ARIA state
+alongside color). See [docs/design-system.md](docs/design-system.md) for the
+tokens, the primitive inventory, and the full baseline.
+
 ## Before Opening a PR
 
 - Run the relevant build or test command for the area you changed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,11 @@
 - [Tamper-evident exports](tamper-evident-exports.md) — document hashes and
   optional signed manifests
 
+## Frontend
+
+- [Design system](design-system.md) — color/typography/spacing tokens, the shared
+  `components/ui` primitives, and the accessibility baseline
+
 ## Testing and CI
 
 - [End-to-end tests in CI](e2e-ci.md)

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,222 @@
+# Design system
+
+Mike's UI is shadcn/ui (`new-york` style, see `frontend/components.json`) on
+Tailwind v4 with CSS-variable tokens, plus Lucide icons. This page documents what
+already exists so contributors can reuse it instead of re-deriving it. It is a
+description of the current system, not a proposal for a new one.
+
+Everything below lives in `frontend/src/app/globals.css` unless stated otherwise.
+
+## Where components live
+
+| Location | What belongs there |
+| --- | --- |
+| `frontend/src/app/components/ui/` | Shared web primitives. Small, unopinionated, no data fetching, no feature knowledge. |
+| `frontend/src/shared/ui/` | Primitives shared by the web app **and** the Word add-in. Framework-light: React, `lucide-react`, `clsx`, `tailwind-merge` only. |
+| `frontend/src/app/components/shared/` | App-level building blocks that assume the app shell — the table layer (`TablePrimitive.tsx`, `TableToolbar.tsx`), page headers, sidebars. |
+| `frontend/src/app/components/<feature>/` | Feature components. Compose the above; do not restate their markup. |
+
+`src/shared/ui/` may not import from `src/app/`. It is compiled into the add-in
+build, which has no Next.js app directory. When you add a file there you must
+also register it for Tailwind class scanning in
+`word-addin/src/taskpane/styles.css`:
+
+```css
+@source "../../../frontend/src/shared/ui/YourThingUI.tsx";
+```
+
+The convention for a cross-target primitive is a `XxxUI.tsx` in `src/shared/ui/`
+plus a thin re-export in `components/ui/` so web callers use one import path —
+see `GlassCardUI`/`glass-card.tsx`, `PillButtonUI`/`pill-button.tsx`, and
+`GlassIconButtonUI`/`glass-icon-button.tsx`.
+
+## Color tokens
+
+Two families coexist. Prefer a token over a raw Tailwind palette class whenever
+one exists; prefer either over a hex literal.
+
+### App surfaces (Mike's own)
+
+These back the "liquid glass" chrome and are the ones most feature code needs.
+
+| Token | Utility | Light value | Intent |
+| --- | --- | --- | --- |
+| `--app-background` | `bg-app-background` | `#f9fafb` | Page canvas behind panels. |
+| `--app-surface` | `bg-app-surface` | `#fdfdfe` | Resting surface of a panel, table header, menu. |
+| `--app-surface-hover` | `hover:bg-app-surface-hover` | `#f9fafb` | Row/item hover. |
+| `--app-surface-active` | `bg-app-surface-active` | `#eff0f3` | Selected or pressed row/item. |
+| `--app-floating` | `bg-app-floating` | `#fefefe` | Detached floating elements above a surface. |
+
+Use the class-name constants in `components/ui/liquid-surface.ts`
+(`APP_SURFACE_HOVER_CLASS`, `APP_SURFACE_ACTIVE_CLASS`,
+`LIQUID_PANEL_SURFACE_CLASS`, …) rather than retyping the utilities, so the
+hover/active pair stays consistent.
+
+`--color-azure: 0, 136, 255` is a raw RGB triple consumed as
+`rgb(var(--color-azure))` by the statute/regulation viewer styles.
+
+### shadcn semantic tokens
+
+The standard shadcn set is present and wired through `@theme inline`:
+`background`/`foreground`, `card`, `popover`, `primary`, `secondary`, `muted`,
+`accent`, `destructive`, `border`, `input`, `ring`, the `sidebar-*` family, and
+`chart-1`…`chart-5`. Values are `oklch()`; a `.dark` block overrides them.
+
+Use these when you pull a component from the shadcn registry, or when you want
+the meaning ("this is the destructive action") rather than a specific color.
+
+### Blue is overridden
+
+`@theme inline` redefines part of Tailwind's blue scale to Mike's azure:
+
+```css
+--color-blue:     rgb(0, 136, 255);
+--color-blue-50:  rgba(0, 136, 255, 0.05);
+--color-blue-100: rgba(0, 136, 255, 0.1);
+--color-blue-200: rgba(0, 136, 255, 0.3);
+--color-blue-600: rgb(0, 136, 255);
+--color-blue-700: rgb(0, 120, 230);
+```
+
+`bg-blue-600` is therefore Mike azure, not Tailwind blue. `blue-300`, `-400`,
+`-500`, `-800` and `-900` are *not* overridden, so the scale is discontinuous —
+stay on the overridden steps for brand blue.
+
+### Dark mode
+
+`@custom-variant dark (&:is(.dark *))` — class-based, not
+`prefers-color-scheme`. The shadcn tokens have `.dark` values; the `--app-*`
+surface tokens do **not**. Since the app chrome is built on `--app-*`, dark mode
+is currently incomplete. Do not treat a `dark:` variant as supported until those
+tokens gain dark values.
+
+## Typography
+
+Both faces are loaded with `next/font/google` in `frontend/src/app/layout.tsx`
+and exposed as CSS variables on `<body>`:
+
+| Face | Variable | Utility | Used for |
+| --- | --- | --- | --- |
+| Inter | `--font-inter` → `--font-sans` | `font-sans` (body default) | All UI text. |
+| EB Garamond | `--font-eb-garamond` → `--font-serif` | `font-serif` | Display headings, legal document body copy, tracked-change cards. |
+
+The Word add-in supplies the same two variables from
+`word-addin/src/taskpane/styles.css` (fonts loaded via `<link>` in
+`index.html`), so `shared/ui` components render identically in both targets.
+
+De facto type scale in the app chrome, most to least common: `text-xs` (dense
+table and control text — the default for most chrome), `text-sm` (body copy,
+normal-size buttons), `text-[10px]` (badges, superscript citations),
+`text-2xl font-serif` (display headings and empty states). There is no separate
+heading component; use `EmptyState` for empty-state headings and `PageHeader`
+for page titles so the display style stays in one place.
+
+## Spacing and radius
+
+There is no bespoke spacing scale — Tailwind's default applies. The de facto
+subset actually in use across `frontend/src/app/components`, by frequency:
+
+- Horizontal padding: `px-3` (dominant), `px-2`, `px-4`, `px-2.5`
+- Vertical padding: `py-2` (dominant), `py-1.5`, `py-1`, `py-0.5`
+- Gaps: `gap-2`, `gap-1.5`, `gap-1`, `gap-3`
+- Control heights: `h-7` (compact chrome: pills, icon buttons, table rows are
+  `h-10`), `h-8`, `h-9`, `h-10`
+
+Stick to those steps. A one-off `px-[13px]` is the kind of drift this document
+exists to prevent.
+
+Radius comes from one token, `--radius: 0.625rem`, with the shadcn scale derived
+from it (`--radius-sm/-md/-lg/-xl` = `radius -4px / -2px / radius / +4px`). In
+practice the app uses the plain Tailwind radii directly: `rounded-full` (pills,
+icon buttons), `rounded-lg`/`rounded-md` (rows, list items), `rounded-xl`
+(inputs, cards), `rounded-2xl` (panels, dropdown surfaces).
+
+## Elevation and the glass surface
+
+The signature surface is a translucent white "liquid glass" panel: a
+`border-white/70` hairline, a `bg-white/55`–`bg-white/65` fill, inset highlight
+shadows, and `backdrop-blur-xl`/`-2xl`. Do not retype the shadow triple. Use one
+of:
+
+- `GLASS_CARD_SURFACE_CLASS` / `GlassCard` — cards
+- `LIQUID_PANEL_SURFACE_CLASS`, `LIQUID_TABLE_SURFACE_CLASS`,
+  `APP_PANEL_SHADOW_CLASS` in `components/ui/liquid-surface.ts` — panels, tables
+- `LiquidDropdownContent` / `LiquidDropdownSurface` — menus
+- `GlassIconButton` — circular icon buttons
+- `.white-liquid-glass` in `globals.css` — the raw-CSS equivalent, for the few
+  places that cannot use Tailwind classes
+
+## Primitives in `components/ui/`
+
+| Primitive | Use it for |
+| --- | --- |
+| `button` | shadcn's button. Variant/size API, `asChild`. Note it has no `type` default — set `type="button"` inside a form. |
+| `pill-button` | The app's primary action button (`tone`: black/white/blue/danger). Shared with the add-in via `PillButtonUI`. |
+| `tab-pill-button` | Segmented filter/tab pills. Pass `active` to get `aria-pressed`. |
+| `glass-icon-button` | Circular glass icon button — modal close, panel dismiss. Requires `aria-label`. |
+| `cite-button` | Copy-quote-and-citation control. |
+| `input`, `form-field` | shadcn input; `FormTextInput` (glass/minimal variants) and `FieldLabel` for app forms. |
+| `search-bar` | Search input with clear button. Pass `label` for a meaningful accessible name. |
+| `toggle-switch` | `role="switch"` toggle with a text label. |
+| `dropdown-menu` | Radix/shadcn menu primitives. |
+| `liquid-dropdown` | The glass skin over `dropdown-menu` — use this in app chrome. |
+| `glass-card`, `liquid-surface` | Card component and shared surface class constants. |
+| `empty-state` | Icon + display heading + copy + optional action, for "nothing here yet". Wrap in `TableEmptyState` inside a table. |
+| `check-square` | The selection square used by directory/picker rows. Decorative by default; the row owns the ARIA state. |
+
+For a real standalone checkbox use `<input type="checkbox">` with
+`TABLE_CHECKBOX_CLASS` (see `TablePrimitive.tsx`), not `check-square`.
+
+## Choosing: existing primitive, shadcn registry, or a one-off
+
+Work down this list and stop at the first that fits.
+
+1. **A primitive in `components/ui/` (or `shared/ui/`) already does it.** Use
+   it. If it is 90% right, add a prop or a variant to the primitive rather than
+   forking it — a fork is how the duplication this document consolidates got
+   there in the first place.
+2. **A shadcn registry component does it.** Add it with the shadcn CLI so it
+   lands in `components/ui/` with the project's `new-york` style and CSS
+   variables, then adapt it in place. Prefer this over hand-rolling anything
+   with non-trivial interaction or ARIA (menus, dialogs, popovers, tooltips).
+3. **The markup is genuinely feature-specific and appears once.** Write it in
+   the feature directory. One occurrence is not a primitive.
+4. **The same markup now appears in two or more feature files.** Promote it:
+   move it into `components/ui/` with a small prop surface, replace every copy,
+   and add a test. Put it in `shared/ui/` instead only if the Word add-in needs
+   it too.
+
+Do not add a new UI dependency to solve something Tailwind plus an existing
+primitive covers.
+
+## Accessibility baseline
+
+These are the rules the primitives already follow. Match them in new work.
+
+- **Focus is always visible.** Every interactive primitive carries
+  `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40
+  focus-visible:ring-offset-2`. If you write `outline-none` you owe the element a
+  replacement indicator in the same class string.
+- **A background tint is not a focus indicator** when the tint is a ~1% luminance
+  step. `liquid-dropdown` items pair `focus:bg-app-surface-active` with a ring
+  for this reason.
+- **Icon-only controls need a name.** `GlassIconButton` requires `aria-label` in
+  its type. When a control has a *visible* label, do not override it with a
+  different `aria-label` (WCAG 2.5.3) — `cite-button` only sets one when its text
+  is hidden.
+- **`type="button"` on every non-submit button.** Anything inside a `<form>`
+  defaults to submitting.
+- **State goes in ARIA, not only in color.** `toggle-switch` uses
+  `role="switch"` + `aria-checked`, `tab-pill-button` uses `aria-pressed`,
+  `check-square` callers that own the interaction pass
+  `role="checkbox"` + `aria-checked` (`"mixed"` for indeterminate).
+- **Non-text contrast ≥ 3:1** for control boundaries (WCAG 1.4.11). The
+  off-state switch track needs `bg-gray-300 ring-1 ring-inset ring-gray-400` to
+  clear it against white; `bg-gray-100` does not.
+- **Decorative elements are hidden.** Icons inside a labelled control get
+  `aria-hidden`.
+
+## Related
+
+- Frontend test conventions: [frontend-testing.md](frontend-testing.md)
+- Component catalog (Storybook or Ladle): tracked in issue #323, not set up yet

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,9 +1,10 @@
 # Design system
 
-Mike's UI is shadcn/ui (`new-york` style, see `frontend/components.json`) on
-Tailwind v4 with CSS-variable tokens, plus Lucide icons. This page documents what
-already exists so contributors can reuse it instead of re-deriving it. It is a
-description of the current system, not a proposal for a new one.
+Mike uses Tailwind v4 with shadcn-derived `new-york` primitives for selected
+controls, alongside its own liquid-glass component system. Lucide supplies the
+icon set. This page documents what already exists so contributors can reuse it
+instead of re-deriving it. It is a description of the current system, not a
+proposal for a new one.
 
 Everything below lives in `frontend/src/app/globals.css` unless stated otherwise.
 

--- a/e2e/project-management.spec.ts
+++ b/e2e/project-management.spec.ts
@@ -311,7 +311,10 @@ test("file upload type validation — .txt file is rejected", async ({ page }) =
 
     const fileChooserPromise = page.waitForEvent("filechooser");
     /* The Upload button label is "Upload" (not "Uploading…") when idle */
-    await page.getByRole("button", { name: "Upload" }).first().click();
+    await page
+        .getByRole("dialog", { name: "Add Documents" })
+        .getByRole("button", { name: "Upload" })
+        .click();
     const fileChooser = await fileChooserPromise;
 
     /*

--- a/frontend/components.json
+++ b/frontend/components.json
@@ -12,11 +12,11 @@
   },
   "iconLibrary": "lucide",
   "aliases": {
-    "components": "@/components",
-    "utils": "@/lib/utils",
-    "ui": "@/components/ui",
-    "lib": "@/lib",
-    "hooks": "@/hooks"
+    "components": "@/app/components",
+    "utils": "@/app/lib/utils",
+    "ui": "@/app/components/ui",
+    "lib": "@/app/lib",
+    "hooks": "@/app/hooks"
   },
   "registries": {}
 }

--- a/frontend/src/app/components/documents/DocTable.tsx
+++ b/frontend/src/app/components/documents/DocTable.tsx
@@ -59,6 +59,8 @@ import {
 import { DocumentSidePanel } from "@/app/components/shared/DocumentSidePanel";
 import { TableLoadMoreRow } from "@/app/components/shared/TableLoadMoreRow";
 import { LibrarySkeuoIcon } from "@/app/components/shared/AppSidebarSkeuoIcons";
+import { EmptyState } from "@/app/components/ui/empty-state";
+import { PillButton } from "@/app/components/ui/pill-button";
 import {
     APP_SURFACE_ACTIVE_CLASS,
     APP_SURFACE_GROUP_HOVER_CLASS,
@@ -69,6 +71,7 @@ import {
     TableFilters,
     TableHeaderCell,
     TableHeaderRow,
+    TableEmptyState,
     TableScrollArea,
     TableStickyCell,
     type TableFilterOption,
@@ -136,7 +139,7 @@ interface DocTableProps {
     loading: boolean;
     search: string;
     operations: DocTableOperations;
-    emptyDropLabel?: string;
+    emptyStateTitle: string;
     renderAddDocumentsModal?: (
         open: boolean,
         onClose: () => void,
@@ -293,7 +296,7 @@ export function DocTable({
     loading,
     search,
     operations,
-    emptyDropLabel = "Drop PDF, Word, Excel, or PowerPoint files here",
+    emptyStateTitle,
     renderAddDocumentsModal,
     onAddDocumentsActionChange,
     onCreateFolderActionChange,
@@ -2684,10 +2687,27 @@ export function DocTable({
                                 ) : (
                                     <div
                                         onClick={openAddDocuments}
-                                        className="flex-1 flex cursor-pointer flex-col items-center justify-center py-24 text-center"
+                                        className="flex flex-1 cursor-pointer"
                                     >
-                                        <LibrarySkeuoIcon className="mb-3 h-8 w-8" />
-                                        <p className="text-sm text-gray-400">{emptyDropLabel}</p>
+                                        <TableEmptyState>
+                                            <EmptyState
+                                                icon={<LibrarySkeuoIcon />}
+                                                title={emptyStateTitle}
+                                                description="Upload documents or drop them here"
+                                                action={
+                                                    <PillButton
+                                                        tone="black"
+                                                        size="sm"
+                                                        onClick={(event) => {
+                                                            event.stopPropagation();
+                                                            openAddDocuments();
+                                                        }}
+                                                    >
+                                                        Upload
+                                                    </PillButton>
+                                                }
+                                            />
+                                        </TableEmptyState>
                                     </div>
                                 )
                             ) : (

--- a/frontend/src/app/components/library/LibraryWorkspace.tsx
+++ b/frontend/src/app/components/library/LibraryWorkspace.tsx
@@ -932,6 +932,7 @@ export function LibraryCollectionPage({
                     loading={loading}
                     search={search}
                     operations={operations}
+                    emptyStateTitle={title}
                     onAddDocumentsActionChange={handleAddDocumentsActionChange}
           onCreateFolderActionChange={handleCreateFolderActionChange}
                     onFolderViewBackActionChange={handleFolderBackActionChange}
@@ -956,11 +957,6 @@ export function LibraryCollectionPage({
           autoLoadOnScroll
                     enableHeaderFilters
                     defaultSort={{ key: "updated", direction: "desc" }}
-                    emptyDropLabel={
-                        kind === "templates"
-                            ? "Drop template files here"
-                            : "Drop PDF, Word, Excel, or PowerPoint files here"
-                    }
                 />
             </div>
         </div>

--- a/frontend/src/app/components/modals/ProjectPickerModal.tsx
+++ b/frontend/src/app/components/modals/ProjectPickerModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type ButtonHTMLAttributes, type ReactNode } from "react";
+import { CheckSquare } from "@/app/components/ui/check-square";
 import { SearchBar } from "@/app/components/ui/search-bar";
 import { ClosedProjectSvgIcon } from "@/app/components/shared/FolderSvgIcon";
 import type { Project } from "../shared/types";
@@ -107,13 +108,13 @@ export function ProjectPickerModal({
                                         }
                                         className={`w-full flex rounded-md items-center gap-2 px-2 py-2 text-xs transition-all text-left ${isSelected ? APP_SURFACE_ACTIVE_CLASS : APP_SURFACE_HOVER_CLASS}`}
                                     >
-                                        <span
-                                            className={`shrink-0 h-3.5 w-3.5 rounded border flex items-center justify-center ${isSelected ? "bg-gray-900 border-gray-900" : "border-gray-300"}`}
-                                        >
-                                            {isSelected && (
-                                                <span className="h-1.5 w-1.5 rounded-sm bg-white" />
-                                            )}
-                                        </span>
+                                        <CheckSquare
+                                            state={
+                                                isSelected
+                                                    ? "checked"
+                                                    : "unchecked"
+                                            }
+                                        />
                                         <ClosedProjectSvgIcon className="h-3.5 w-3.5 shrink-0" />
                                         <span
                                             className={`flex-1 truncate ${isSelected ? "text-gray-900" : "text-gray-700"}`}

--- a/frontend/src/app/components/projects/ProjectAssistantTable.tsx
+++ b/frontend/src/app/components/projects/ProjectAssistantTable.tsx
@@ -23,6 +23,7 @@ import {
     type TableSortDirection,
     TableStickyCell,
 } from "@/app/components/shared/TablePrimitive";
+import { EmptyState } from "@/app/components/ui/empty-state";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { ChatSkeuoIcon } from "@/app/components/shared/AppSidebarSkeuoIcons";
 import type { Chat } from "@/app/components/shared/types";
@@ -225,23 +226,22 @@ export function ProjectAssistantTable({
                 <ProjectAssistantLoadingRows />
             ) : chats.length === 0 ? (
                 <TableEmptyState>
-                    <ChatSkeuoIcon className="mb-4 h-8 w-8" />
-                    <p className="text-2xl font-medium font-serif text-gray-900">
-                        Assistant
-                    </p>
-                    <p className="mt-1 text-xs text-gray-400 max-w-xs">
-                        Ask questions and get answers grounded in the documents
-                        in this project.
-                    </p>
-                    <PillButton
-                        tone="black"
-                        size="sm"
-                        onClick={onCreateChat}
-                        className="mt-4 px-3"
-                    >
-                        <Plus className="h-3.5 w-3.5" />
-                        Create
-                    </PillButton>
+                    <EmptyState
+                        icon={<ChatSkeuoIcon />}
+                        title="Assistant"
+                        description="Ask questions and get answers grounded in the documents in this project."
+                        action={
+                            <PillButton
+                                tone="black"
+                                size="sm"
+                                onClick={onCreateChat}
+                                className="px-3"
+                            >
+                                <Plus className="h-3.5 w-3.5" />
+                                Create
+                            </PillButton>
+                        }
+                    />
                 </TableEmptyState>
             ) : (
                 <TableBody>

--- a/frontend/src/app/components/projects/ProjectDocumentsView.tsx
+++ b/frontend/src/app/components/projects/ProjectDocumentsView.tsx
@@ -322,6 +322,7 @@ export function ProjectDocumentsView({ projectId, folderId = null }: Props) {
                 loading={projectLoading}
                 search={search}
                 operations={operations}
+                emptyStateTitle="Documents"
                 onAddDocumentsActionChange={
                     workspace.setAddDocumentsHeaderAction
                 }

--- a/frontend/src/app/components/projects/ProjectReviewsTable.tsx
+++ b/frontend/src/app/components/projects/ProjectReviewsTable.tsx
@@ -24,6 +24,7 @@ import {
     type TableSortDirection,
     TableStickyCell,
 } from "@/app/components/shared/TablePrimitive";
+import { EmptyState } from "@/app/components/ui/empty-state";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { TabularReviewSkeuoIcon } from "@/app/components/shared/AppSidebarSkeuoIcons";
 import type { Document, TabularReview } from "@/app/components/shared/types";
@@ -247,26 +248,25 @@ export function ProjectReviewsTable({
                             No reviews found
                         </p>
                     ) : (
-                        <>
-                            <TabularReviewSkeuoIcon className="mb-4 h-8 w-8" />
-                            <p className="text-2xl font-medium font-serif text-gray-900">
-                                Tabular Reviews
-                            </p>
-                            <p className="mt-1 text-xs text-gray-400 max-w-xs">
-                                Extract data from project documents into tables
-                                using AI.
-                            </p>
-                            <PillButton
-                                tone="black"
-                                size="sm"
-                                onClick={onCreateReview}
-                                disabled={creatingReview || docs.length === 0}
-                                className="mt-4 px-3"
-                            >
-                                <Plus className="h-3.5 w-3.5" />
-                                Create
-                            </PillButton>
-                        </>
+                        <EmptyState
+                            icon={<TabularReviewSkeuoIcon />}
+                            title="Tabular Reviews"
+                            description="Extract data from project documents into tables using AI."
+                            action={
+                                <PillButton
+                                    tone="black"
+                                    size="sm"
+                                    onClick={onCreateReview}
+                                    disabled={
+                                        creatingReview || docs.length === 0
+                                    }
+                                    className="px-3"
+                                >
+                                    <Plus className="h-3.5 w-3.5" />
+                                    Create
+                                </PillButton>
+                            }
+                        />
                     )}
                 </TableEmptyState>
             ) : (

--- a/frontend/src/app/components/projects/ProjectsOverview.tsx
+++ b/frontend/src/app/components/projects/ProjectsOverview.tsx
@@ -46,6 +46,7 @@ import {
     type TableSortDirection,
     TableStickyCell,
 } from "@/app/components/shared/TablePrimitive";
+import { EmptyState } from "@/app/components/ui/empty-state";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { TabPillButton } from "@/app/components/ui/tab-pill-button";
 import { useQueryParamTab } from "@/app/hooks/useQueryParamTab";
@@ -559,45 +560,42 @@ export function ProjectsOverview() {
                     </TableBody>
                 ) : loadError ? (
                     <TableEmptyState>
-                        <OpenProjectSvgIcon className="mb-4 h-8 w-8" />
-                        <p className="text-2xl font-medium font-serif text-gray-900">
-                            Projects
-                        </p>
-                        <p className="mt-1 text-xs text-red-500 max-w-xs">
-                            {loadError}
-                        </p>
-                        <PillButton
-                            tone="black"
-                            size="sm"
-                            onClick={retry}
-                            className="mt-4 px-3"
-                        >
-                            Try again
-                        </PillButton>
+                        <EmptyState
+                            icon={<OpenProjectSvgIcon />}
+                            title="Projects"
+                            description={loadError}
+                            tone="error"
+                            action={
+                                <PillButton
+                                    tone="black"
+                                    size="sm"
+                                    onClick={retry}
+                                    className="px-3"
+                                >
+                                    Try again
+                                </PillButton>
+                            }
+                        />
                     </TableEmptyState>
                 ) : visibleProjects.length === 0 ? (
                     <TableEmptyState>
                         {activeFilter === "all" || activeFilter === "mine" ? (
-                            <>
-                                <OpenProjectSvgIcon className="mb-4 h-8 w-8" />
-                                <p className="text-2xl font-medium font-serif text-gray-900">
-                                    Projects
-                                </p>
-                                <p className="mt-1 text-xs text-gray-400 max-w-xs">
-                                    Upload documents into projects and to
-                                    commence chats and tabular reviews with
-                                    them.
-                                </p>
-                                <PillButton
-                                    tone="black"
-                                    size="sm"
-                                    onClick={() => setModalOpen(true)}
-                                    className="mt-4 px-3"
-                                >
-                                    <Plus className="h-3.5 w-3.5" />
-                                    Create
-                                </PillButton>
-                            </>
+                            <EmptyState
+                                icon={<OpenProjectSvgIcon />}
+                                title="Projects"
+                                description="Upload documents into projects and to commence chats and tabular reviews with them."
+                                action={
+                                    <PillButton
+                                        tone="black"
+                                        size="sm"
+                                        onClick={() => setModalOpen(true)}
+                                        className="px-3"
+                                    >
+                                        <Plus className="h-3.5 w-3.5" />
+                                        Create
+                                    </PillButton>
+                                }
+                            />
                         ) : (
                             <p className="text-sm text-gray-400">
                                 No {activeFilter} projects

--- a/frontend/src/app/components/shared/DocumentSidePanel.tsx
+++ b/frontend/src/app/components/shared/DocumentSidePanel.tsx
@@ -18,6 +18,7 @@ import { FileTypeIcon } from "@/app/components/shared/FileTypeIcon";
 import { PdfView } from "@/app/components/shared/views/PdfView";
 import { DocxView } from "@/app/components/shared/views/DocxView";
 import { SpreadsheetView } from "@/app/components/shared/views/SpreadsheetView";
+import { GlassIconButton } from "@/app/components/ui/glass-icon-button";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { WarningPopup } from "@/app/components/popups/WarningPopup";
 import type { Document } from "@/app/components/shared/types";
@@ -507,14 +508,9 @@ export function DocumentSidePanel({
                             Details
                         </button>
                     </div>
-                    <button
-                        type="button"
-                        onClick={onClose}
-                        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/70 bg-white/55 text-gray-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),inset_0_-1px_0_rgba(255,255,255,0.55),0_6px_18px_rgba(15,23,42,0.08)] backdrop-blur-xl transition-colors hover:bg-white/75 hover:text-gray-700"
-                        aria-label="Close"
-                    >
+                    <GlassIconButton onClick={onClose} aria-label="Close">
                         <X className="h-3.5 w-3.5" />
-                    </button>
+                    </GlassIconButton>
                 </div>
             </div>
 

--- a/frontend/src/app/components/shared/FileDirectory.tsx
+++ b/frontend/src/app/components/shared/FileDirectory.tsx
@@ -8,10 +8,11 @@ import {
   useRef,
   useState,
 } from "react";
-import { Check, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import type { Document, LibraryFolder, Project } from "./types";
 import { FileTypeIcon } from "./FileTypeIcon";
 import { ProjectSvgIcon, SubfolderSvgIcon } from "./FolderSvgIcon";
+import { CheckSquare } from "@/app/components/ui/check-square";
 import { SearchBar } from "@/app/components/ui/search-bar";
 import { TabPillButton } from "@/app/components/ui/tab-pill-button";
 import { SkeletonLine } from "./TablePrimitive";
@@ -593,13 +594,7 @@ export function FileDirectory({
           selected ? APP_SURFACE_ACTIVE_CLASS : APP_SURFACE_HOVER_CLASS
                 }`}
             >
-                <span
-                    className={`shrink-0 h-3.5 w-3.5 rounded border flex items-center justify-center ${
-            selected ? "bg-gray-900 border-gray-900" : "border-gray-300"
-                    }`}
-                >
-                    {selected && <Check className="h-2.5 w-2.5 text-white" />}
-                </span>
+                <CheckSquare state={selected ? "checked" : "unchecked"} />
                 <DocFileIcon fileType={doc.file_type} />
                 <span
           className={`min-w-0 truncate ${selected ? "text-gray-900" : "text-gray-700"}`}
@@ -652,7 +647,7 @@ export function FileDirectory({
                         style={{ paddingLeft: indentedRowPadding(depth) }}
                         className={`w-full rounded-md ${DIRECTORY_GRID_CLASS} py-2 pr-2 text-xs transition-all text-left ${APP_SURFACE_HOVER_CLASS}`}
                     >
-                        <span
+                        <CheckSquare
                             role="checkbox"
                             aria-checked={someSelected ? "mixed" : allSelected}
               aria-disabled={!folderSelectionReady}
@@ -667,17 +662,18 @@ export function FileDirectory({
                                 toggleDocuments(docsInFolder);
                 }
                             }}
-                            className={`shrink-0 h-3.5 w-3.5 rounded border flex items-center justify-center ${
-                                allSelected || someSelected
-                                    ? "bg-gray-900 border-gray-900"
-                  : !folderSelectionReady || docsInFolder.length === 0
-                                      ? "border-gray-200 bg-gray-50"
-                                      : "border-gray-300"
-                            }`}
-                        >
-              {allSelected && <Check className="h-2.5 w-2.5 text-white" />}
-                            {someSelected && <span className="h-px w-2 bg-white" />}
-                        </span>
+                            state={
+                                allSelected
+                                    ? "checked"
+                                    : someSelected
+                                      ? "indeterminate"
+                                      : "unchecked"
+                            }
+                            muted={
+                                !folderSelectionReady ||
+                                docsInFolder.length === 0
+                            }
+                        />
             {(libraryTab && loadingFolderIds[libraryTab].has(folder.id)) ||
             (projectId &&
               loadingProjectLevels.has(`${projectId}:${folder.id}`)) ||
@@ -1079,7 +1075,7 @@ export function FileDirectory({
                       onClick={() => toggleFolder(project.id)}
                                         className={`w-full rounded-md ${DIRECTORY_GRID_CLASS} px-2 py-2 text-xs transition-all text-left ${APP_SURFACE_HOVER_CLASS}`}
                                     >
-                                        <span
+                                        <CheckSquare
                                             role="checkbox"
                                             aria-checked={
                                                 someProjectDocsSelected
@@ -1098,21 +1094,18 @@ export function FileDirectory({
                                                 toggleDocuments(docs);
                           }
                                             }}
-                                            className={`shrink-0 h-3.5 w-3.5 rounded border flex items-center justify-center ${
-                          allProjectDocsSelected || someProjectDocsSelected
-                                                    ? "bg-gray-900 border-gray-900"
-                            : !projectSelectionReady || docs.length === 0
-                                                      ? "border-gray-200 bg-gray-50"
-                                                      : "border-gray-300"
-                                            }`}
-                                        >
-                                            {allProjectDocsSelected && (
-                                                <Check className="h-2.5 w-2.5 text-white" />
-                                            )}
-                                            {someProjectDocsSelected && (
-                                                <span className="h-px w-2 bg-white" />
-                                            )}
-                                        </span>
+                                            state={
+                                                allProjectDocsSelected
+                                                    ? "checked"
+                                                    : someProjectDocsSelected
+                                                      ? "indeterminate"
+                                                      : "unchecked"
+                                            }
+                                            muted={
+                                                !projectSelectionReady ||
+                                                docs.length === 0
+                                            }
+                                        />
                                         <ProjectSvgIcon
                                             open={isExpanded}
                                             className="h-3.5 w-3.5 shrink-0"

--- a/frontend/src/app/components/tabular/TREditColumnMenu.tsx
+++ b/frontend/src/app/components/tabular/TREditColumnMenu.tsx
@@ -16,6 +16,7 @@ import {
     LiquidDropdownContent,
     LiquidDropdownRadioItem,
 } from "@/app/components/ui/liquid-dropdown";
+import { GlassIconButton } from "@/app/components/ui/glass-icon-button";
 import { PillButton } from "@/app/components/ui/pill-button";
 
 // Liquid-glass field styling shared by the menu's inputs/controls, matching the
@@ -248,14 +249,12 @@ export function TREditColumnMenu({
                         <p className="font-serif text-lg font-medium text-gray-900">
                             Edit Column
                         </p>
-                        <button
-                            type="button"
+                        <GlassIconButton
                             onClick={() => setOpen(false)}
                             aria-label="Close"
-                            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/70 bg-white/55 text-gray-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),inset_0_-1px_0_rgba(255,255,255,0.55),0_6px_18px_rgba(15,23,42,0.08)] backdrop-blur-xl transition-colors hover:bg-white/75 hover:text-gray-700"
                         >
                             <X className="h-3.5 w-3.5" />
-                        </button>
+                        </GlassIconButton>
                     </div>
                     <label className="text-xs font-medium text-gray-800">
                         Label

--- a/frontend/src/app/components/tabular/TRSidePanel.tsx
+++ b/frontend/src/app/components/tabular/TRSidePanel.tsx
@@ -41,6 +41,7 @@ import {
     APP_SURFACE_PRESSED_CLASS,
     LIQUID_PANEL_SURFACE_CLASS,
 } from "@/app/components/ui/liquid-surface";
+import { GlassIconButton } from "@/app/components/ui/glass-icon-button";
 
 function isDocxDocument(d: {
     file_type?: string | null;
@@ -458,14 +459,9 @@ export function TRSidePanel({
                             )}
                         </button>
                     )}
-                    <button
-                        type="button"
-                        onClick={onClose}
-                        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/70 bg-white/55 text-gray-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),inset_0_-1px_0_rgba(255,255,255,0.55),0_6px_18px_rgba(15,23,42,0.08)] backdrop-blur-xl transition-colors hover:bg-white/75 hover:text-gray-700"
-                        aria-label="Close"
-                    >
+                    <GlassIconButton onClick={onClose} aria-label="Close">
                         <X className="h-3.5 w-3.5" />
-                    </button>
+                    </GlassIconButton>
                 </div>
 
                 {/* Analysis panel */}

--- a/frontend/src/app/components/tabular/TRTable.tsx
+++ b/frontend/src/app/components/tabular/TRTable.tsx
@@ -21,6 +21,7 @@ import {
     SkeletonLine,
     TableScrollArea,
 } from "../shared/TablePrimitive";
+import { EmptyState } from "@/app/components/ui/empty-state";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { TabularReviewSkeuoIcon } from "@/app/components/shared/AppSidebarSkeuoIcons";
 import { TRFirstColumnCell } from "./TRFirstColumnCell";
@@ -253,35 +254,34 @@ export const TRTable = forwardRef<TRTableHandle, Props>(function TRTable(
                     {dragOverFiles && (
                         <div className="absolute inset-0 z-[90] border-2 border-blue-400 bg-blue-50/40 pointer-events-none" />
                     )}
-                    <div className="flex flex-1 flex-col items-start justify-center w-full max-w-xs mx-auto">
-                        <TabularReviewSkeuoIcon className="mb-4 h-8 w-8" />
-                        <p className="text-2xl font-medium font-serif text-gray-900">
-                            Tabular Review
-                        </p>
-                        <p className="mt-1 text-xs text-gray-400 text-left">
-                            Add columns and documents to get started.
-                        </p>
-                        <div className="mt-4 flex items-center gap-2">
-                            <PillButton
-                                tone="black"
-                                size="sm"
-                                onClick={onAddColumn}
-                                className="px-3"
-                            >
-                                <Plus className="h-3.5 w-3.5" />
-                                Add Columns
-                            </PillButton>
-                            <PillButton
-                                tone="white"
-                                size="sm"
-                                onClick={onAddDocuments}
-                                className="px-3"
-                            >
-                                <Upload className="h-3.5 w-3.5" />
-                                Add Documents
-                            </PillButton>
-                        </div>
-                    </div>
+                    <EmptyState
+                        className="mx-auto w-full max-w-xs flex-1 justify-center"
+                        icon={<TabularReviewSkeuoIcon />}
+                        title="Tabular Review"
+                        description="Add columns and documents to get started."
+                        action={
+                            <div className="flex items-center gap-2">
+                                <PillButton
+                                    tone="black"
+                                    size="sm"
+                                    onClick={onAddColumn}
+                                    className="px-3"
+                                >
+                                    <Plus className="h-3.5 w-3.5" />
+                                    Add Columns
+                                </PillButton>
+                                <PillButton
+                                    tone="white"
+                                    size="sm"
+                                    onClick={onAddDocuments}
+                                    className="px-3"
+                                >
+                                    <Upload className="h-3.5 w-3.5" />
+                                    Add Documents
+                                </PillButton>
+                            </div>
+                        }
+                    />
                 </div>
             </TableScrollArea>
         );

--- a/frontend/src/app/components/ui/check-square.test.tsx
+++ b/frontend/src/app/components/ui/check-square.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CheckSquare } from "./check-square";
+
+function square(container: HTMLElement) {
+    return container.querySelector('[data-slot="check-square"]');
+}
+
+describe("CheckSquare", () => {
+    it("renders a check mark when checked", () => {
+        const { container } = render(<CheckSquare state="checked" />);
+        const el = square(container);
+
+        expect(el).toHaveAttribute("data-state", "checked");
+        expect(el).toHaveClass("bg-gray-900", "border-gray-900");
+        expect(
+            container.querySelector('[data-slot="check-square-mark"]'),
+        ).toBeInTheDocument();
+    });
+
+    it("renders a dash when indeterminate", () => {
+        const { container } = render(<CheckSquare state="indeterminate" />);
+
+        expect(square(container)).toHaveClass("bg-gray-900", "border-gray-900");
+        expect(
+            container.querySelector('[data-slot="check-square-dash"]'),
+        ).toBeInTheDocument();
+    });
+
+    it("renders an empty square when unchecked", () => {
+        const { container } = render(<CheckSquare state="unchecked" />);
+
+        expect(square(container)).toHaveClass("border-gray-300");
+        expect(
+            container.querySelector('[data-slot="check-square-mark"]'),
+        ).toBeNull();
+    });
+
+    it("uses the muted styling for an unselectable unchecked square", () => {
+        const { container } = render(<CheckSquare state="unchecked" muted />);
+        expect(square(container)).toHaveClass("border-gray-200", "bg-gray-50");
+    });
+
+    it("ignores muted once the square is checked", () => {
+        const { container } = render(<CheckSquare state="checked" muted />);
+        expect(square(container)).toHaveClass("bg-gray-900");
+    });
+
+    it("is hidden from assistive tech because the row owns the semantics", () => {
+        const { container } = render(<CheckSquare state="checked" />);
+        expect(square(container)).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("forwards click handlers and extra props", () => {
+        const onClick = vi.fn();
+        render(
+            <CheckSquare
+                state="unchecked"
+                role="button"
+                aria-hidden={undefined}
+                title="Select all"
+                onClick={onClick}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Select all" }));
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/src/app/components/ui/check-square.test.tsx
+++ b/frontend/src/app/components/ui/check-square.test.tsx
@@ -51,19 +51,35 @@ describe("CheckSquare", () => {
         expect(square(container)).toHaveAttribute("aria-hidden", "true");
     });
 
-    it("forwards click handlers and extra props", () => {
-        const onClick = vi.fn();
+    it("stays exposed when the caller gives it a role", () => {
         render(
             <CheckSquare
+                state="indeterminate"
+                role="checkbox"
+                aria-checked="mixed"
+                aria-label="Select all files"
+            />,
+        );
+
+        const box = screen.getByRole("checkbox", { name: "Select all files" });
+        expect(box).not.toHaveAttribute("aria-hidden");
+        expect(box).toHaveAttribute("aria-checked", "mixed");
+    });
+
+    it("forwards click handlers and extra props", () => {
+        const onClick = vi.fn();
+        const { container } = render(
+            <CheckSquare
                 state="unchecked"
-                role="button"
-                aria-hidden={undefined}
                 title="Select all"
                 onClick={onClick}
             />,
         );
 
-        fireEvent.click(screen.getByRole("button", { name: "Select all" }));
+        const el = square(container) as HTMLElement;
+        expect(el).toHaveAttribute("title", "Select all");
+
+        fireEvent.click(el);
         expect(onClick).toHaveBeenCalledTimes(1);
     });
 });

--- a/frontend/src/app/components/ui/check-square.tsx
+++ b/frontend/src/app/components/ui/check-square.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import * as React from "react";
+import { Check } from "lucide-react";
+import { cn } from "@/app/lib/utils";
+
+export type CheckSquareState = "checked" | "unchecked" | "indeterminate";
+
+type CheckSquareProps = Omit<React.ComponentProps<"span">, "children"> & {
+    state: CheckSquareState;
+    /** Dims an unchecked square that cannot be selected yet. */
+    muted?: boolean;
+};
+
+/**
+ * The selection square used by directory and picker rows. It is a presentational
+ * indicator: the surrounding row owns the interaction and the ARIA state, so this
+ * is hidden from assistive tech by default. For a standalone control, prefer a
+ * real `<input type="checkbox">`.
+ */
+export function CheckSquare({
+    state,
+    muted = false,
+    className,
+    role,
+    ...props
+}: CheckSquareProps) {
+    const marked = state !== "unchecked";
+
+    return (
+        <span
+            data-slot="check-square"
+            data-state={state}
+            role={role}
+            // Decorative by default; a caller that gives it a role owns the
+            // ARIA state itself and must stay visible to assistive tech.
+            aria-hidden={role ? undefined : true}
+            className={cn(
+                "flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border",
+                marked
+                    ? "border-gray-900 bg-gray-900"
+                    : muted
+                      ? "border-gray-200 bg-gray-50"
+                      : "border-gray-300",
+                className,
+            )}
+            {...props}
+        >
+            {state === "checked" ? (
+                <Check
+                    data-slot="check-square-mark"
+                    className="h-2.5 w-2.5 text-white"
+                />
+            ) : null}
+            {state === "indeterminate" ? (
+                <span
+                    data-slot="check-square-dash"
+                    className="h-px w-2 bg-white"
+                />
+            ) : null}
+        </span>
+    );
+}

--- a/frontend/src/app/components/ui/cite-button.test.tsx
+++ b/frontend/src/app/components/ui/cite-button.test.tsx
@@ -26,6 +26,46 @@ describe("CiteButton", () => {
         expect(screen.queryByText("Cite")).not.toBeInTheDocument();
     });
 
+    it("defaults to type=button so it never submits a form", () => {
+        render(<CiteButton quoteText="hello" quoteLabel="Page 2" />);
+        expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+    });
+
+    it("names the icon-only button for assistive tech", () => {
+        render(
+            <CiteButton
+                quoteText="hello"
+                quoteLabel="Page 2"
+                showText={false}
+            />,
+        );
+        expect(
+            screen.getByRole("button", { name: "Copy quote and citation" }),
+        ).toBeInTheDocument();
+    });
+
+    it("leaves the visible label as the accessible name when text is shown", () => {
+        render(<CiteButton quoteText="hello" quoteLabel="Page 2" />);
+        // WCAG 2.5.3: the accessible name must contain the visible label.
+        expect(screen.getByRole("button")).not.toHaveAttribute("aria-label");
+    });
+
+    it("has a visible keyboard focus ring", () => {
+        render(<CiteButton quoteText="hello" quoteLabel="Page 2" />);
+        expect(screen.getByRole("button")).toHaveClass("focus-visible:ring-2");
+    });
+
+    it("announces the copied state politely", async () => {
+        const user = userEvent.setup();
+        vi.spyOn(navigator.clipboard, "writeText");
+        render(<CiteButton quoteText="hello" quoteLabel="Page 2" />);
+
+        await user.click(screen.getByRole("button"));
+
+        const status = await screen.findByRole("status");
+        expect(status).toHaveTextContent("Copied");
+    });
+
     it("copies the quote and citation, then shows 'Copied'", async () => {
         // userEvent.setup() installs a clipboard stub on navigator; spy on it.
         const user = userEvent.setup();

--- a/frontend/src/app/components/ui/cite-button.tsx
+++ b/frontend/src/app/components/ui/cite-button.tsx
@@ -39,8 +39,12 @@ export function CiteButton({
 
     return (
         <button
+            type="button"
             onClick={handleClick}
-            className={`transition-colors flex items-center gap-1 ${className}`}
+            // Only name the button when there is no visible label; overriding a
+            // visible "Cite" with a different name breaks WCAG 2.5.3.
+            aria-label={showText ? undefined : "Copy quote and citation"}
+            className={`transition-colors flex items-center gap-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2 ${className}`}
             title="Copy Quote and Citation"
         >
             {isCopied ? (
@@ -53,6 +57,7 @@ export function CiteButton({
             )}
             {showText && (
                 <span
+                    role="status"
                     className={
                         isCopied
                             ? `text-green-600 ${textClassName}`

--- a/frontend/src/app/components/ui/empty-state.test.tsx
+++ b/frontend/src/app/components/ui/empty-state.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { EmptyState } from "./empty-state";
+
+describe("EmptyState", () => {
+    it("renders the title as the accessible heading", () => {
+        render(<EmptyState title="Workflows" />);
+        expect(
+            screen.getByRole("heading", { name: "Workflows" }),
+        ).toBeInTheDocument();
+    });
+
+    it("renders the description when provided", () => {
+        render(<EmptyState title="Workflows" description="Nothing here yet." />);
+        expect(screen.getByText("Nothing here yet.")).toBeInTheDocument();
+    });
+
+    it("omits the description paragraph when not provided", () => {
+        const { container } = render(<EmptyState title="Workflows" />);
+        expect(
+            container.querySelector('[data-slot="empty-state-description"]'),
+        ).toBeNull();
+    });
+
+    it("applies the shared display heading classes", () => {
+        render(<EmptyState title="Workflows" />);
+        expect(screen.getByRole("heading", { name: "Workflows" })).toHaveClass(
+            "font-serif",
+            "text-2xl",
+            "font-medium",
+            "text-gray-900",
+        );
+    });
+
+    it("uses the error tone for the description when requested", () => {
+        render(
+            <EmptyState title="Projects" description="Boom" tone="error" />,
+        );
+        expect(screen.getByText("Boom")).toHaveClass("text-red-500");
+    });
+
+    it("uses the muted tone for the description by default", () => {
+        render(<EmptyState title="Projects" description="Add one" />);
+        expect(screen.getByText("Add one")).toHaveClass("text-gray-400");
+    });
+
+    it("renders the icon and the action slots", () => {
+        const { container } = render(
+            <EmptyState
+                icon={<svg data-testid="empty-icon" />}
+                title="Projects"
+                action={<button type="button">Create</button>}
+            />,
+        );
+
+        expect(screen.getByTestId("empty-icon")).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "Create" }),
+        ).toBeInTheDocument();
+        expect(
+            container.querySelector('[data-slot="empty-state-icon"]'),
+        ).toHaveClass("mb-4");
+    });
+
+    it("merges a caller className onto the root", () => {
+        const { container } = render(
+            <EmptyState title="Projects" className="max-w-sm" />,
+        );
+        expect(
+            container.querySelector('[data-slot="empty-state"]'),
+        ).toHaveClass("max-w-sm");
+    });
+});

--- a/frontend/src/app/components/ui/empty-state.test.tsx
+++ b/frontend/src/app/components/ui/empty-state.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { createElement } from "react";
 import { describe, expect, it } from "vitest";
 import { EmptyState } from "./empty-state";
 
@@ -58,6 +59,22 @@ describe("EmptyState", () => {
         expect(
             container.querySelector('[data-slot="empty-state-icon"]'),
         ).toHaveClass("mb-4");
+    });
+
+    it("sizes image icons as well as SVG icons", () => {
+        const { container } = render(
+            <EmptyState
+                icon={createElement("img", {
+                    src: "/icons/features/library.svg",
+                    alt: "",
+                })}
+                title="Files"
+            />,
+        );
+
+        const icon = container.querySelector('[data-slot="empty-state-icon"]');
+        expect(icon?.className).toContain("[&>*]:h-8");
+        expect(icon?.className).toContain("[&>*]:w-8");
     });
 
     it("merges a caller className onto the root", () => {

--- a/frontend/src/app/components/ui/empty-state.test.tsx
+++ b/frontend/src/app/components/ui/empty-state.test.tsx
@@ -3,11 +3,9 @@ import { describe, expect, it } from "vitest";
 import { EmptyState } from "./empty-state";
 
 describe("EmptyState", () => {
-    it("renders the title as the accessible heading", () => {
+    it("renders the title", () => {
         render(<EmptyState title="Workflows" />);
-        expect(
-            screen.getByRole("heading", { name: "Workflows" }),
-        ).toBeInTheDocument();
+        expect(screen.getByText("Workflows")).toBeInTheDocument();
     });
 
     it("renders the description when provided", () => {
@@ -24,7 +22,7 @@ describe("EmptyState", () => {
 
     it("applies the shared display heading classes", () => {
         render(<EmptyState title="Workflows" />);
-        expect(screen.getByRole("heading", { name: "Workflows" })).toHaveClass(
+        expect(screen.getByText("Workflows")).toHaveClass(
             "font-serif",
             "text-2xl",
             "font-medium",

--- a/frontend/src/app/components/ui/empty-state.tsx
+++ b/frontend/src/app/components/ui/empty-state.tsx
@@ -36,7 +36,7 @@ export function EmptyState({
                 <span
                     data-slot="empty-state-icon"
                     aria-hidden="true"
-                    className="mb-4 inline-flex [&>svg]:h-8 [&>svg]:w-8"
+                    className="mb-4 inline-flex [&>*]:h-8 [&>*]:w-8"
                 >
                     {icon}
                 </span>

--- a/frontend/src/app/components/ui/empty-state.tsx
+++ b/frontend/src/app/components/ui/empty-state.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/app/lib/utils";
+
+type EmptyStateProps = {
+    /** Rendered at 32px; pass the bare icon, the wrapper sizes it. */
+    icon?: ReactNode;
+    title: ReactNode;
+    description?: ReactNode;
+    /** Usually a `PillButton`. */
+    action?: ReactNode;
+    tone?: "default" | "error";
+    className?: string;
+};
+
+/**
+ * The standard "nothing here yet" block: icon, serif display heading, muted
+ * body copy and an optional call to action. Drop it inside `TableEmptyState`
+ * for tables, or use it standalone for panels.
+ */
+export function EmptyState({
+    icon,
+    title,
+    description,
+    action,
+    tone = "default",
+    className,
+}: EmptyStateProps) {
+    return (
+        <div
+            data-slot="empty-state"
+            className={cn("flex flex-col items-start text-left", className)}
+        >
+            {icon ? (
+                <span
+                    data-slot="empty-state-icon"
+                    aria-hidden="true"
+                    className="mb-4 inline-flex [&>svg]:h-8 [&>svg]:w-8"
+                >
+                    {icon}
+                </span>
+            ) : null}
+            <p className="font-serif text-2xl font-medium text-gray-900">
+                {title}
+            </p>
+            {description ? (
+                <p
+                    data-slot="empty-state-description"
+                    className={cn(
+                        "mt-1 max-w-xs text-xs",
+                        tone === "error" ? "text-red-500" : "text-gray-400",
+                    )}
+                >
+                    {description}
+                </p>
+            ) : null}
+            {action ? <div className="mt-4">{action}</div> : null}
+        </div>
+    );
+}

--- a/frontend/src/app/components/ui/form-field.test.tsx
+++ b/frontend/src/app/components/ui/form-field.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FieldLabel, FormTextInput } from "./form-field";
+
+describe("FormTextInput", () => {
+    it("replaces the suppressed outline with a focus ring", () => {
+        render(<FormTextInput aria-label="Name" />);
+        expect(screen.getByRole("textbox", { name: "Name" })).toHaveClass(
+            "focus-visible:ring-2",
+        );
+    });
+
+    it("also rings the minimal variant", () => {
+        render(<FormTextInput variant="minimal" aria-label="Title" />);
+        expect(screen.getByRole("textbox", { name: "Title" })).toHaveClass(
+            "focus-visible:ring-2",
+        );
+    });
+});
+
+describe("FieldLabel", () => {
+    it("associates a label with its control", () => {
+        render(
+            <>
+                <FieldLabel htmlFor="cm">Matter number</FieldLabel>
+                <input id="cm" />
+            </>,
+        );
+        expect(
+            screen.getByRole("textbox", { name: "Matter number" }),
+        ).toBeInTheDocument();
+    });
+
+    it("keeps forwarded props when rendered as a non-label element", () => {
+        render(
+            <>
+                <FieldLabel as="span" id="group-name">
+                    Documents
+                </FieldLabel>
+                <div role="group" aria-labelledby="group-name" />
+            </>,
+        );
+        expect(
+            screen.getByRole("group", { name: "Documents" }),
+        ).toBeInTheDocument();
+    });
+});

--- a/frontend/src/app/components/ui/form-field.tsx
+++ b/frontend/src/app/components/ui/form-field.tsx
@@ -2,14 +2,19 @@
 
 import {
     forwardRef,
-    type ComponentPropsWithoutRef,
+    type HTMLAttributes,
     type InputHTMLAttributes,
     type ReactNode,
 } from "react";
 import { cn } from "@/app/lib/utils";
 
+// `outline-none` removes the browser's focus indicator, so every variant has to
+// supply its own `focus-visible:` ring or the field becomes unusable by keyboard.
+const FOCUS_RING_CLASS =
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2";
+
 export const FORM_CONTROL_GLASS_CLASS =
-    "w-full rounded-xl border border-white/70 bg-white px-3 text-sm text-gray-700 shadow-[0_3px_9px_rgba(15,23,42,0.052),inset_0_1px_0_rgba(255,255,255,0.86),inset_0_-1px_0_rgba(255,255,255,0.58)] outline-none placeholder:text-gray-400 backdrop-blur-xl transition-colors disabled:cursor-not-allowed disabled:opacity-60";
+    `w-full rounded-xl border border-white/70 bg-white px-3 text-sm text-gray-700 shadow-[0_3px_9px_rgba(15,23,42,0.052),inset_0_1px_0_rgba(255,255,255,0.86),inset_0_-1px_0_rgba(255,255,255,0.58)] outline-none placeholder:text-gray-400 backdrop-blur-xl transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${FOCUS_RING_CLASS}`;
 
 type FormTextInputVariant = "glass" | "minimal";
 
@@ -19,8 +24,10 @@ type FormTextInputProps = InputHTMLAttributes<HTMLInputElement> & {
 
 const variantClasses: Record<FormTextInputVariant, string> = {
     glass: cn("h-10", FORM_CONTROL_GLASS_CLASS),
-    minimal:
-        "w-full bg-transparent font-serif text-2xl text-gray-800 outline-none placeholder:text-gray-300 disabled:cursor-not-allowed disabled:text-gray-400",
+    minimal: cn(
+        "w-full rounded bg-transparent font-serif text-2xl text-gray-800 outline-none placeholder:text-gray-300 disabled:cursor-not-allowed disabled:text-gray-400",
+        FOCUS_RING_CLASS,
+    ),
 };
 
 export const FormTextInput = forwardRef<HTMLInputElement, FormTextInputProps>(
@@ -35,15 +42,18 @@ export const FormTextInput = forwardRef<HTMLInputElement, FormTextInputProps>(
 
 FormTextInput.displayName = "FormTextInput";
 
-type FieldLabelProps = ComponentPropsWithoutRef<"label"> & {
+// Element-agnostic so the same props spread onto a label, p or span.
+type FieldLabelProps = HTMLAttributes<HTMLElement> & {
     children: ReactNode;
     as?: "label" | "p" | "span";
+    htmlFor?: string;
 };
 
 export function FieldLabel({
     as = "label",
     children,
     className,
+    htmlFor,
     ...props
 }: FieldLabelProps) {
     const classes = cn(
@@ -51,11 +61,23 @@ export function FieldLabel({
         className,
     );
 
-    if (as === "p") return <p className={classes}>{children}</p>;
-    if (as === "span") return <span className={classes}>{children}</span>;
+    // The non-label variants still need forwarded props: `id` is what lets a
+    // caller point `aria-labelledby` at them.
+    if (as === "p")
+        return (
+            <p className={classes} {...props}>
+                {children}
+            </p>
+        );
+    if (as === "span")
+        return (
+            <span className={classes} {...props}>
+                {children}
+            </span>
+        );
 
     return (
-        <label className={classes} {...props}>
+        <label className={classes} htmlFor={htmlFor} {...props}>
             {children}
         </label>
     );

--- a/frontend/src/app/components/ui/glass-icon-button.test.tsx
+++ b/frontend/src/app/components/ui/glass-icon-button.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { GlassIconButton } from "./glass-icon-button";
+
+describe("GlassIconButton", () => {
+    it("exposes the required accessible name", () => {
+        render(
+            <GlassIconButton aria-label="Close">
+                <svg />
+            </GlassIconButton>,
+        );
+        expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+    });
+
+    it("defaults to type=button so it never submits a form", () => {
+        render(
+            <GlassIconButton aria-label="Close">
+                <svg />
+            </GlassIconButton>,
+        );
+        expect(screen.getByRole("button", { name: "Close" })).toHaveAttribute(
+            "type",
+            "button",
+        );
+    });
+
+    it("carries the shared glass surface classes", () => {
+        render(
+            <GlassIconButton aria-label="Close">
+                <svg />
+            </GlassIconButton>,
+        );
+        expect(screen.getByRole("button", { name: "Close" })).toHaveClass(
+            "h-7",
+            "w-7",
+            "rounded-full",
+            "backdrop-blur-xl",
+        );
+    });
+
+    it("has a visible keyboard focus ring", () => {
+        render(
+            <GlassIconButton aria-label="Close">
+                <svg />
+            </GlassIconButton>,
+        );
+        expect(screen.getByRole("button", { name: "Close" })).toHaveClass(
+            "focus-visible:ring-2",
+        );
+    });
+
+    it("lets callers override classes without losing the base", () => {
+        render(
+            <GlassIconButton aria-label="Close" className="ml-auto">
+                <svg />
+            </GlassIconButton>,
+        );
+        const button = screen.getByRole("button", { name: "Close" });
+        expect(button).toHaveClass("ml-auto", "rounded-full");
+    });
+
+    it("fires onClick when activated", async () => {
+        const onClick = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <GlassIconButton aria-label="Close" onClick={onClick}>
+                <svg />
+            </GlassIconButton>,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Close" }));
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/src/app/components/ui/glass-icon-button.tsx
+++ b/frontend/src/app/components/ui/glass-icon-button.tsx
@@ -1,0 +1,5 @@
+export {
+    GlassIconButtonUI as GlassIconButton,
+    glassIconButtonUIClassName,
+} from "@/shared/ui/GlassIconButtonUI";
+export type { GlassIconButtonUIProps as GlassIconButtonProps } from "@/shared/ui/GlassIconButtonUI";

--- a/frontend/src/app/components/ui/liquid-dropdown.tsx
+++ b/frontend/src/app/components/ui/liquid-dropdown.tsx
@@ -12,8 +12,10 @@ import { APP_SURFACE_HOVER_CLASS } from "@/app/components/ui/liquid-surface";
 const LIQUID_DROPDOWN_CLASS =
     "rounded-2xl border border-white/70 bg-app-surface shadow-[0_8px_24px_rgba(15,23,42,0.12),inset_0_1px_0_rgba(255,255,255,0.9),inset_0_-10px_24px_rgba(255,255,255,0.18)] backdrop-blur-2xl";
 
+// The highlighted item has to be distinguishable from a merely hovered one:
+// `app-surface-hover` is a ~1% luminance step, so focus also gets a ring.
 const LIQUID_DROPDOWN_ITEM_CLASS =
-    `cursor-pointer text-xs text-gray-600 transition-colors ${APP_SURFACE_HOVER_CLASS} focus:bg-app-surface-hover focus:text-gray-800`;
+    `cursor-pointer text-xs text-gray-600 transition-colors ${APP_SURFACE_HOVER_CLASS} focus:bg-app-surface-active focus:text-gray-900 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500/40`;
 
 export function LiquidDropdownContent({
     className,

--- a/frontend/src/app/components/ui/pill-button.test.tsx
+++ b/frontend/src/app/components/ui/pill-button.test.tsx
@@ -20,6 +20,24 @@ describe("PillButton", () => {
         );
     });
 
+    it("has a visible keyboard focus ring", () => {
+        render(<PillButton tone="black">Save</PillButton>);
+        expect(screen.getByRole("button", { name: "Save" })).toHaveClass(
+            "focus-visible:ring-2",
+        );
+    });
+
+    it("keeps the focus ring when rendered via asChild", () => {
+        render(
+            <PillButton tone="blue" asChild>
+                <a href="/docs">Docs</a>
+            </PillButton>,
+        );
+        expect(screen.getByRole("link", { name: "Docs" })).toHaveClass(
+            "focus-visible:ring-2",
+        );
+    });
+
     it("applies the tone class", () => {
         render(<PillButton tone="danger">Delete</PillButton>);
         expect(screen.getByRole("button", { name: "Delete" })).toHaveClass(

--- a/frontend/src/app/components/ui/search-bar.test.tsx
+++ b/frontend/src/app/components/ui/search-bar.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SearchBar } from "./search-bar";
+
+describe("SearchBar", () => {
+    it("gives the input a default accessible name", () => {
+        render(<SearchBar value="" onValueChange={() => {}} />);
+        expect(
+            screen.getByRole("searchbox", { name: "Search" }),
+        ).toBeInTheDocument();
+    });
+
+    it("lets callers override the accessible name", () => {
+        render(
+            <SearchBar
+                value=""
+                onValueChange={() => {}}
+                aria-label="Search workflows"
+            />,
+        );
+        expect(
+            screen.getByRole("searchbox", { name: "Search workflows" }),
+        ).toBeInTheDocument();
+    });
+
+    it("shows a focus ring on the wrapper because the input suppresses its outline", () => {
+        const { container } = render(
+            <SearchBar value="" onValueChange={() => {}} />,
+        );
+        expect(
+            container.querySelector('[data-slot="search-bar"]'),
+        ).toHaveClass("focus-within:ring-2");
+    });
+
+    it("clears the value from the labelled clear button", async () => {
+        const onValueChange = vi.fn();
+        const user = userEvent.setup();
+        render(<SearchBar value="draft" onValueChange={onValueChange} />);
+
+        await user.click(screen.getByRole("button", { name: "Clear search" }));
+
+        expect(onValueChange).toHaveBeenCalledWith("");
+    });
+
+    it("gives the clear button a visible focus ring", () => {
+        render(<SearchBar value="draft" onValueChange={() => {}} />);
+        expect(
+            screen.getByRole("button", { name: "Clear search" }),
+        ).toHaveClass("focus-visible:ring-2");
+    });
+});

--- a/frontend/src/app/components/ui/search-bar.tsx
+++ b/frontend/src/app/components/ui/search-bar.tsx
@@ -13,6 +13,8 @@ type SearchBarProps = Omit<
     value: string;
     onValueChange: (value: string) => void;
     size?: SearchBarSize;
+    /** Accessible name for the input; the placeholder alone is not a label. */
+    label?: string;
     clearLabel?: string;
     wrapperClassName?: string;
     inputClassName?: string;
@@ -43,6 +45,7 @@ export const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
             onValueChange,
             size = "normal",
             clearLabel = "Clear search",
+            label = "Search",
             placeholder = "Search...",
             className,
             wrapperClassName,
@@ -55,8 +58,9 @@ export const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
 
         return (
             <div
+                data-slot="search-bar"
                 className={cn(
-                    "flex items-center border border-white/70 bg-white/55 text-gray-700 shadow-[0_3px_9px_rgba(15,23,42,0.06),inset_0_1px_0_rgba(255,255,255,0.86),inset_0_-1px_0_rgba(255,255,255,0.58)] backdrop-blur-xl transition-colors focus-within:border-white/90 focus-within:bg-white/70",
+                    "flex items-center border border-white/70 bg-white/55 text-gray-700 shadow-[0_3px_9px_rgba(15,23,42,0.06),inset_0_1px_0_rgba(255,255,255,0.86),inset_0_-1px_0_rgba(255,255,255,0.58)] backdrop-blur-xl transition-colors focus-within:border-white/90 focus-within:bg-white/70 focus-within:ring-2 focus-within:ring-blue-500/40",
                     classes.wrapper,
                     className,
                     wrapperClassName,
@@ -73,8 +77,11 @@ export const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
                     type="search"
                     value={value}
                     placeholder={placeholder}
+                    aria-label={label}
                     onChange={(event) => onValueChange(event.target.value)}
                     className={cn(
+                        // The wrapper carries the focus ring, so the input's own
+                        // outline is suppressed to avoid a double indicator.
                         "min-w-0 flex-1 bg-transparent text-gray-700 outline-none placeholder:text-gray-400 [&::-webkit-search-cancel-button]:hidden",
                         classes.input,
                         inputClassName,
@@ -86,7 +93,7 @@ export const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
                         type="button"
                         onClick={() => onValueChange("")}
                         className={cn(
-                            "flex shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-white/70 hover:text-gray-600",
+                            "flex shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-white/70 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40",
                             classes.clear,
                         )}
                         aria-label={clearLabel}

--- a/frontend/src/app/components/ui/tab-pill-button.test.tsx
+++ b/frontend/src/app/components/ui/tab-pill-button.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TabPillButton } from "./tab-pill-button";
+
+describe("TabPillButton", () => {
+    it("defaults to type=button", () => {
+        render(<TabPillButton>All</TabPillButton>);
+        expect(screen.getByRole("button", { name: "All" })).toHaveAttribute(
+            "type",
+            "button",
+        );
+    });
+
+    it("reports its selected state to assistive tech", () => {
+        render(<TabPillButton active>Mine</TabPillButton>);
+        expect(screen.getByRole("button", { name: "Mine" })).toHaveAttribute(
+            "aria-pressed",
+            "true",
+        );
+    });
+
+    it("omits aria-pressed when the button is not a toggle", () => {
+        render(<TabPillButton>Neutral</TabPillButton>);
+        expect(
+            screen.getByRole("button", { name: "Neutral" }),
+        ).not.toHaveAttribute("aria-pressed");
+    });
+
+    it("has a visible keyboard focus ring", () => {
+        render(<TabPillButton active>Mine</TabPillButton>);
+        expect(screen.getByRole("button", { name: "Mine" })).toHaveClass(
+            "focus-visible:ring-2",
+        );
+    });
+});

--- a/frontend/src/app/components/ui/tab-pill-button.tsx
+++ b/frontend/src/app/components/ui/tab-pill-button.tsx
@@ -25,7 +25,7 @@ export function TabPillButton({
             type={type}
             aria-pressed={active}
             className={cn(
-                "inline-flex h-7 items-center justify-center gap-1.5 rounded-full border px-3 text-xs font-medium shadow-[0_3px_9px_rgba(15,23,42,0.05),inset_0_1px_0_rgba(255,255,255,0.86),inset_0_-1px_0_rgba(255,255,255,0.58)] backdrop-blur-xl transition-all active:scale-[0.98] disabled:cursor-default disabled:opacity-40 disabled:active:scale-100",
+                "inline-flex h-7 items-center justify-center gap-1.5 rounded-full border px-3 text-xs font-medium shadow-[0_3px_9px_rgba(15,23,42,0.05),inset_0_1px_0_rgba(255,255,255,0.86),inset_0_-1px_0_rgba(255,255,255,0.58)] backdrop-blur-xl transition-all active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2 disabled:cursor-default disabled:opacity-40 disabled:active:scale-100",
                 stateClass,
                 className,
             )}

--- a/frontend/src/app/components/ui/toggle-switch.test.tsx
+++ b/frontend/src/app/components/ui/toggle-switch.test.tsx
@@ -28,4 +28,19 @@ describe("ToggleSwitch", () => {
         fireEvent.click(toggle);
         expect(onCheckedChange).toHaveBeenCalledWith(false);
     });
+
+    it("keeps the off-state track perceivable against a white surface", () => {
+        const { container } = render(
+            <ToggleSwitch checked={false} onCheckedChange={() => {}}>
+                Group documents
+            </ToggleSwitch>,
+        );
+
+        // WCAG 1.4.11: an off switch needs a >=3:1 boundary, which bg-gray-100
+        // against white does not provide on its own.
+        const track = container.querySelector(
+            '[data-slot="toggle-switch-track"]',
+        );
+        expect(track).toHaveClass("bg-gray-300", "ring-1", "ring-gray-400");
+    });
 });

--- a/frontend/src/app/components/ui/toggle-switch.tsx
+++ b/frontend/src/app/components/ui/toggle-switch.tsx
@@ -37,7 +37,11 @@ export function ToggleSwitch({
                 aria-hidden="true"
                 className={cn(
                     "relative inline-flex h-5 w-9 shrink-0 rounded-full transition-colors duration-200",
-                    checked ? "bg-blue-600" : "bg-gray-100",
+                    // WCAG 1.4.11 needs a 3:1 boundary; the off track is only
+                    // perceivable on a white surface with the darker fill+ring.
+                    checked
+                        ? "bg-blue-600"
+                        : "bg-gray-300 ring-1 ring-inset ring-gray-400",
                 )}
             >
                 <span

--- a/frontend/src/app/components/workflows/WorkflowDetailPage.tsx
+++ b/frontend/src/app/components/workflows/WorkflowDetailPage.tsx
@@ -49,6 +49,7 @@ import {
 import { PeopleModal } from "@/app/components/modals/PeopleModal";
 import { OpenSourceWorkflowModal } from "@/app/components/workflows/OpenSourceWorkflowModal";
 import { PageHeader } from "@/app/components/shared/PageHeader";
+import { EmptyState } from "@/app/components/ui/empty-state";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { TabPillButton } from "@/app/components/ui/tab-pill-button";
 import { LIQUID_TABLE_SURFACE_CLASS } from "@/app/components/ui/liquid-surface";
@@ -777,25 +778,24 @@ export function WorkflowDetailPage({ id, workflowType }: Props) {
             >
               {visibleColumns.length === 0 ? (
                 <TableEmptyState>
-                  <TabularReviewSkeuoIcon className="mb-4 h-8 w-8" />
-                  <p className="text-2xl font-medium font-serif text-gray-900">
-                    Columns
-                  </p>
-                  <p className="mt-1 text-xs text-gray-400 text-left">
-                    Add columns to define what this tabular review workflow
-                    extracts from each document.
-                  </p>
-                  {!readOnly && (
-                    <PillButton
-                      tone="black"
-                      size="sm"
-                      onClick={() => setAddColumnOpen(true)}
-                      className="mt-4 px-3"
-                    >
-                      <Plus className="h-3.5 w-3.5" />
-                      Add Column
-                    </PillButton>
-                  )}
+                  <EmptyState
+                    icon={<TabularReviewSkeuoIcon />}
+                    title="Columns"
+                    description="Add columns to define what this tabular review workflow extracts from each document."
+                    action={
+                      !readOnly && (
+                        <PillButton
+                          tone="black"
+                          size="sm"
+                          onClick={() => setAddColumnOpen(true)}
+                          className="px-3"
+                        >
+                          <Plus className="h-3.5 w-3.5" />
+                          Add Column
+                        </PillButton>
+                      )
+                    }
+                  />
                 </TableEmptyState>
               ) : (
                 <TableBody>

--- a/frontend/src/app/components/workflows/WorkflowList.tsx
+++ b/frontend/src/app/components/workflows/WorkflowList.tsx
@@ -22,6 +22,7 @@ import { TableToolbar } from "../shared/TableToolbar";
 import { RowActionMenuItems, RowActions } from "../shared/RowActions";
 import { PageHeader } from "@/app/components/shared/PageHeader";
 import { SubfolderSvgIcon } from "@/app/components/shared/FolderSvgIcon";
+import { EmptyState } from "@/app/components/ui/empty-state";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { TabPillButton } from "@/app/components/ui/tab-pill-button";
 import { LiquidDropdownSurface } from "@/app/components/ui/liquid-dropdown";
@@ -858,31 +859,31 @@ function WorkflowTable({
         </TableBody>
       ) : workflows.length === 0 ? (
         <TableEmptyState>
-          <WorkflowSkeuoIcon className="mb-4 h-8 w-8" />
-          <p className="font-serif text-2xl font-medium text-gray-900">
-            Workflows
-          </p>
-          <p className="mt-1 text-left text-xs text-gray-400">
-            {error || "Create a reusable workflow or import one from Add-ons."}
-          </p>
-          <PillButton
-            tone="black"
-            size="sm"
-            onClick={onCreate}
-            className="mt-4 px-3"
-          >
-            <Plus className="h-3.5 w-3.5" /> Create
-          </PillButton>
+          <EmptyState
+            icon={<WorkflowSkeuoIcon />}
+            title="Workflows"
+            description={
+              error || "Create a reusable workflow or import one from Add-ons."
+            }
+            action={
+              <PillButton
+                tone="black"
+                size="sm"
+                onClick={onCreate}
+                className="px-3"
+              >
+                <Plus className="h-3.5 w-3.5" /> Create
+              </PillButton>
+            }
+          />
         </TableEmptyState>
       ) : displayedWorkflows.length === 0 ? (
         <TableEmptyState>
-          <WorkflowSkeuoIcon className="mb-4 h-8 w-8" />
-          <p className="font-serif text-2xl font-medium text-gray-900">
-            No matching workflows
-          </p>
-          <p className="mt-1 text-left text-xs text-gray-400">
-            Adjust the table filters to see more workflows.
-          </p>
+          <EmptyState
+            icon={<WorkflowSkeuoIcon />}
+            title="No matching workflows"
+            description="Adjust the table filters to see more workflows."
+          />
         </TableEmptyState>
       ) : (
         <>
@@ -1157,14 +1158,14 @@ function AddonTable({
         </TableBody>
       ) : isEmpty ? (
         <TableEmptyState>
-          <WorkflowSkeuoIcon className="mb-4 h-8 w-8" />
-          <p className="font-serif text-2xl font-medium text-gray-900">
-            Add-ons
-          </p>
-          <p className="mt-1 text-xs text-gray-400">
-            {error ||
-              (activePackKey ? "This pack is empty." : "No add-ons found.")}
-          </p>
+          <EmptyState
+            icon={<WorkflowSkeuoIcon />}
+            title="Add-ons"
+            description={
+              error ||
+              (activePackKey ? "This pack is empty." : "No add-ons found.")
+            }
+          />
         </TableEmptyState>
       ) : (
         <TableBody>

--- a/frontend/src/app/components/workflows/WorkflowReferenceFiles.tsx
+++ b/frontend/src/app/components/workflows/WorkflowReferenceFiles.tsx
@@ -20,6 +20,7 @@ import {
   formatUnsupportedDocumentWarning,
   partitionSupportedDocumentFiles,
 } from "@/app/lib/documentUploadValidation";
+import { EmptyState } from "@/app/components/ui/empty-state";
 import { ConfirmPopup } from "../popups/ConfirmPopup";
 import { FileTypeIcon } from "../shared/FileTypeIcon";
 import { RowActions } from "../shared/RowActions";
@@ -271,12 +272,10 @@ export const WorkflowReferenceFiles = forwardRef<
           </TableBody>
         ) : files.length === 0 ? (
           <TableEmptyState>
-            <p className="font-serif text-2xl font-medium text-gray-900">
-              Reference files
-            </p>
-            <p className="mt-1 text-xs text-gray-400">
-              Upload files that this workflow can reference when it runs.
-            </p>
+            <EmptyState
+              title="Reference files"
+              description="Upload files that this workflow can reference when it runs."
+            />
           </TableEmptyState>
         ) : (
           <TableBody>

--- a/frontend/src/shared/ui/GlassIconButtonUI.tsx
+++ b/frontend/src/shared/ui/GlassIconButtonUI.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { type ButtonHTMLAttributes, type ReactElement } from "react";
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export type GlassIconButtonUIProps = Omit<
+    ButtonHTMLAttributes<HTMLButtonElement>,
+    "className"
+> & {
+    className?: string;
+    /** Required: the button is icon-only, so it has no text to name it. */
+    "aria-label": string;
+};
+
+const BASE_CLASS =
+    "flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/70 bg-white/55 text-gray-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),inset_0_-1px_0_rgba(255,255,255,0.55),0_6px_18px_rgba(15,23,42,0.08)] backdrop-blur-xl transition-colors hover:bg-white/75 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2";
+
+export function glassIconButtonUIClassName(className?: string) {
+    return twMerge(clsx(BASE_CLASS, className));
+}
+
+/** Canonical circular glass icon button (modal close, panel dismiss, …). */
+export function GlassIconButtonUI({
+    type = "button",
+    className,
+    ...props
+}: GlassIconButtonUIProps): ReactElement {
+    return (
+        <button
+            type={type}
+            className={glassIconButtonUIClassName(className)}
+            {...props}
+        />
+    );
+}

--- a/frontend/src/shared/ui/ModalUI.tsx
+++ b/frontend/src/shared/ui/ModalUI.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
+import { GlassIconButtonUI } from "./GlassIconButtonUI";
 
 export type ModalUISize = "sm" | "md" | "lg" | "xl";
 
@@ -158,14 +159,9 @@ export function ModalUI({
                             </div>
                             {headerAction}
                         </div>
-                        <button
-                            type="button"
-                            onClick={onClose}
-                            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/70 bg-white/55 text-gray-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.75),inset_0_-1px_0_rgba(255,255,255,0.55),0_6px_18px_rgba(15,23,42,0.08)] backdrop-blur-xl transition-colors hover:bg-white/75 hover:text-gray-700"
-                            aria-label="Close"
-                        >
+                        <GlassIconButtonUI onClick={onClose} aria-label="Close">
                             <X className="h-3.5 w-3.5" />
-                        </button>
+                        </GlassIconButtonUI>
                     </header>
                 )}
 

--- a/frontend/src/shared/ui/PillButtonUI.tsx
+++ b/frontend/src/shared/ui/PillButtonUI.tsx
@@ -44,7 +44,7 @@ export function pillButtonUIClassName({
 }) {
     return twMerge(
         clsx(
-            "inline-flex items-center justify-center gap-1.5 rounded-full font-medium transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40 disabled:active:scale-100",
+            "inline-flex items-center justify-center gap-1.5 rounded-full font-medium transition-all active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40 disabled:active:scale-100",
             toneClasses[tone],
             sizeClasses[size],
             className,

--- a/word-addin/src/taskpane/styles.css
+++ b/word-addin/src/taskpane/styles.css
@@ -10,6 +10,7 @@
 @source "../../../frontend/src/shared/ui/PreResponseWrapperUI.tsx";
 @source "../../../frontend/src/shared/ui/DocumentEventBlocksUI.tsx";
 @source "../../../frontend/src/shared/ui/GlassCardUI.tsx";
+@source "../../../frontend/src/shared/ui/GlassIconButtonUI.tsx";
 @source "../../../frontend/src/shared/ui/ModalUI.tsx";
 @source "../../../frontend/src/shared/ui/HeaderButtonsUI.tsx";
 @source "../../../frontend/src/shared/ui/PillButtonUI.tsx";


### PR DESCRIPTION
## Summary

Formalizes the design system that already exists (shadcn/ui `new-york` + Tailwind v4 CSS-variable tokens) rather than introducing a new one: documents the current tokens and primitives, consolidates three duplicated feature-component patterns into shared primitives, and fixes the accessibility gaps in `components/ui/*`.

No visual redesign, no new dependency, no Storybook (that stays in #323).

Closes #322

## Changes

### 1. `docs/design-system.md` (new)

Documents the current foundations, derived from `frontend/src/app/globals.css` and an audit of `frontend/src/app/components`:

- **Color** — the `--app-*` surface family (Mike's own liquid-glass chrome) and the shadcn semantic set, with intent per token. Flags two real gotchas: `@theme inline` overrides part of Tailwind's blue scale to Mike azure (and leaves `blue-300/400/500/800/900` untouched, so the scale is discontinuous), and the `--app-*` tokens have no `.dark` values, so dark mode is currently incomplete.
- **Typography** — Inter (`font-sans`) / EB Garamond (`font-serif`), how they're loaded in both the web app and the add-in, and the de facto type scale.
- **Spacing and radius** — the actual subset in use (`px-3`/`py-2`/`gap-2` dominate; `h-7` for compact chrome), plus the `--radius` token and which radii the app really uses.
- **Where components live** — the `components/ui/` vs `shared/ui/` vs `components/shared/` vs feature split, including the rule that `shared/ui/` cannot import from `app/` and that new files there must be registered in the add-in's `@source` list.
- **Choosing** — a stop-at-the-first-match list for existing primitive vs. shadcn registry vs. one-off, with "promote on the second occurrence" as the consolidation trigger.
- **Accessibility baseline** — the rules the primitives now follow.

### 2. Consolidation

Targets were re-derived from the current tree rather than reused from earlier analysis, so they differ from what the issue's "audit for consolidation candidates" bullet might have anticipated. Ranked by (number of duplicate sites) x (how identical the markup is):

- **`EmptyState`** (`components/ui/empty-state.tsx`) — icon + serif display heading + muted copy + optional action. `TableEmptyState` already existed as a *wrapper*, but 10 call sites across 7 files each re-hand-rolled the interior; the heading string had already drifted into two class orderings (`font-serif text-2xl font-medium` vs `text-2xl font-medium font-serif`), and `TRTable` had additionally re-implemented the wrapper with a different max-width. Now one component, one class string.
- **`GlassIconButton`** (`shared/ui/GlassIconButtonUI.tsx` + `components/ui/glass-icon-button.tsx`) — the circular glass icon button. `ModalUI` owned a copy inline but never exported it, so `TREditColumnMenu`, `TRSidePanel` and `DocumentSidePanel` each carried a byte-identical 400-character class string. It lives in `shared/ui/` (following the `PillButtonUI`/`GlassCardUI` convention) so `ModalUI` can use it too — otherwise the most-used instance of the button would have kept its own copy and missed the focus-ring fix. `aria-label` is required by the type.
- **`CheckSquare`** (`components/ui/check-square.tsx`) — the selection square in directory and picker rows, 4 sites across `FileDirectory` and `ProjectPickerModal`, including the indeterminate/disabled variants. Decorative (`aria-hidden`) by default since the row usually owns the semantics; a caller that passes a `role` keeps it exposed and supplies its own `aria-checked`. This also removes a visual drift where `ProjectPickerModal` drew a dot instead of the check mark used everywhere else.

`AddProjectDocsModal` no longer exists — the picker markup it used to hold now lives in `FileDirectory`, which is where the checkbox consolidation landed.

### 3. Accessibility pass on `components/ui/*`

Each was re-verified against current source; fixes applied where still broken.

- `cite-button` — added `type="button"` (it would submit an enclosing form), an `aria-label` for the icon-only mode (previously only `title`, the weakest name source) that is deliberately *not* set when the visible "Cite" label is shown so the accessible name still contains the visible label (WCAG 2.5.3), a focus-visible ring, and `role="status"` so the Cite→Copied swap is announced.
- `pill-button` — the base class in `PillButtonUI` gained a focus-visible ring. Fixing it there covers the plain button, the `asChild`/`Slot` path, and the Word add-in in one place.
- `tab-pill-button` — focus-visible ring.
- `toggle-switch` — the off-state track was `bg-gray-100`, roughly 1.07:1 against white and well under the 3:1 that WCAG 1.4.11 requires for a control boundary. Now `bg-gray-300` with an inset `ring-gray-400`. The on state already passes.
- `search-bar` — the input has `outline-none` and the only focus signal was a near-imperceptible wrapper tint; the wrapper now also gets a ring, and the clear button gets its own. Added a `label` prop (default "Search") because a placeholder is not an accessible name.
- `form-field` — `FORM_CONTROL_GLASS_CLASS` and the `minimal` variant both suppressed the outline with nothing in its place, so these inputs had no keyboard focus state at all. Both now carry a ring. `FieldLabel` also silently dropped all forwarded props on its `as="p"` / `as="span"` branches, which meant an `id` passed for `aria-labelledby` never reached the DOM.
- `liquid-dropdown` — the glass skin replaced the shadcn focus background with `app-surface-hover`, a ~1% luminance step that made the highlighted item indistinguishable from a hovered one. Now `app-surface-active` plus an inset ring.
- `button` (shadcn) and `dropdown-menu` (Radix) were checked and left alone — their focus handling is already adequate and diverging from the registry costs more than it gains. `button`'s missing `type` default is upstream shadcn behavior and is called out in the docs instead.

### 4. `CONTRIBUTING.md`

One additive "Frontend UI Work" section on checking `components/ui/` and the shadcn registry before writing a new component, and on the promote-on-second-occurrence rule. Existing sections are untouched. Also linked the new doc from `docs/README.md`.

## Test plan

- [x] Unit tests added — `empty-state`, `check-square` and `glass-icon-button` test files, plus new accessibility assertions in `cite-button`, `pill-button`, `toggle-switch`, and new `search-bar`, `form-field` and `tab-pill-button` test files. Written failing first (17 failures), then implemented.
- [x] `npx vitest run` (frontend) — 447 passing, up from 404. The 4 failures in `src/app/lib/mikeApi.test.ts` (`blob.text is not a function`) are pre-existing, present on unmodified `main` locally, unrelated to this change, and green in CI — a local jsdom/Node artifact, so no issue was filed for them.
- [x] `npm run lint --prefix frontend` with the ESLint cache cleared — 0 errors.
- [x] `npx tsc --noEmit` (frontend) — clean.
- [x] `npm run build --prefix frontend` — compiles, 25 static pages generated.
- [x] Word add-in `npm run typecheck` and `webpack --mode production` — both pass, since `ModalUI` now depends on the new `shared/ui` file and the add-in's Tailwind `@source` list had to learn about it.
- [ ] No E2E added — this is a refactor plus a11y attributes with no new user-facing flow.

No changes to `package.json` or `package-lock.json`.
