### PR TITLE
feat(auth): add email confirmation and password recovery

### DIFF
--- a/backend/migrations/20260819_01_auth_email_confirmation.sql
+++ b/backend/migrations/20260819_01_auth_email_confirmation.sql
@@ -1,0 +1,61 @@
+-- Preserve profile fields while signup awaits email confirmation, and keep the
+-- profile email mirror current after a confirmed email-address change.
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.user_profiles (
+    user_id,
+    email,
+    display_name,
+    organisation
+  )
+  values (
+    new.id,
+    lower(new.email),
+    nullif(left(btrim(coalesce(new.raw_user_meta_data ->> 'display_name', '')), 200), ''),
+    nullif(left(btrim(coalesce(new.raw_user_meta_data ->> 'organisation', '')), 200), '')
+  )
+  on conflict (user_id) do update
+    set email = excluded.email,
+        display_name = coalesce(
+          nullif(btrim(user_profiles.display_name), ''),
+          excluded.display_name
+        ),
+        organisation = coalesce(
+          nullif(btrim(user_profiles.organisation), ''),
+          excluded.organisation
+        ),
+        updated_at = now();
+  return new;
+exception when others then
+  -- Never block signup if the profile insert fails.
+  return new;
+end;
+$$;
+
+create or replace function public.handle_user_email_updated()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.user_profiles
+  set email = lower(new.email),
+      updated_at = now()
+  where user_id = new.id;
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_email_updated on auth.users;
+create trigger on_auth_user_email_updated
+  after update of email on auth.users
+  for each row
+  when (old.email is distinct from new.email)
+  execute procedure public.handle_user_email_updated();

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -46,10 +46,28 @@ security definer
 set search_path = public
 as $$
 begin
-  insert into public.user_profiles (user_id, email)
-  values (new.id, lower(new.email))
+  insert into public.user_profiles (
+    user_id,
+    email,
+    display_name,
+    organisation
+  )
+  values (
+    new.id,
+    lower(new.email),
+    nullif(left(btrim(coalesce(new.raw_user_meta_data ->> 'display_name', '')), 200), ''),
+    nullif(left(btrim(coalesce(new.raw_user_meta_data ->> 'organisation', '')), 200), '')
+  )
   on conflict (user_id) do update
     set email = excluded.email,
+        display_name = coalesce(
+          nullif(btrim(user_profiles.display_name), ''),
+          excluded.display_name
+        ),
+        organisation = coalesce(
+          nullif(btrim(user_profiles.organisation), ''),
+          excluded.organisation
+        ),
         updated_at = now();
   return new;
 exception when others then
@@ -62,6 +80,28 @@ drop trigger if exists on_auth_user_created on auth.users;
 create trigger on_auth_user_created
   after insert on auth.users
   for each row execute procedure public.handle_new_user();
+
+create or replace function public.handle_user_email_updated()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.user_profiles
+  set email = lower(new.email),
+      updated_at = now()
+  where user_id = new.id;
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_email_updated on auth.users;
+create trigger on_auth_user_email_updated
+  after update of email on auth.users
+  for each row
+  when (old.email is distinct from new.email)
+  execute procedure public.handle_user_email_updated();
 
 create table if not exists public.user_api_keys (
   id uuid primary key default gen_random_uuid(),

--- a/backend/supabase/config.toml
+++ b/backend/supabase/config.toml
@@ -156,11 +156,14 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://localhost:3000"
 # The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
 # external_url = ""
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = [
+  "http://localhost:3000/auth/callback",
+  "http://127.0.0.1:3000/auth/callback",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to auth.external_url.
@@ -179,7 +182,7 @@ enable_anonymous_sign_ins = false
 # Allow/disallow testing manual linking of accounts
 enable_manual_linking = false
 # Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
-minimum_password_length = 6
+minimum_password_length = 10
 # Passwords that do not meet the following requirements will be rejected as weak. Supported values
 # are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
 password_requirements = ""
@@ -223,9 +226,9 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = false
+enable_confirmations = true
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.
-secure_password_change = false
+secure_password_change = true
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1s"
 # Number of characters used in the email OTP.
@@ -233,15 +236,16 @@ otp_length = 6
 # Number of seconds before the email OTP expires (defaults to 1 hour).
 otp_expiry = 3600
 
-# Use a production-ready SMTP server
-# [auth.email.smtp]
-# enabled = true
-# host = "smtp.sendgrid.net"
-# port = 587
-# user = "apikey"
-# pass = "env(SENDGRID_API_KEY)"
-# admin_email = "admin@email.com"
-# sender_name = "Admin"
+# Deliver local Auth messages through Resend. Keep the API key in backend/.env;
+# config.toml is tracked and must never contain the credential itself.
+[auth.email.smtp]
+enabled = true
+host = "smtp.resend.com"
+port = 465
+user = "resend"
+pass = "env(RESEND_API_KEY)"
+admin_email = "noreply@mikeoss.com"
+sender_name = "MikeOSS (No Reply)"
 
 # Uncomment to customize email template
 # [auth.email.template.invite]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       GOTRUE_JWT_AUD: authenticated
       GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
       GOTRUE_JWT_ADMIN_ROLES: service_role
+      GOTRUE_PASSWORD_MIN_LENGTH: "10"
       # Open registration by default (localhost). On a public host, create your
       # account then set GOTRUE_DISABLE_SIGNUP=true to pull the ladder up.
       GOTRUE_DISABLE_SIGNUP: ${GOTRUE_DISABLE_SIGNUP:-false}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -66,8 +66,29 @@ configured globally, its matching field is read-only.
 ## Authentication email
 
 Supabase Auth sends signup, email-change, and password-recovery messages.
-Configure production SMTP in the Supabase dashboard if those flows are enabled.
-Mike does not require a Resend API key.
+Configure production SMTP in the Supabase dashboard; Mike does not require a
+Resend API key for these messages.
+
+In **Authentication > URL Configuration**, set the Site URL to the deployed
+frontend origin and add that origin's `/auth/callback` URL to the redirect
+allow list. For example:
+
+```text
+https://your-mike.example/auth/callback
+```
+
+Enable email confirmation for production signups. Keep secure email change
+enabled so Supabase requires confirmation from both the current and proposed
+addresses. Set the minimum password length to 10; this applies when passwords
+are created or changed and does not invalidate existing shorter passwords. The
+same callback handles signup confirmation, confirmed email
+changes, and password-recovery links before sending the user to the appropriate
+Mike page.
+
+Review the Supabase email templates after changing the public Site URL, and
+test every link against the deployed frontend before inviting users. Existing
+deployments must also apply the latest migration so confirmed email changes are
+mirrored into `user_profiles`.
 
 ## Install and run
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -66,7 +66,10 @@ docker compose up -d --force-recreate auth
 ```
 
 Open [Mailpit](http://localhost:8025) to read the confirmation message. Mailpit
-also captures local email-change messages, and no email leaves your machine.
+also captures local email-change and password-reset messages, and no email
+leaves your machine. These links pass through `/auth/callback` and return to the
+relevant app screen. Local signup autoconfirm remains enabled by default; turn
+it off only when you specifically want to test the confirmation flow.
 
 ## Local models with Ollama
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,22 @@ docker compose up -d --force-recreate auth
 ## Production authentication email does not arrive
 
 Authentication email is sent by Supabase Auth. Check its email-provider
-settings and configure production SMTP in the Supabase dashboard.
+settings, delivery logs, and rate limits, and configure production SMTP in the
+Supabase dashboard. Mike intentionally shows the same password-reset response
+for registered and unregistered addresses, so that screen cannot confirm
+whether an account exists.
+
+## A confirmation or password-reset link is rejected
+
+Confirm that the deployed frontend's exact `/auth/callback` URL is present in
+the Supabase Auth redirect allow list and that the Site URL uses the correct
+scheme and hostname. Request a new message after correcting either value;
+authentication links expire and may only be usable once.
+
+For a secure email change, Supabase sends messages to both the current and new
+addresses. The change remains pending until both messages are confirmed. If an
+email change succeeds in Auth but the profile still shows the old address,
+verify that the latest database migration has been applied.
 
 ## Port 54322 is already allocated
 

--- a/frontend/public/icons/sign-out.svg
+++ b/frontend/public/icons/sign-out.svg
@@ -1,9 +1,9 @@
 <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="slabFace" x1="8" y1="7" x2="42" y2="58" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#DCE8F2" stop-opacity="0.82"/>
-      <stop offset="0.58" stop-color="#B9CAD9" stop-opacity="0.76"/>
-      <stop offset="1" stop-color="#8EA1B4" stop-opacity="0.86"/>
+      <stop offset="0" stop-color="#687789"/>
+      <stop offset="0.58" stop-color="#3E4D60"/>
+      <stop offset="1" stop-color="#1F2B3B"/>
     </linearGradient>
     <linearGradient id="slabRim" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.95"/>
@@ -11,9 +11,9 @@
       <stop offset="1" stop-color="#233044" stop-opacity="0.62"/>
     </linearGradient>
     <linearGradient id="arrowFace" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#687789"/>
-      <stop offset="0.48" stop-color="#3E4D60"/>
-      <stop offset="1" stop-color="#1F2B3B"/>
+      <stop offset="0" stop-color="#DCE8F2" stop-opacity="0.82"/>
+      <stop offset="0.48" stop-color="#B9CAD9" stop-opacity="0.76"/>
+      <stop offset="1" stop-color="#8EA1B4" stop-opacity="0.86"/>
     </linearGradient>
     <linearGradient id="arrowRim" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.72"/>

--- a/frontend/src/app/(pages)/settings/page.tsx
+++ b/frontend/src/app/(pages)/settings/page.tsx
@@ -22,6 +22,11 @@ const devLog = (...args: Parameters<typeof console.log>) => {
     if (isDev) console.log(...args);
 };
 
+interface EmailWarning {
+    title: string;
+    message: string;
+}
+
 export default function SettingsPage() {
     const router = useRouter();
     const { user, signOut, updateEmail } = useAuth();
@@ -36,7 +41,7 @@ export default function SettingsPage() {
     const [isSavingEmail, setIsSavingEmail] = useState(false);
     const [emailSaved, setEmailSaved] = useState(false);
     const [emailStatus, setEmailStatus] = useState<string | null>(null);
-    const [emailWarning, setEmailWarning] = useState<string | null>(null);
+    const [emailWarning, setEmailWarning] = useState<EmailWarning | null>(null);
     const [emailMfaOpen, setEmailMfaOpen] = useState(false);
     const [deleteConfirm, setDeleteConfirm] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
@@ -56,6 +61,22 @@ export default function SettingsPage() {
             setEmail(user.pendingEmail || user.email);
         }
     }, [user?.email, user?.pendingEmail]);
+
+    useEffect(() => {
+        if (
+            new URLSearchParams(window.location.search).get("emailChange") !==
+                "processed" ||
+            !user
+        ) {
+            return;
+        }
+        setEmailStatus(
+            user.pendingEmail
+                ? "One confirmation was accepted. Confirm the email change from both your current and new addresses to finish."
+                : "Email updated.",
+        );
+        window.history.replaceState({}, "", "/settings");
+    }, [user]);
 
     const handleDeleteAccount = async () => {
         devLog("[account/mfa] delete account requested");
@@ -106,7 +127,7 @@ export default function SettingsPage() {
             setEmailSaved(true);
             setEmailStatus(
                 pendingEmail
-                    ? `Confirmation sent to ${pendingEmail}. Your current email remains ${updatedUser.email} until the change is confirmed.`
+                    ? `Confirmation sent to your current address and ${pendingEmail}. Confirm both messages to finish the change. Your current email remains ${updatedUser.email} until then.`
                     : "Email updated.",
             );
             setTimeout(() => setEmailSaved(false), 2000);
@@ -119,7 +140,20 @@ export default function SettingsPage() {
 
             if (isAlreadyRegisteredEmailError(message)) {
                 setEmail(user?.pendingEmail || user?.email || "");
-                setEmailWarning(message);
+                setEmailWarning({
+                    title: "Email already registered",
+                    message,
+                });
+                return;
+            }
+
+            if (isEmailRateLimitError(message)) {
+                setEmail(user?.pendingEmail || user?.email || "");
+                setEmailWarning({
+                    title: "Email change unavailable",
+                    message:
+                        "You can’t change your email this often. Please wait before trying again.",
+                });
                 return;
             }
 
@@ -351,8 +385,8 @@ export default function SettingsPage() {
             />
             <WarningPopup
                 open={!!emailWarning}
-                title="Email already registered"
-                message={emailWarning}
+                title={emailWarning?.title}
+                message={emailWarning?.message}
                 onClose={() => setEmailWarning(null)}
             />
             <MfaVerificationPopup
@@ -387,4 +421,8 @@ function isAlreadyRegisteredEmailError(message: string) {
     return message
         .toLowerCase()
         .includes("a user with this email address has already been registered");
+}
+
+function isEmailRateLimitError(message: string) {
+    return /email.*rate limit|rate limit.*email/i.test(message);
 }

--- a/frontend/src/app/(pages)/settings/security/page.tsx
+++ b/frontend/src/app/(pages)/settings/security/page.tsx
@@ -19,6 +19,8 @@ import {
 } from "@/app/components/popups/MfaVerificationPopup";
 import { SettingsSection } from "../SettingsSection";
 import { SettingsToggle } from "../SettingsToggle";
+import { useAuth } from "@/app/contexts/AuthContext";
+import { browserAuthCallbackUrl } from "@/app/lib/authRedirects";
 
 type MfaFactor = {
     id: string;
@@ -161,6 +163,7 @@ function MfaSettingsSkeleton() {
 }
 
 export default function SecurityPage() {
+    const { user } = useAuth();
     const { profile, updateMfaOnLogin } = useUserProfile();
     const [loading, setLoading] = useState(true);
     const [factors, setFactors] = useState<MfaFactor[]>([]);
@@ -178,6 +181,10 @@ export default function SecurityPage() {
     >(null);
     const [pendingLoginPreference, setPendingLoginPreference] = useState<
         boolean | null
+    >(null);
+    const [passwordResetSending, setPasswordResetSending] = useState(false);
+    const [passwordResetStatus, setPasswordResetStatus] = useState<
+        string | null
     >(null);
 
     async function refreshMfaState() {
@@ -452,6 +459,29 @@ export default function SecurityPage() {
         }
     }
 
+    async function sendPasswordReset() {
+        if (!user?.email || passwordResetSending) return;
+        setPasswordResetSending(true);
+        setPasswordResetStatus(null);
+        try {
+            const redirectTo = browserAuthCallbackUrl("/reset-password");
+            const { error } = await supabase.auth.resetPasswordForEmail(
+                user.email,
+                redirectTo ? { redirectTo } : undefined,
+            );
+            if (error) throw error;
+            setPasswordResetStatus(
+                `Password-reset instructions sent to ${user.email}.`,
+            );
+        } catch {
+            setPasswordResetStatus(
+                "Unable to send a password-reset email right now. Please try again.",
+            );
+        } finally {
+            setPasswordResetSending(false);
+        }
+    }
+
     const hasVerifiedFactor = factors.length > 0;
     const sessionVerified = currentLevel === "aal2";
     const loginMfaEnabled = profile?.mfaOnLogin === true;
@@ -551,6 +581,39 @@ export default function SecurityPage() {
                             {status}
                         </p>
                     )}
+                </SettingsSection>
+            </section>
+            <section className="space-y-3">
+                <h2 className="text-2xl font-medium font-serif text-gray-900">
+                    Password
+                </h2>
+                <SettingsSection>
+                    <div className="flex flex-col gap-3 px-4 py-5 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="min-w-0 space-y-1">
+                            <p className="text-sm font-medium text-gray-700">
+                                Reset password
+                            </p>
+                            <p className="text-sm text-gray-500">
+                                Send a secure password-reset link to {user?.email}.
+                            </p>
+                            {passwordResetStatus && (
+                                <p className="text-xs text-gray-500">
+                                    {passwordResetStatus}
+                                </p>
+                            )}
+                        </div>
+                        <PillButton
+                            tone="black"
+                            size="sm"
+                            onClick={() => void sendPasswordReset()}
+                            disabled={passwordResetSending || !user?.email}
+                            className="shrink-0"
+                        >
+                            {passwordResetSending
+                                ? "Sending..."
+                                : "Send reset email"}
+                        </PillButton>
+                    </div>
                 </SettingsSection>
             </section>
             <Modal

--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Loader2 } from "lucide-react";
+import { SiteLogo } from "@/app/components/site-logo";
+import { PillButton } from "@/app/components/ui/pill-button";
+import { authGlassCardClassName } from "@/app/components/auth/authStyles";
+import { authErrorDescription, safeAuthNext } from "@/app/lib/authRedirects";
+import { supabase } from "@/app/lib/supabase";
+
+function AuthCallbackContent() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const [error, setError] = useState<string | null>(null);
+    const isErrorPreview =
+        process.env.NODE_ENV !== "production" &&
+        searchParams.get("preview") === "confirmation-error";
+    const displayedError = isErrorPreview
+        ? "This confirmation link is invalid or has expired."
+        : error;
+
+    useEffect(() => {
+        if (isErrorPreview) return;
+
+        let cancelled = false;
+
+        async function completeAuth() {
+            const providerError = authErrorDescription(
+                window.location.search,
+                window.location.hash,
+            );
+            if (providerError) {
+                setError(providerError);
+                return;
+            }
+
+            const code = searchParams.get("code");
+            if (code) {
+                const { error: exchangeError } =
+                    await supabase.auth.exchangeCodeForSession(code);
+                if (exchangeError) {
+                    setError(exchangeError.message);
+                    return;
+                }
+            } else {
+                const { data, error: sessionError } =
+                    await supabase.auth.getSession();
+                if (sessionError) {
+                    setError(sessionError.message);
+                    return;
+                }
+                if (!data.session) {
+                    setError(
+                        "This confirmation link is invalid or has expired.",
+                    );
+                    return;
+                }
+            }
+
+            if (!cancelled) {
+                router.replace(safeAuthNext(searchParams.get("next")));
+            }
+        }
+
+        void completeAuth();
+        return () => {
+            cancelled = true;
+        };
+    }, [isErrorPreview, router, searchParams]);
+
+    return (
+        <div className="relative flex min-h-dvh items-center justify-center bg-gray-50/80 px-6 py-10">
+            <div className="absolute top-4 md:top-8 left-1/2 -translate-x-1/2">
+                <SiteLogo size="lg" asLink />
+            </div>
+            <div className="w-full max-w-md">
+                <div className={authGlassCardClassName}>
+                    {displayedError ? (
+                        <>
+                            <h1 className="text-2xl font-medium font-serif text-gray-950">
+                                Unable to confirm
+                            </h1>
+                            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+                                {displayedError}
+                            </p>
+                            <PillButton
+                                asChild
+                                tone="black"
+                                size="normal"
+                                className="mt-6"
+                            >
+                                <Link href="/login">Return to login</Link>
+                            </PillButton>
+                        </>
+                    ) : (
+                        <>
+                            <Loader2 className="h-6 w-6 animate-spin text-gray-500" />
+                            <h1 className="mt-4 text-2xl font-medium font-serif text-gray-950">
+                                Confirming your request
+                            </h1>
+                            <p className="mt-2 text-sm text-gray-500">
+                                This should only take a moment.
+                            </p>
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default function AuthCallbackPage() {
+    return (
+        <Suspense fallback={null}>
+            <AuthCallbackContent />
+        </Suspense>
+    );
+}

--- a/frontend/src/app/components/auth/authStyles.ts
+++ b/frontend/src/app/components/auth/authStyles.ts
@@ -1,0 +1,5 @@
+export const authGlassCardClassName =
+    "rounded-2xl border border-white/70 bg-white/72 p-8 shadow-sm backdrop-blur-2xl";
+
+export const authInputClassName =
+    "rounded-lg border border-transparent bg-gray-100 px-3 shadow-none focus-visible:border-gray-200 focus-visible:ring-2 focus-visible:ring-gray-300/45";

--- a/frontend/src/app/components/auth/passwordPolicy.ts
+++ b/frontend/src/app/components/auth/passwordPolicy.ts
@@ -1,0 +1,3 @@
+export const MIN_PASSWORD_LENGTH = 10;
+
+export const minimumPasswordMessage = `Password must be at least ${MIN_PASSWORD_LENGTH} characters`;

--- a/frontend/src/app/components/popups/WarningPopup.tsx
+++ b/frontend/src/app/components/popups/WarningPopup.tsx
@@ -44,20 +44,25 @@ export function WarningPopup({
         <div className="pointer-events-none fixed left-1/2 top-5 z-[220] w-[min(92vw,520px)] -translate-x-1/2 px-4">
             <div
                 className={cn(
-                    "pointer-events-auto flex items-start gap-2 rounded-2xl border border-white/70 bg-red-50/75 px-3 py-2 text-xs shadow-[0_4px_12px_rgba(15,23,42,0.11),inset_0_1px_0_rgba(255,255,255,0.9),inset_0_-6px_12px_rgba(255,255,255,0.2)] backdrop-blur-2xl",
+                    "pointer-events-auto flex items-start gap-2 rounded-2xl border border-white/70 bg-white px-3 py-3 text-xs shadow-[0_4px_12px_rgba(15,23,42,0.11),inset_0_1px_0_rgba(255,255,255,0.9),inset_0_-6px_12px_rgba(255,255,255,0.2)] backdrop-blur-2xl",
                     className,
                 )}
             >
                 <div className="min-w-0 flex-1 self-center text-red-600">
                     {title && (
-                        <div className="flex items-center gap-1.5 font-medium mb-1">
+                        <div className="mb-1 flex items-center gap-1.5 text-sm font-medium">
                             {warningIcon}
                             {title}
                         </div>
                     )}
                     {message && (
                         <div
-                            className={cn(!title && "flex items-start gap-1.5")}
+                            className={cn(
+                                "text-black",
+                                title
+                                    ? "pl-[18px]"
+                                    : "flex items-start gap-1.5",
+                            )}
                         >
                             {!title && warningIcon}
                             <span className="min-w-0">{message}</span>
@@ -81,7 +86,7 @@ export function WarningPopup({
                 <button
                     type="button"
                     onClick={onClose}
-                    className="shrink-0 text-red-700 transition-colors hover:text-red-500"
+                    className="shrink-0 text-black transition-colors hover:text-gray-600"
                     aria-label="Dismiss warning"
                 >
                     <X className="h-3.5 w-3.5" />

--- a/frontend/src/app/components/shared/AppSidebarSkeuoIcons.tsx
+++ b/frontend/src/app/components/shared/AppSidebarSkeuoIcons.tsx
@@ -6,7 +6,7 @@ type IconProps = Omit<
 >;
 
 const ICON_BASE_PATH = "/icons";
-const ICON_VERSION = "32";
+const ICON_VERSION = "33";
 
 function AppSidebarIcon({
     name,

--- a/frontend/src/app/contexts/AuthContext.tsx
+++ b/frontend/src/app/contexts/AuthContext.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import type { User as SupabaseUser } from "@supabase/supabase-js";
 import { supabase } from "@/app/lib/supabase";
+import { browserAuthCallbackUrl } from "@/app/lib/authRedirects";
 
 interface User {
     id: string;
@@ -74,10 +75,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
 
     const updateEmail = async (email: string) => {
-        const redirectTo =
-            typeof window === "undefined"
-                ? undefined
-                : `${window.location.origin}/settings`;
+        const redirectTo = browserAuthCallbackUrl(
+            "/settings?emailChange=processed",
+        );
         const { data, error } = await supabase.auth.updateUser(
             { email },
             redirectTo ? { emailRedirectTo: redirectTo } : undefined,

--- a/frontend/src/app/forgot-password/page.test.tsx
+++ b/frontend/src/app/forgot-password/page.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ForgotPasswordPage from "./page";
+
+const { resetPasswordForEmail } = vi.hoisted(() => ({
+    resetPasswordForEmail: vi.fn(),
+}));
+
+vi.mock("@/app/lib/supabase", () => ({
+    supabase: {
+        auth: { resetPasswordForEmail },
+    },
+}));
+
+vi.mock("@/app/components/site-logo", () => ({
+    SiteLogo: () => <div>Mike</div>,
+}));
+
+describe("ForgotPasswordPage", () => {
+    beforeEach(() => {
+        resetPasswordForEmail.mockReset();
+    });
+
+    it("sends recovery through the shared callback", async () => {
+        resetPasswordForEmail.mockResolvedValue({ error: null });
+        const user = userEvent.setup();
+        render(<ForgotPasswordPage />);
+
+        await user.type(
+            screen.getByRole("textbox", { name: "Email" }),
+            "person@example.com",
+        );
+        await user.click(
+            screen.getByRole("button", { name: "Send reset link" }),
+        );
+
+        expect(resetPasswordForEmail).toHaveBeenCalledWith(
+            "person@example.com",
+            {
+                redirectTo:
+                    "http://localhost:3000/auth/callback?next=%2Freset-password",
+            },
+        );
+        expect(
+            await screen.findByRole("heading", { name: "Check your email" }),
+        ).toBeInTheDocument();
+    });
+
+    it("uses the same response when the request fails", async () => {
+        resetPasswordForEmail.mockRejectedValue(new Error("not found"));
+        const user = userEvent.setup();
+        render(<ForgotPasswordPage />);
+
+        await user.type(
+            screen.getByRole("textbox", { name: "Email" }),
+            "unknown@example.com",
+        );
+        await user.click(
+            screen.getByRole("button", { name: "Send reset link" }),
+        );
+
+        expect(
+            await screen.findByRole("heading", { name: "Check your email" }),
+        ).toBeInTheDocument();
+        expect(screen.getByText(/If an account exists/)).toBeInTheDocument();
+    });
+});

--- a/frontend/src/app/forgot-password/page.tsx
+++ b/frontend/src/app/forgot-password/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Input } from "@/app/components/ui/input";
+import { PillButton } from "@/app/components/ui/pill-button";
+import { SiteLogo } from "@/app/components/site-logo";
+import {
+    authGlassCardClassName,
+    authInputClassName,
+} from "@/app/components/auth/authStyles";
+import { browserAuthCallbackUrl } from "@/app/lib/authRedirects";
+import { supabase } from "@/app/lib/supabase";
+
+export default function ForgotPasswordPage() {
+    const [email, setEmail] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [submitted, setSubmitted] = useState(false);
+
+    async function handleSubmit(event: React.FormEvent) {
+        event.preventDefault();
+        setLoading(true);
+        try {
+            const redirectTo = browserAuthCallbackUrl("/reset-password");
+            await supabase.auth.resetPasswordForEmail(
+                email.trim(),
+                redirectTo ? { redirectTo } : undefined,
+            );
+        } catch {
+            // Keep the response indistinguishable from a successful request.
+        } finally {
+            // Use the same response for existing and unknown addresses so this
+            // screen cannot be used to enumerate Mike accounts.
+            setSubmitted(true);
+            setLoading(false);
+        }
+    }
+
+    return (
+        <div
+            className={`relative flex min-h-dvh justify-center bg-gray-50/80 px-6 ${
+                submitted
+                    ? "items-center py-10"
+                    : "items-start pb-10 pt-32 md:pt-40"
+            }`}
+        >
+            <div className="absolute top-4 md:top-8 left-1/2 -translate-x-1/2">
+                <SiteLogo size="lg" asLink />
+            </div>
+            <div className="w-full max-w-md">
+                <div className={authGlassCardClassName}>
+                    {submitted ? (
+                        <div>
+                            <h1 className="text-2xl font-medium font-serif text-gray-950">
+                                Check your email
+                            </h1>
+                            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+                                If an account exists for {email.trim()}, we sent
+                                a password-reset link. The link expires and can
+                                only be used once.
+                            </p>
+                            <PillButton
+                                asChild
+                                tone="black"
+                                size="normal"
+                                className="mt-6"
+                            >
+                                <Link href="/login">Return to login</Link>
+                            </PillButton>
+                        </div>
+                    ) : (
+                        <>
+                            <h1 className="text-2xl font-medium font-serif text-gray-950">
+                                Reset your password
+                            </h1>
+                            <p className="mt-2 text-sm leading-relaxed text-gray-500">
+                                Enter your account email and we will send you a
+                                secure reset link.
+                            </p>
+                            <form
+                                onSubmit={handleSubmit}
+                                className="mt-6 space-y-4"
+                            >
+                                <div>
+                                    <label
+                                        htmlFor="email"
+                                        className="mb-2 block text-sm font-medium text-gray-700"
+                                    >
+                                        Email
+                                    </label>
+                                    <Input
+                                        id="email"
+                                        type="email"
+                                        autoComplete="email"
+                                        value={email}
+                                        onChange={(event) =>
+                                            setEmail(event.target.value)
+                                        }
+                                        required
+                                        className={`w-full ${authInputClassName}`}
+                                    />
+                                </div>
+                                <PillButton
+                                    type="submit"
+                                    tone="black"
+                                    size="normal"
+                                    disabled={loading || !email.trim()}
+                                    className="w-full"
+                                >
+                                    {loading
+                                        ? "Sending reset link..."
+                                        : "Send reset link"}
+                                </PillButton>
+                            </form>
+                            <div className="mt-5 text-center">
+                                <Link
+                                    href="/login"
+                                    className="text-sm font-medium text-gray-500 transition-colors hover:text-gray-950"
+                                >
+                                    Return to login
+                                </Link>
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/app/lib/authRedirects.test.ts
+++ b/frontend/src/app/lib/authRedirects.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+    authCallbackUrl,
+    authErrorDescription,
+    browserAuthCallbackUrl,
+    safeAuthNext,
+} from "./authRedirects";
+
+describe("safeAuthNext", () => {
+    it("allows known internal destinations with query parameters", () => {
+        expect(safeAuthNext("/settings?emailChange=processed")).toBe(
+            "/settings?emailChange=processed",
+        );
+        expect(safeAuthNext("/reset-password")).toBe("/reset-password");
+    });
+
+    it.each([
+        "assistant",
+        "https://evil.example",
+        "//evil.example/path",
+        "/unknown",
+        "/settings\\evil",
+        "/settings\n/assistant",
+    ])("rejects unsafe destination %s", (candidate) => {
+        expect(safeAuthNext(candidate)).toBe("/assistant");
+    });
+
+    it("uses a caller-provided fallback when no destination is supplied", () => {
+        expect(safeAuthNext(undefined, "/login")).toBe("/login");
+    });
+});
+
+describe("authCallbackUrl", () => {
+    it("builds an origin-bound callback with an encoded safe destination", () => {
+        expect(
+            authCallbackUrl(
+                "https://app.example.com",
+                "/settings?emailChange=processed",
+            ),
+        ).toBe(
+            "https://app.example.com/auth/callback?next=%2Fsettings%3FemailChange%3Dprocessed",
+        );
+    });
+
+    it("builds callbacks from the browser origin", () => {
+        expect(browserAuthCallbackUrl("/reset-password")).toBe(
+            "http://localhost:3000/auth/callback?next=%2Freset-password",
+        );
+    });
+});
+
+describe("authErrorDescription", () => {
+    it("reads provider errors from query parameters or implicit-flow hashes", () => {
+        expect(
+            authErrorDescription("?error_description=Expired+link", ""),
+        ).toBe("Expired link");
+        expect(
+            authErrorDescription("", "#error=access_denied"),
+        ).toBe("access_denied");
+        expect(authErrorDescription("?error=query_error", "")).toBe(
+            "query_error",
+        );
+        expect(
+            authErrorDescription("", "#error_description=Invalid+request"),
+        ).toBe("Invalid request");
+        expect(authErrorDescription("", "")).toBeNull();
+    });
+});

--- a/frontend/src/app/lib/authRedirects.ts
+++ b/frontend/src/app/lib/authRedirects.ts
@@ -1,0 +1,53 @@
+const AUTH_REDIRECT_PATHS = new Set([
+    "/assistant",
+    "/login",
+    "/reset-password",
+    "/settings",
+]);
+
+export function safeAuthNext(
+    candidate: string | null | undefined,
+    fallback = "/assistant",
+): string {
+    if (!candidate || !candidate.startsWith("/") || candidate.startsWith("//")) {
+        return fallback;
+    }
+    if (candidate.includes("\\") || /[\u0000-\u001f\u007f]/.test(candidate)) {
+        return fallback;
+    }
+
+    const base = new URL("https://auth.mike.local");
+    const resolved = new URL(candidate, base);
+    if (
+        resolved.origin !== base.origin ||
+        !AUTH_REDIRECT_PATHS.has(resolved.pathname)
+    ) {
+        return fallback;
+    }
+    return `${resolved.pathname}${resolved.search}`;
+}
+
+export function authCallbackUrl(origin: string, next: string): string {
+    const callback = new URL("/auth/callback", origin);
+    callback.searchParams.set("next", safeAuthNext(next));
+    return callback.toString();
+}
+
+export function browserAuthCallbackUrl(next: string): string | undefined {
+    if (typeof window === "undefined") return undefined;
+    return authCallbackUrl(window.location.origin, next);
+}
+
+export function authErrorDescription(
+    search: string,
+    hash: string,
+): string | null {
+    const query = new URLSearchParams(search);
+    const fragment = new URLSearchParams(hash.replace(/^#/, ""));
+    return (
+        query.get("error_description") ||
+        query.get("error") ||
+        fragment.get("error_description") ||
+        fragment.get("error")
+    );
+}

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LoginPage from "./page";
+
+const { signInWithPassword, replace, push } = vi.hoisted(() => ({
+    signInWithPassword: vi.fn(),
+    replace: vi.fn(),
+    push: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ replace, push }),
+}));
+
+vi.mock("@/app/lib/supabase", () => ({
+    supabase: { auth: { signInWithPassword } },
+}));
+
+vi.mock("@/app/contexts/AuthContext", () => ({
+    useAuth: () => ({ isAuthenticated: false, authLoading: false }),
+}));
+
+vi.mock("@/app/components/site-logo", () => ({
+    SiteLogo: () => <div>Mike</div>,
+}));
+
+describe("LoginPage", () => {
+    beforeEach(() => {
+        signInWithPassword.mockReset();
+        replace.mockReset();
+        push.mockReset();
+    });
+
+    it("allows an existing account to submit a password shorter than the new minimum", async () => {
+        signInWithPassword.mockResolvedValue({ error: null });
+        const user = userEvent.setup();
+        render(<LoginPage />);
+
+        await user.type(
+            screen.getByRole("textbox", { name: "Email" }),
+            "existing@example.com",
+        );
+        await user.type(screen.getByLabelText("Password"), "oldpass");
+        await user.click(screen.getByRole("button", { name: "Log in" }));
+
+        expect(signInWithPassword).toHaveBeenCalledWith({
+            email: "existing@example.com",
+            password: "oldpass",
+        });
+        expect(push).toHaveBeenCalledWith("/assistant");
+    });
+});

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -3,22 +3,16 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/app/lib/supabase";
-import { Button } from "@/app/components/ui/button";
 import { Input } from "@/app/components/ui/input";
+import { PillButton } from "@/app/components/ui/pill-button";
 import Link from "next/link";
 import { SiteLogo } from "@/app/components/site-logo";
 import { useAuth } from "@/app/contexts/AuthContext";
-
-const authGlassCardClassName =
-    "rounded-2xl border border-white/70 bg-white/72 p-8 shadow-[0_4px_14px_rgba(15,23,42,0.045),inset_0_1px_0_rgba(255,255,255,0.86),inset_0_-8px_18px_rgba(255,255,255,0.12)] backdrop-blur-2xl";
-const authInputClassName =
-    "rounded-lg border border-transparent bg-gray-100 px-3 shadow-none focus-visible:border-gray-200 focus-visible:ring-2 focus-visible:ring-gray-300/45";
-const authToggleClassName =
-    "flex gap-1 rounded-full bg-gray-200 p-1 text-xs font-medium";
-const authToggleActiveClassName =
-    "inline-flex h-6 items-center rounded-full border border-white/80 bg-white/86 px-3 text-gray-900 shadow-[0_2px_7px_rgba(15,23,42,0.08),inset_0_1px_0_rgba(255,255,255,0.9),inset_0_-3px_7px_rgba(229,231,235,0.32)] backdrop-blur-xl";
-const authToggleInactiveClassName =
-    "inline-flex h-6 items-center rounded-full border border-transparent px-3 text-gray-500 transition-colors hover:bg-white/38 hover:text-gray-900";
+import { cn } from "@/app/lib/utils";
+import {
+    authGlassCardClassName,
+    authInputClassName,
+} from "@/app/components/auth/authStyles";
 
 export default function LoginPage() {
     const router = useRouter();
@@ -60,29 +54,18 @@ export default function LoginPage() {
     };
 
     return (
-        <div className="min-h-dvh bg-gray-50/80 flex items-start justify-center px-6 pt-32 md:pt-40 pb-10 relative">
+        <div className="relative flex min-h-dvh items-center justify-center bg-gray-50/80 px-6 py-10">
             <div className="absolute top-4 md:top-8 left-1/2 -translate-x-1/2">
                 <SiteLogo size="lg" asLink />
             </div>
             <div className="w-full max-w-md">
                 {/* Login Form */}
-                <div className={`${authGlassCardClassName} mb-4`}>
-                    <div className="flex justify-between items-center mb-6">
-                        <h2 className="text-left text-2xl font-medium font-serif text-gray-950">
-                            Log In
-                        </h2>
-                        <div className={authToggleClassName}>
-                            <span className={authToggleActiveClassName}>
-                                Log in
-                            </span>
-                            <Link
-                                href="/signup"
-                                className={authToggleInactiveClassName}
-                            >
-                                Sign up
-                            </Link>
-                        </div>
-                    </div>
+                <div
+                    className={cn(authGlassCardClassName, "mb-4 pb-5")}
+                >
+                    <h2 className="mb-6 text-left text-2xl font-medium font-serif text-gray-950">
+                        Log In
+                    </h2>
                     <form onSubmit={handleLogin} className="space-y-4">
                         <div>
                             <label
@@ -96,19 +79,26 @@ export default function LoginPage() {
                                 type="email"
                                 value={email}
                                 onChange={(e) => setEmail(e.target.value)}
-                                placeholder="Enter your email"
                                 required
                                 className={`w-full ${authInputClassName}`}
                             />
                         </div>
 
                         <div>
-                            <label
-                                htmlFor="password"
-                                className="block text-sm font-medium text-gray-700 mb-2"
-                            >
-                                Password
-                            </label>
+                            <div className="mb-2 flex items-center justify-between gap-3">
+                                <label
+                                    htmlFor="password"
+                                    className="block text-sm font-medium text-gray-700"
+                                >
+                                    Password
+                                </label>
+                                <Link
+                                    href="/forgot-password"
+                                    className="text-xs font-medium text-gray-500 transition-colors hover:text-gray-950"
+                                >
+                                    Forgot password?
+                                </Link>
+                            </div>
                             <Input
                                 id="password"
                                 type="password"
@@ -126,13 +116,26 @@ export default function LoginPage() {
                             </div>
                         )}
 
-                        <Button
-                            type="submit"
-                            disabled={loading}
-                            className="w-full mt-5 bg-black hover:bg-gray-900 text-white"
-                        >
-                            {loading ? "Logging in..." : "Log in"}
-                        </Button>
+                        <div className="pt-2">
+                            <PillButton
+                                type="submit"
+                                tone="black"
+                                size="normal"
+                                disabled={loading}
+                                className="w-full"
+                            >
+                                {loading ? "Logging in..." : "Log in"}
+                            </PillButton>
+                        </div>
+                        <div className="text-center text-sm text-gray-500">
+                            Don&apos;t have an account?{" "}
+                            <Link
+                                href="/signup"
+                                className="font-medium transition-colors hover:text-gray-950"
+                            >
+                                Sign up
+                            </Link>
+                        </div>
                     </form>
                 </div>
             </div>

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Loader2 } from "lucide-react";
+import { Input } from "@/app/components/ui/input";
+import { PillButton } from "@/app/components/ui/pill-button";
+import { SiteLogo } from "@/app/components/site-logo";
+import {
+    authGlassCardClassName,
+    authInputClassName,
+} from "@/app/components/auth/authStyles";
+import {
+    MIN_PASSWORD_LENGTH,
+    minimumPasswordMessage,
+} from "@/app/components/auth/passwordPolicy";
+import { supabase } from "@/app/lib/supabase";
+
+function ResetPasswordContent() {
+    const searchParams = useSearchParams();
+    const [ready, setReady] = useState(false);
+    const [password, setPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [success, setSuccess] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const preview =
+        process.env.NODE_ENV !== "production"
+            ? searchParams.get("preview")
+            : null;
+    const isVerifyingPreview = preview === "reset-verifying";
+    const isUnavailablePreview = preview === "reset-unavailable";
+    const displayedReady = isUnavailablePreview || ready;
+    const displayedError = isUnavailablePreview
+        ? "This password-reset link is invalid or has expired."
+        : error;
+    const resetUnavailable =
+        displayedReady && !!displayedError && !password && !confirmPassword;
+    const verticallyCentered = !displayedReady || success || resetUnavailable;
+
+    useEffect(() => {
+        if (isVerifyingPreview || isUnavailablePreview) return;
+
+        let cancelled = false;
+        void supabase.auth
+            .getSession()
+            .then(({ data, error: sessionError }) => {
+                if (cancelled) return;
+                if (sessionError || !data.session) {
+                    setError(
+                        "This password-reset link is invalid or has expired.",
+                    );
+                }
+                setReady(true);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [isUnavailablePreview, isVerifyingPreview]);
+
+    async function handleSubmit(event: React.FormEvent) {
+        event.preventDefault();
+        setError(null);
+        if (password.length < MIN_PASSWORD_LENGTH) {
+            setError(`${minimumPasswordMessage}.`);
+            return;
+        }
+        if (password !== confirmPassword) {
+            setError("Passwords do not match.");
+            return;
+        }
+
+        setLoading(true);
+        try {
+            const { error: updateError } = await supabase.auth.updateUser({
+                password,
+            });
+            if (updateError) throw updateError;
+            await supabase.auth.signOut({ scope: "global" });
+            setSuccess(true);
+        } catch (updateError) {
+            setError(
+                updateError instanceof Error
+                    ? updateError.message
+                    : "Unable to update your password.",
+            );
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <div
+            className={`relative flex min-h-dvh justify-center bg-gray-50/80 px-6 ${
+                verticallyCentered
+                    ? "items-center py-10"
+                    : "items-start pb-10 pt-32 md:pt-40"
+            }`}
+        >
+            <div className="absolute top-4 md:top-8 left-1/2 -translate-x-1/2">
+                <SiteLogo size="lg" asLink />
+            </div>
+            <div className="w-full max-w-md">
+                <div className={authGlassCardClassName}>
+                    {!displayedReady ? (
+                        <div>
+                            <Loader2 className="h-6 w-6 animate-spin text-gray-500" />
+                            <h1 className="mt-4 font-serif text-2xl font-medium text-gray-950">
+                                Verifying your reset link...
+                            </h1>
+                            <p className="mt-2 text-sm text-gray-500">
+                                This should only take a moment.
+                            </p>
+                        </div>
+                    ) : success ? (
+                        <div>
+                            <h1 className="text-2xl font-medium font-serif text-gray-950">
+                                Password updated
+                            </h1>
+                            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+                                Your password has been changed. Log in again
+                                with your new password.
+                            </p>
+                            <PillButton
+                                asChild
+                                tone="black"
+                                size="normal"
+                                className="mt-6"
+                            >
+                                <Link href="/login">Log in</Link>
+                            </PillButton>
+                        </div>
+                    ) : resetUnavailable ? (
+                        <div>
+                            <h1 className="text-2xl font-medium font-serif text-gray-950">
+                                Reset link unavailable
+                            </h1>
+                            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+                                {displayedError}
+                            </p>
+                            <PillButton
+                                asChild
+                                tone="black"
+                                size="normal"
+                                className="mt-6"
+                            >
+                                <Link href="/forgot-password">
+                                    Request another link
+                                </Link>
+                            </PillButton>
+                        </div>
+                    ) : (
+                        <>
+                            <h1 className="text-2xl font-medium font-serif text-gray-950">
+                                Choose a new password
+                            </h1>
+                            <p className="mt-2 text-sm text-gray-500">
+                                Use at least {MIN_PASSWORD_LENGTH} characters.
+                            </p>
+                            <form
+                                onSubmit={handleSubmit}
+                                className="mt-6 space-y-4"
+                            >
+                                <div>
+                                    <label
+                                        htmlFor="password"
+                                        className="mb-2 block text-sm font-medium text-gray-700"
+                                    >
+                                        New password
+                                    </label>
+                                    <Input
+                                        id="password"
+                                        type="password"
+                                        autoComplete="new-password"
+                                        value={password}
+                                        onChange={(event) =>
+                                            setPassword(event.target.value)
+                                        }
+                                        required
+                                        className={`w-full ${authInputClassName}`}
+                                    />
+                                </div>
+                                <div>
+                                    <label
+                                        htmlFor="confirmPassword"
+                                        className="mb-2 block text-sm font-medium text-gray-700"
+                                    >
+                                        Confirm new password
+                                    </label>
+                                    <Input
+                                        id="confirmPassword"
+                                        type="password"
+                                        autoComplete="new-password"
+                                        value={confirmPassword}
+                                        onChange={(event) =>
+                                            setConfirmPassword(
+                                                event.target.value,
+                                            )
+                                        }
+                                        required
+                                        className={`w-full ${authInputClassName}`}
+                                    />
+                                </div>
+                                {error && (
+                                    <div className="rounded bg-red-50 p-3 text-sm text-red-600">
+                                        {error}
+                                    </div>
+                                )}
+                                <PillButton
+                                    type="submit"
+                                    tone="black"
+                                    size="normal"
+                                    disabled={
+                                        loading || !password || !confirmPassword
+                                    }
+                                    className="w-full"
+                                >
+                                    {loading
+                                        ? "Updating password..."
+                                        : "Update password"}
+                                </PillButton>
+                            </form>
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default function ResetPasswordPage() {
+    return (
+        <Suspense fallback={null}>
+            <ResetPasswordContent />
+        </Suspense>
+    );
+}

--- a/frontend/src/app/signup/check-email/page.test.tsx
+++ b/frontend/src/app/signup/check-email/page.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SignupCheckEmailPage from "./page";
+
+const { replace, useAuth } = vi.hoisted(() => ({
+    replace: vi.fn(),
+    useAuth: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ replace }),
+}));
+
+vi.mock("@/app/contexts/AuthContext", () => ({ useAuth }));
+
+vi.mock("@/app/components/site-logo", () => ({
+    SiteLogo: () => <div>Mike</div>,
+}));
+
+describe("SignupCheckEmailPage", () => {
+    beforeEach(() => {
+        replace.mockReset();
+        useAuth.mockReturnValue({
+            isAuthenticated: false,
+            authLoading: false,
+        });
+    });
+
+    it("shows the confirmation instructions on a dedicated route", () => {
+        render(<SignupCheckEmailPage />);
+
+        expect(
+            screen.getByRole("heading", { name: "Check your email" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("link", { name: "Return to login" }),
+        ).toHaveAttribute("href", "/login");
+    });
+
+    it("redirects authenticated users to the assistant", async () => {
+        useAuth.mockReturnValue({
+            isAuthenticated: true,
+            authLoading: false,
+        });
+
+        render(<SignupCheckEmailPage />);
+
+        await waitFor(() => {
+            expect(replace).toHaveBeenCalledWith("/assistant");
+        });
+        expect(
+            screen.queryByRole("heading", { name: "Check your email" }),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/app/signup/check-email/page.tsx
+++ b/frontend/src/app/signup/check-email/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
+import { authGlassCardClassName } from "@/app/components/auth/authStyles";
+import { SiteLogo } from "@/app/components/site-logo";
+import { PillButton } from "@/app/components/ui/pill-button";
+import { useAuth } from "@/app/contexts/AuthContext";
+
+export default function SignupCheckEmailPage() {
+    const router = useRouter();
+    const { isAuthenticated, authLoading } = useAuth();
+
+    useEffect(() => {
+        if (!authLoading && isAuthenticated) {
+            router.replace("/assistant");
+        }
+    }, [authLoading, isAuthenticated, router]);
+
+    return (
+        <div className="relative flex min-h-dvh items-center justify-center bg-gray-50/80 px-6 py-10">
+            <div className="absolute top-4 left-1/2 -translate-x-1/2 md:top-8">
+                <SiteLogo size="lg" asLink />
+            </div>
+            <div className="w-full max-w-md">
+                <div className={authGlassCardClassName}>
+                    {authLoading || isAuthenticated ? (
+                        <Loader2 className="mx-auto h-6 w-6 animate-spin text-gray-500" />
+                    ) : (
+                        <>
+                            <h1 className="font-serif text-2xl font-medium text-gray-950">
+                                Check your email
+                            </h1>
+                            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+                                We sent a confirmation link to your email
+                                address. Confirm your address before logging in.
+                            </p>
+                            <PillButton
+                                asChild
+                                tone="black"
+                                size="normal"
+                                className="mt-6"
+                            >
+                                <Link href="/login">Return to login</Link>
+                            </PillButton>
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/app/signup/page.test.tsx
+++ b/frontend/src/app/signup/page.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SignupPage from "./page";
+
+const { signUp, replace, push } = vi.hoisted(() => ({
+    signUp: vi.fn(),
+    replace: vi.fn(),
+    push: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ replace, push }),
+    useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/app/lib/supabase", () => ({
+    supabase: { auth: { signUp } },
+}));
+
+vi.mock("@/app/contexts/AuthContext", () => ({
+    useAuth: () => ({ isAuthenticated: false, authLoading: false }),
+}));
+
+vi.mock("@/app/lib/mikeApi", () => ({
+    updateUserProfile: vi.fn(),
+}));
+
+vi.mock("@/app/components/site-logo", () => ({
+    SiteLogo: () => <div>Mike</div>,
+}));
+
+describe("SignupPage", () => {
+    beforeEach(() => {
+        signUp.mockReset();
+        replace.mockReset();
+        push.mockReset();
+    });
+
+    it("rejects a whitespace-only name", () => {
+        render(<SignupPage />);
+
+        fireEvent.change(screen.getByLabelText("Name"), {
+            target: { value: "   " },
+        });
+        fireEvent.submit(
+            screen.getByRole("button", { name: "Sign up" }).closest("form")!,
+        );
+
+        expect(screen.getByText("Name is required")).toBeInTheDocument();
+        expect(signUp).not.toHaveBeenCalled();
+    });
+
+    it("stores profile metadata and waits for email confirmation", async () => {
+        signUp.mockResolvedValue({
+            data: { session: null, user: { id: "user-1" } },
+            error: null,
+        });
+        const user = userEvent.setup();
+        render(<SignupPage />);
+
+        await user.type(screen.getByLabelText(/Name/), "  Alex  ");
+        await user.type(
+            screen.getByLabelText(/Organisation/),
+            "  Example LLP  ",
+        );
+        await user.type(
+            screen.getByRole("textbox", { name: "Email" }),
+            "alex@example.com",
+        );
+        await user.type(screen.getByLabelText("Password"), "secret1234");
+        await user.type(
+            screen.getByLabelText("Confirm Password"),
+            "secret1234",
+        );
+        await user.click(screen.getByRole("button", { name: "Sign up" }));
+
+        expect(signUp).toHaveBeenCalledWith({
+            email: "alex@example.com",
+            password: "secret1234",
+            options: {
+                emailRedirectTo:
+                    "http://localhost:3000/auth/callback?next=%2Fassistant%3Fconfirmed%3D1",
+                data: {
+                    display_name: "Alex",
+                    organisation: "Example LLP",
+                },
+            },
+        });
+        expect(push).toHaveBeenCalledWith("/signup/check-email");
+    });
+});

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -1,29 +1,28 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { supabase } from "@/app/lib/supabase";
-import { Button } from "@/app/components/ui/button";
 import { Input } from "@/app/components/ui/input";
+import { PillButton } from "@/app/components/ui/pill-button";
 import Link from "next/link";
 import { SiteLogo } from "@/app/components/site-logo";
-import { CheckCircle2 } from "lucide-react";
 import { useAuth } from "@/app/contexts/AuthContext";
 import { updateUserProfile } from "@/app/lib/mikeApi";
+import { browserAuthCallbackUrl } from "@/app/lib/authRedirects";
+import { cn } from "@/app/lib/utils";
+import {
+    authGlassCardClassName,
+    authInputClassName,
+} from "@/app/components/auth/authStyles";
+import {
+    MIN_PASSWORD_LENGTH,
+    minimumPasswordMessage,
+} from "@/app/components/auth/passwordPolicy";
 
-const authGlassCardClassName =
-    "rounded-2xl border border-white/70 bg-white/72 p-8 shadow-[0_4px_14px_rgba(15,23,42,0.045),inset_0_1px_0_rgba(255,255,255,0.86),inset_0_-8px_18px_rgba(255,255,255,0.12)] backdrop-blur-2xl";
-const authInputClassName =
-    "rounded-lg border border-transparent bg-gray-100 px-3 shadow-none focus-visible:border-gray-200 focus-visible:ring-2 focus-visible:ring-gray-300/45";
-const authToggleClassName =
-    "flex gap-1 rounded-full bg-gray-200 p-1 text-xs font-medium";
-const authToggleActiveClassName =
-    "inline-flex h-6 items-center rounded-full border border-white/80 bg-white/86 px-3 text-gray-900 shadow-[0_2px_7px_rgba(15,23,42,0.08),inset_0_1px_0_rgba(255,255,255,0.9),inset_0_-3px_7px_rgba(229,231,235,0.32)] backdrop-blur-xl";
-const authToggleInactiveClassName =
-    "inline-flex h-6 items-center rounded-full border border-transparent px-3 text-gray-500 transition-colors hover:bg-white/38 hover:text-gray-900";
-
-export default function SignupPage() {
+function SignupContent() {
     const router = useRouter();
+    const searchParams = useSearchParams();
     const { isAuthenticated, authLoading } = useAuth();
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
@@ -33,17 +32,33 @@ export default function SignupPage() {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [success, setSuccess] = useState(false);
+    const isAccountCreatedPreview =
+        process.env.NODE_ENV !== "production" &&
+        searchParams.get("preview") === "account-created";
 
     useEffect(() => {
+        if (isAccountCreatedPreview) return;
         if (!authLoading && isAuthenticated && !success) {
             router.replace("/assistant");
         }
-    }, [authLoading, isAuthenticated, router, success]);
+    }, [
+        authLoading,
+        isAccountCreatedPreview,
+        isAuthenticated,
+        router,
+        success,
+    ]);
 
     const handleSignup = async (e: React.FormEvent) => {
         e.preventDefault();
         setLoading(true);
         setError(null);
+
+        if (!name.trim()) {
+            setError("Name is required");
+            setLoading(false);
+            return;
+        }
 
         // Validate passwords match
         if (password !== confirmPassword) {
@@ -53,23 +68,34 @@ export default function SignupPage() {
         }
 
         // Validate password length
-        if (password.length < 6) {
-            setError("Password must be at least 6 characters");
+        if (password.length < MIN_PASSWORD_LENGTH) {
+            setError(minimumPasswordMessage);
             setLoading(false);
             return;
         }
 
         try {
+            const trimmedEmail = email.trim();
+            const trimmedName = name.trim();
+            const trimmedOrg = organisation.trim();
+            const emailRedirectTo = browserAuthCallbackUrl(
+                "/assistant?confirmed=1",
+            );
             const { data, error } = await supabase.auth.signUp({
-                email,
+                email: trimmedEmail,
                 password,
+                options: {
+                    ...(emailRedirectTo ? { emailRedirectTo } : {}),
+                    data: {
+                        display_name: trimmedName || null,
+                        organisation: trimmedOrg || null,
+                    },
+                },
             });
 
             if (error) throw error;
 
             if (data.session) {
-                const trimmedName = name.trim();
-                const trimmedOrg = organisation.trim();
                 if (trimmedName || trimmedOrg) {
                     try {
                         await updateUserProfile({
@@ -83,11 +109,13 @@ export default function SignupPage() {
                         );
                     }
                 }
+                setSuccess(true);
+                setTimeout(() => {
+                    router.push("/assistant");
+                }, 2000);
+            } else {
+                router.push("/signup/check-email");
             }
-            setSuccess(true);
-            setTimeout(() => {
-                router.push("/assistant");
-            }, 2000);
         } catch (error: unknown) {
             setError(
                 error instanceof Error
@@ -100,25 +128,28 @@ export default function SignupPage() {
     };
 
     // Success View
-    if (success) {
+    if (success || isAccountCreatedPreview) {
         return (
-            <div className="min-h-dvh bg-gray-50/80 flex items-start justify-center px-6 pt-32 md:pt-40 pb-10 relative">
+            <div className="relative flex min-h-dvh items-center justify-center bg-gray-50/80 px-6 py-10">
                 <div className="absolute top-4 md:top-8 left-1/2 -translate-x-1/2">
                     <SiteLogo size="lg" asLink />
                 </div>
                 <div className="w-full max-w-md">
-                    <div
-                        className={`${authGlassCardClassName} p-10 text-center`}
-                    >
-                        <div className="mx-auto w-12 h-12 bg-green-50 rounded-full flex items-center justify-center mb-6">
-                            <CheckCircle2 className="h-6 w-6 text-green-600" />
-                        </div>
-                        <h2 className="text-2xl font-bold text-gray-950 mb-3">
+                    <div className={authGlassCardClassName}>
+                        <h1 className="font-serif text-2xl font-medium text-gray-950">
                             Account created!
-                        </h2>
-                        <p className="text-gray-600 leading-relaxed">
+                        </h1>
+                        <p className="mt-3 text-sm leading-relaxed text-gray-600">
                             Redirecting you to the home page...
                         </p>
+                        <PillButton
+                            asChild
+                            tone="black"
+                            size="normal"
+                            className="mt-6"
+                        >
+                            <Link href="/assistant">Continue</Link>
+                        </PillButton>
                     </div>
                 </div>
             </div>
@@ -132,23 +163,10 @@ export default function SignupPage() {
                 <SiteLogo size="lg" asLink />
             </div>
             <div className="w-full max-w-md">
-                <div className={`${authGlassCardClassName} mb-4`}>
-                    <div className="flex justify-between items-center mb-6">
-                        <h2 className="text-left text-2xl font-medium font-serif text-gray-950">
-                            Create Account
-                        </h2>
-                        <div className={authToggleClassName}>
-                            <Link
-                                href="/login"
-                                className={authToggleInactiveClassName}
-                            >
-                                Log in
-                            </Link>
-                            <span className={authToggleActiveClassName}>
-                                Sign up
-                            </span>
-                        </div>
-                    </div>
+                <div className={cn(authGlassCardClassName, "mb-4 pb-5")}>
+                    <h2 className="mb-6 text-left text-2xl font-medium font-serif text-gray-950">
+                        Sign Up
+                    </h2>
 
                     <form onSubmit={handleSignup} className="space-y-4">
                         <div>
@@ -156,17 +174,15 @@ export default function SignupPage() {
                                 htmlFor="name"
                                 className="block text-sm font-medium text-gray-700 mb-2"
                             >
-                                Name{" "}
-                                <span className="text-gray-400 font-normal">
-                                    (optional)
-                                </span>
+                                Name
                             </label>
                             <Input
                                 id="name"
                                 type="text"
                                 value={name}
                                 onChange={(e) => setName(e.target.value)}
-                                placeholder="Your name"
+                                maxLength={200}
+                                required
                                 className={`w-full ${authInputClassName}`}
                             />
                         </div>
@@ -188,7 +204,7 @@ export default function SignupPage() {
                                 onChange={(e) =>
                                     setOrganisation(e.target.value)
                                 }
-                                placeholder="Your organisation"
+                                maxLength={200}
                                 className={`w-full ${authInputClassName}`}
                             />
                         </div>
@@ -205,7 +221,6 @@ export default function SignupPage() {
                                 type="email"
                                 value={email}
                                 onChange={(e) => setEmail(e.target.value)}
-                                placeholder="Enter your email"
                                 required
                                 className={`w-full ${authInputClassName}`}
                             />
@@ -223,7 +238,7 @@ export default function SignupPage() {
                                 type="password"
                                 value={password}
                                 onChange={(e) => setPassword(e.target.value)}
-                                placeholder="Create a password (min. 6 characters)"
+                                placeholder={`Create a password (min. ${MIN_PASSWORD_LENGTH} characters)`}
                                 required
                                 className={`w-full ${authInputClassName}`}
                             />
@@ -243,7 +258,6 @@ export default function SignupPage() {
                                 onChange={(e) =>
                                     setConfirmPassword(e.target.value)
                                 }
-                                placeholder="Confirm your password"
                                 required
                                 className={`w-full ${authInputClassName}`}
                             />
@@ -255,38 +269,57 @@ export default function SignupPage() {
                             </div>
                         )}
 
-                        <Button
-                            type="submit"
-                            disabled={loading}
-                            className="w-full bg-black hover:bg-gray-900 text-white"
-                        >
-                            {loading ? "Creating account..." : "Sign up"}
-                        </Button>
+                        <div className="space-y-3 pt-2">
+                            <div className="text-center text-xs text-gray-500">
+                                By signing up, you agree to our{" "}
+                                <Link
+                                    href="https://mikeoss.com/terms"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-blue-600 hover:underline"
+                                >
+                                    Terms of Use
+                                </Link>{" "}
+                                and{" "}
+                                <Link
+                                    href="https://mikeoss.com/privacy"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-blue-600 hover:underline"
+                                >
+                                    Privacy Policy
+                                </Link>
+                            </div>
+                            <PillButton
+                                type="submit"
+                                tone="black"
+                                size="normal"
+                                disabled={loading}
+                                className="w-full"
+                            >
+                                {loading ? "Creating account..." : "Sign up"}
+                            </PillButton>
+                        </div>
+                        <div className="text-center text-sm text-gray-500">
+                            Have an account?{" "}
+                            <Link
+                                href="/login"
+                                className="font-medium transition-colors hover:text-gray-950"
+                            >
+                                Log in
+                            </Link>
+                        </div>
                     </form>
-
-                    {/* Terms and Privacy */}
-                    <div className="mt-4 text-center text-xs text-gray-500">
-                        By signing up, you agree to our{" "}
-                        <Link
-                            href="https://mikeoss.com/terms"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-blue-600 hover:underline"
-                        >
-                            Terms of Use
-                        </Link>{" "}
-                        and{" "}
-                        <Link
-                            href="https://mikeoss.com/privacy"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-blue-600 hover:underline"
-                        >
-                            Privacy Policy
-                        </Link>
-                    </div>
                 </div>
             </div>
         </div>
+    );
+}
+
+export default function SignupPage() {
+    return (
+        <Suspense fallback={null}>
+            <SignupContent />
+        </Suspense>
     );
 }

--- a/frontend/src/app/verify-mfa/page.tsx
+++ b/frontend/src/app/verify-mfa/page.tsx
@@ -7,6 +7,7 @@ import { SiteLogo } from "@/app/components/site-logo";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { useAuth } from "@/app/contexts/AuthContext";
 import { supabase } from "@/app/lib/supabase";
+import { authGlassCardClassName } from "@/app/components/auth/authStyles";
 import {
     needsMfaVerification,
     VerificationCodeInput,
@@ -19,9 +20,6 @@ type MfaFactor = {
     factor_type: string;
 };
 
-const authGlassCardClassName =
-    "rounded-2xl border border-white/70 bg-white/72 px-8 py-8 shadow-[0_4px_14px_rgba(15,23,42,0.045),inset_0_1px_0_rgba(255,255,255,0.86),inset_0_-8px_18px_rgba(255,255,255,0.12)] backdrop-blur-2xl";
-
 export default function VerifyMfaPage() {
     const router = useRouter();
     const searchParams = useSearchParams();
@@ -32,12 +30,33 @@ export default function VerifyMfaPage() {
     const [loading, setLoading] = useState(true);
     const [verifying, setVerifying] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const isMfaPreview =
+        process.env.NODE_ENV !== "production" &&
+        searchParams.get("preview") === "mfa";
+    const displayedFactors = isMfaPreview
+        ? [
+              {
+                  id: "preview-factor",
+                  friendly_name: "Authenticator app",
+                  factor_type: "totp",
+              },
+          ]
+        : factors;
+    const displayedFactorId = isMfaPreview
+        ? "preview-factor"
+        : selectedFactorId;
+    const displayedLoading = isMfaPreview ? false : loading;
 
     const nextPath = safeNextPath(searchParams.get("next"));
     const canVerify =
-        !loading && !verifying && !!selectedFactorId && code.trim().length === 6;
+        !displayedLoading &&
+        !verifying &&
+        !!displayedFactorId &&
+        code.trim().length === 6;
 
     useEffect(() => {
+        if (isMfaPreview) return;
+
         if (authLoading) return;
         if (!user) {
             router.replace("/login");
@@ -88,7 +107,7 @@ export default function VerifyMfaPage() {
         return () => {
             cancelled = true;
         };
-    }, [authLoading, nextPath, router, user]);
+    }, [authLoading, isMfaPreview, nextPath, router, user]);
 
     async function verify() {
         if (!canVerify) return;
@@ -97,7 +116,7 @@ export default function VerifyMfaPage() {
         setError(null);
         const { error: verifyError } =
             await supabase.auth.mfa.challengeAndVerify({
-                factorId: selectedFactorId,
+                factorId: displayedFactorId,
                 code: code.trim(),
             });
         setVerifying(false);
@@ -118,13 +137,13 @@ export default function VerifyMfaPage() {
     }
 
     return (
-        <div className="relative flex min-h-dvh items-start justify-center bg-gray-50/80 px-6 pb-10 pt-32 md:pt-40">
+        <div className="relative flex min-h-dvh items-center justify-center bg-gray-50/80 px-6 py-10">
             <div className="absolute left-1/2 top-4 -translate-x-1/2 md:top-8">
                 <SiteLogo size="lg" asLink />
             </div>
             <div className={`w-full max-w-md ${authGlassCardClassName}`}>
                 <div className="mb-8 space-y-2">
-                    <h1 className="text-2xl font-serif">
+                    <h1 className="font-serif text-2xl font-medium text-gray-950">
                         Verify your identity
                     </h1>
                     <p className="text-sm text-gray-500">
@@ -134,27 +153,27 @@ export default function VerifyMfaPage() {
                 </div>
 
                 <div className="space-y-6">
-                    {loading ? (
+                    {displayedLoading ? (
                         <div className="flex h-13 items-center justify-center text-sm text-gray-500">
                             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                             Loading authenticator...
                         </div>
-                    ) : factors.length === 0 ? (
+                    ) : displayedFactors.length === 0 ? (
                         <p className="rounded-lg bg-gray-100 px-3 py-2 text-sm text-gray-600">
                             No verified authenticator factor is available for
                             this session.
                         </p>
                     ) : (
                         <>
-                            {factors.length > 1 && (
+                            {displayedFactors.length > 1 && (
                                 <select
-                                    value={selectedFactorId}
+                                    value={displayedFactorId}
                                     onChange={(event) =>
                                         setSelectedFactorId(event.target.value)
                                     }
                                     className="h-9 w-full rounded-lg border border-transparent bg-gray-100 px-3 text-sm text-gray-900 shadow-none outline-none focus-visible:border-gray-200 focus-visible:ring-2 focus-visible:ring-gray-300/45"
                                 >
-                                    {factors.map((factor) => (
+                                    {displayedFactors.map((factor) => (
                                         <option
                                             key={factor.id}
                                             value={factor.id}
@@ -169,7 +188,7 @@ export default function VerifyMfaPage() {
                                 value={code}
                                 onChange={setCode}
                                 disabled={verifying}
-                                autoFocus={!loading}
+                                autoFocus={!displayedLoading}
                                 canSubmit={canVerify}
                                 onSubmit={() => void verify()}
                             />


### PR DESCRIPTION
## Summary

Adds complete email-verification and password-recovery flows around Supabase Auth, including signup confirmation, confirmed email-address changes, forgot/reset password screens, safe callback handling, and consistent authentication UI.

## Changes

### Signup and email confirmation

- Sends new signups through Supabase email confirmation while leaving the deployment's autoconfirm choice configurable.
- Requires a display name during signup and carries profile metadata through the confirmation flow.
- Adds `/signup/check-email` and callback/result states for confirmation, account creation, expired links, and authentication errors.
- Prevents already-confirmed users from being left on the check-email screen.

### Email-address changes

- Routes email changes through Supabase's secure double-confirmation flow.
- Adds settings feedback for pending email changes and friendly rate-limit warnings.
- Mirrors a confirmed Auth email change into `user_profiles.email` through a database trigger.

### Password recovery

- Adds the forgot-password request page, recovery callback handling, reset-password form, and password-updated result state.
- Uses a shared minimum password length of 10 for signup and password changes. Existing accounts with shorter passwords remain valid until their password is changed.
- Restricts post-authentication redirects to an explicit internal allow list.

### UI

- Aligns login, signup, confirmation, recovery, MFA, and result screens around the same vertically centered card treatment, `shadow-sm`, left-aligned copy, and pill actions.
- Updates authentication navigation prompts, field placeholders, spacing, terms placement, warning presentation, and the sign-out icon.

### Local and production configuration

- Enables local email confirmation and secure password changes in Supabase config.
- Configures local SMTP delivery through Resend using `RESEND_API_KEY` from `backend/.env`, with `noreply@mikeoss.com` and `MikeOSS (No Reply)` as sender details.
- Uses `localhost:3000` and explicit `/auth/callback` redirect allow-list entries.
- Documents production SMTP, callback URL, confirmation, password-policy, migration, and troubleshooting requirements.

## Database

Adds `20260819_01_auth_email_confirmation.sql`, which:

- preserves signup profile metadata while confirmation is pending;
- keeps existing non-empty profile fields during trigger upserts; and
- updates the profile email mirror only after Supabase commits the confirmed Auth email change.

## Validation

- `npx tsc --noEmit` in `frontend`
- 5 auth-focused Vitest files: 18 tests passing
