### PR TITLE
Review fixes for #365: gate exemptions, lossless autosave, migration fallback, add-in OAuth hardening

### DIFF
--- a/backend/src/__tests__/integration/user.routes.test.ts
+++ b/backend/src/__tests__/integration/user.routes.test.ts
@@ -53,6 +53,7 @@ type QueryResult = { data: unknown; error: unknown };
 // (first select fails with 42703, the retry succeeds).
 let supabaseState: {
     tables: Record<string, QueryResult | QueryResult[]>;
+    updates: Record<string, unknown[]>;
     adminGetUserById: QueryResult;
     adminDeleteUser: { error: unknown };
 };
@@ -60,6 +61,7 @@ let supabaseState: {
 function resetSupabaseState() {
     supabaseState = {
         tables: {},
+        updates: {},
         adminGetUserById: {
             data: { user: { id: "u1", factors: [] } },
             error: null,
@@ -104,6 +106,12 @@ function makeQuery(table: string) {
         "contains",
     ];
     for (const m of chain) q[m] = vi.fn(() => q);
+    // Record update payloads so tests can assert what a route WROTE (the
+    // per-table result stub only models what queries return).
+    q.update = vi.fn((payload: unknown) => {
+        (supabaseState.updates[table] ??= []).push(payload);
+        return q;
+    });
     q.single = vi.fn(() => Promise.resolve(resultForTable(table)));
     q.maybeSingle = vi.fn(() => Promise.resolve(resultForTable(table)));
     q.then = (
@@ -359,6 +367,39 @@ describe("user.routes", () => {
             });
         });
 
+        it("keeps live onboarding columns when only migration 02 is missing", async () => {
+            // password_set_at (20260821_02) missing must NOT drop the
+            // migration-01 columns that DO exist — otherwise a new user on
+            // such a database would report onboardingComplete: true and
+            // skip onboarding entirely.
+            const migration01Row = profileRow({ onboarding_version: null });
+            delete (migration01Row as Record<string, unknown>).password_set_at;
+            supabaseState.tables.user_profiles = [
+                {
+                    data: null,
+                    error: {
+                        code: "42703",
+                        message:
+                            "column user_profiles.password_set_at does not exist",
+                    },
+                },
+                { data: migration01Row, error: null },
+            ];
+
+            const res = await request(app)
+                .get("/user/profile")
+                .set(...AUTH);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toMatchObject({
+                jurisdiction: "Singapore",
+                practiceAreas: ["Corporate and M&A"],
+                onboardingComplete: false,
+                onboardingVersion: null,
+                passwordSet: false,
+            });
+        });
+
         it("returns 500 with detail when the profile load errors", async () => {
             supabaseState.tables.user_profiles = {
                 data: null,
@@ -577,10 +618,15 @@ describe("user.routes", () => {
 
         // display_name and organisation are injected into every chat's
         // system prompt, so their size must be bounded like the other
-        // personalisation fields (200 matches handle_new_user's cap).
-        it.each(["displayName", "organisation"])(
-            "rejects a %s longer than 200 characters",
-            async (field) => {
+        // personalisation fields. Truncation (not rejection) mirrors
+        // handle_new_user's left(..., 200) and keeps any over-long value
+        // written before the cap editable rather than stuck.
+        it.each([
+            ["displayName", "display_name"],
+            ["organisation", "organisation"],
+        ] as const)(
+            "truncates %s to 200 characters",
+            async (field, column) => {
                 supabaseState.tables.user_profiles = {
                     data: profileRow(),
                     error: null,
@@ -589,12 +635,13 @@ describe("user.routes", () => {
                 const res = await request(app)
                     .patch("/user/profile")
                     .set(...AUTH)
-                    .send({ [field]: "x".repeat(201) });
+                    .send({ [field]: "x".repeat(250) });
 
-                expect(res.status).toBe(400);
-                expect(res.body.detail).toBe(
-                    `${field} must be 200 characters or fewer`,
-                );
+                expect(res.status).toBe(200);
+                const written = supabaseState.updates.user_profiles?.at(-1) as
+                    | Record<string, unknown>
+                    | undefined;
+                expect(written?.[column]).toBe("x".repeat(200));
             },
         );
     });

--- a/backend/src/__tests__/integration/user.routes.test.ts
+++ b/backend/src/__tests__/integration/user.routes.test.ts
@@ -48,8 +48,11 @@ const {
 // ---------------------------------------------------------------------------
 type QueryResult = { data: unknown; error: unknown };
 
+// A table entry may be a queue of results: each query consumes the next one,
+// and the last repeats. Lets tests drive the selectProfile fallback cascade
+// (first select fails with 42703, the retry succeeds).
 let supabaseState: {
-    tables: Record<string, QueryResult>;
+    tables: Record<string, QueryResult | QueryResult[]>;
     adminGetUserById: QueryResult;
     adminDeleteUser: { error: unknown };
 };
@@ -67,7 +70,13 @@ function resetSupabaseState() {
 resetSupabaseState();
 
 function resultForTable(table: string): QueryResult {
-    return supabaseState.tables[table] ?? { data: null, error: null };
+    const entry = supabaseState.tables[table];
+    if (Array.isArray(entry)) {
+        return entry.length > 1
+            ? (entry.shift() as QueryResult)
+            : (entry[0] ?? { data: null, error: null });
+    }
+    return entry ?? { data: null, error: null };
 }
 
 function makeQuery(table: string) {
@@ -304,6 +313,52 @@ describe("user.routes", () => {
             expect(requireMfaIfEnrolled).not.toHaveBeenCalled();
         });
 
+        it("keeps saved preferences on a database without the onboarding migration", async () => {
+            // Replicated live (PR #365 review): with the 20260821 columns
+            // dropped, the profile select failed on "jurisdiction", skipped
+            // every fallback tier, and silently reset legal_research_us and
+            // quick_actions_visible to defaults. The retry tier must preserve
+            // the user's saved values and report legacy-exempt onboarding.
+            const preMigrationRow = {
+                display_name: "Ada",
+                organisation: "Acme",
+                message_credits_used: 3,
+                credits_reset_date: "2999-01-01T00:00:00.000Z",
+                tier: "Pro",
+                title_model: null,
+                tabular_model: "gemini-3-flash-preview",
+                mfa_on_login: false,
+                legal_research_us: false,
+                quick_actions_visible: false,
+            };
+            supabaseState.tables.user_profiles = [
+                {
+                    data: null,
+                    error: {
+                        code: "42703",
+                        message:
+                            "column user_profiles.jurisdiction does not exist",
+                    },
+                },
+                { data: preMigrationRow, error: null },
+            ];
+
+            const res = await request(app)
+                .get("/user/profile")
+                .set(...AUTH);
+
+            expect(res.status).toBe(200);
+            expect(res.body).toMatchObject({
+                legalResearchUs: false,
+                quickActionsVisible: false,
+                onboardingComplete: true,
+                onboardingVersion: 0,
+                passwordSet: false,
+                jurisdiction: null,
+                practiceAreas: [],
+            });
+        });
+
         it("returns 500 with detail when the profile load errors", async () => {
             supabaseState.tables.user_profiles = {
                 data: null,
@@ -519,6 +574,29 @@ describe("user.routes", () => {
 
             expect(res.status).toBe(200);
         });
+
+        // display_name and organisation are injected into every chat's
+        // system prompt, so their size must be bounded like the other
+        // personalisation fields (200 matches handle_new_user's cap).
+        it.each(["displayName", "organisation"])(
+            "rejects a %s longer than 200 characters",
+            async (field) => {
+                supabaseState.tables.user_profiles = {
+                    data: profileRow(),
+                    error: null,
+                };
+
+                const res = await request(app)
+                    .patch("/user/profile")
+                    .set(...AUTH)
+                    .send({ [field]: "x".repeat(201) });
+
+                expect(res.status).toBe(400);
+                expect(res.body.detail).toBe(
+                    `${field} must be 200 characters or fewer`,
+                );
+            },
+        );
     });
 
     describe("POST /user/onboarding", () => {

--- a/backend/src/lib/__tests__/userSettings.test.ts
+++ b/backend/src/lib/__tests__/userSettings.test.ts
@@ -122,3 +122,77 @@ describe("getUserModelSettings router-model allowlist", () => {
         expect(settings.tabular_model).toBe("claude-sonnet-5");
     });
 });
+
+// A database without the 20260821 onboarding migration rejects the widened
+// select outright (42703). The retry with the pre-migration column set must
+// preserve the user's saved models and legal-research choice — silently
+// resetting them was the severe half of the un-migrated-DB bug.
+function retryingProfileDb(
+    first: { data: unknown; error: unknown },
+    second: { data: unknown; error: unknown },
+) {
+    const results = [first, second];
+    const chain: Record<string, unknown> = {};
+    for (const method of ["from", "select", "eq"]) {
+        chain[method] = vi.fn(() => chain);
+    }
+    chain.single = vi.fn(async () => results.shift() ?? second);
+    return chain as never;
+}
+
+describe("getUserModelSettings on an un-migrated database", () => {
+    it("retries without the onboarding columns and keeps saved settings", async () => {
+        const settings = await getUserModelSettings(
+            "user-1",
+            retryingProfileDb(
+                {
+                    data: null,
+                    error: {
+                        code: "42703",
+                        message:
+                            "column user_profiles.jurisdiction does not exist",
+                    },
+                },
+                {
+                    data: {
+                        title_model: "claude-haiku-4-5",
+                        tabular_model: "claude-sonnet-5",
+                        legal_research_us: false,
+                    },
+                    error: null,
+                },
+            ),
+        );
+
+        expect(settings.title_model).toBe("claude-haiku-4-5");
+        expect(settings.tabular_model).toBe("claude-sonnet-5");
+        expect(settings.legal_research_us).toBe(false);
+        expect(settings.personalisation).toMatchObject({
+            displayName: null,
+            practiceAreas: [],
+        });
+    });
+
+    it("falls back to defaults when the retry also fails", async () => {
+        const settings = await getUserModelSettings(
+            "user-1",
+            retryingProfileDb(
+                {
+                    data: null,
+                    error: {
+                        code: "42703",
+                        message:
+                            "column user_profiles.jurisdiction does not exist",
+                    },
+                },
+                {
+                    data: null,
+                    error: { code: "42703", message: "even older database" },
+                },
+            ),
+        );
+
+        expect(settings.legal_research_us).toBe(true);
+        expect(settings.title_model).toBeTruthy();
+    });
+});

--- a/backend/src/lib/userSettings.ts
+++ b/backend/src/lib/userSettings.ts
@@ -65,7 +65,21 @@ export async function getUserModelSettings(
         getStoredUserApiKeys(userId, client),
         getAllUserRouterModels(userId, client),
     ]);
-    const data = profileResult.data;
+    let data = profileResult.data;
+
+    // A database that predates the 20260821 onboarding migration rejects the
+    // select above outright (unknown column), which would silently fall every
+    // caller back to default models and re-enable US legal research for users
+    // who turned it off. Retry with the pre-migration column set so saved
+    // settings keep working; personalisation simply stays empty.
+    if (profileResult.error?.code === "42703") {
+        const legacy = await client
+            .from("user_profiles")
+            .select("title_model, tabular_model, legal_research_us")
+            .eq("user_id", userId)
+            .single();
+        data = legacy.data as typeof data;
+    }
 
     // A stored preference can name a router model the user has since removed
     // from (or never had in) their saved selection — e.g. a hand-crafted

--- a/backend/src/lib/userSettings.ts
+++ b/backend/src/lib/userSettings.ts
@@ -78,7 +78,10 @@ export async function getUserModelSettings(
             .select("title_model, tabular_model, legal_research_us")
             .eq("user_id", userId)
             .single();
-        data = legacy.data as typeof data;
+        // A second failure (a database even older than the pre-migration
+        // shape) keeps data null and falls through to the defaults below —
+        // the pre-retry behavior, now explicit instead of accidental.
+        data = legacy.error ? null : (legacy.data as typeof data);
     }
 
     // A stored preference can name a router model the user has since removed

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -181,6 +181,18 @@ function mcpOAuthPopupCsp(nonce: string) {
 
 const PROFILE_SELECT =
     "display_name, organisation, jurisdiction, practice_setting, professional_title, practice_areas, onboarding_version, password_set_at, message_credits_used, credits_reset_date, tier, title_model, tabular_model, mfa_on_login, legal_research_us, quick_actions_visible";
+// PROFILE_SELECT minus the 20260821 onboarding / password-capability columns,
+// for databases that have not applied those migrations yet.
+const PROFILE_SELECT_NO_ONBOARDING =
+    "display_name, organisation, message_credits_used, credits_reset_date, tier, title_model, tabular_model, mfa_on_login, legal_research_us, quick_actions_visible";
+const ONBOARDING_PROFILE_COLUMNS = [
+    "jurisdiction",
+    "practice_setting",
+    "professional_title",
+    "practice_areas",
+    "onboarding_version",
+    "password_set_at",
+];
 const PROFILE_SELECT_NO_QUICK_ACTIONS =
     "display_name, organisation, message_credits_used, credits_reset_date, tier, title_model, tabular_model, mfa_on_login, legal_research_us";
 const PROFILE_SELECT_NO_LEGAL =
@@ -217,8 +229,33 @@ async function selectProfile(
             ? await fullQuery.single()
             : await fullQuery.maybeSingle();
     if (!full.error) return full;
+    let cascadeError: unknown = full.error;
 
-    if (isMissingProfileColumn(full.error, "quick_actions_visible")) {
+    // A database that predates the 20260821 onboarding / password-capability
+    // migrations rejects the full select on the first of the new columns,
+    // which would otherwise skip every tier below (they key on *their* new
+    // column's name) and land on a select that silently resets model,
+    // legal-research and quick-action preferences to defaults. Retry without
+    // the onboarding columns: serializeProfile treats the absent fields as
+    // legacy-exempt, which matches what the migration would backfill.
+    if (
+        ONBOARDING_PROFILE_COLUMNS.some((column) =>
+            isMissingProfileColumn(cascadeError, column),
+        )
+    ) {
+        const preOnboardingQuery = db
+            .from("user_profiles")
+            .select(PROFILE_SELECT_NO_ONBOARDING)
+            .eq("user_id", userId);
+        const preOnboarding =
+            mode === "single"
+                ? await preOnboardingQuery.single()
+                : await preOnboardingQuery.maybeSingle();
+        if (!preOnboarding.error) return preOnboarding;
+        cascadeError = preOnboarding.error;
+    }
+
+    if (isMissingProfileColumn(cascadeError, "quick_actions_visible")) {
         const previousQuery = db
             .from("user_profiles")
             .select(PROFILE_SELECT_NO_QUICK_ACTIONS)
@@ -639,6 +676,10 @@ function validateProfilePayload(body: unknown):
     if (!personalisation.ok) return personalisation;
     Object.assign(update, personalisation.update);
 
+    // Both fields flow into every chat's system prompt via
+    // buildUserPersonalisationPrompt, so an unbounded value would inflate
+    // token cost on every message. 200 matches the cap the signup trigger
+    // (handle_new_user) applies to the same columns.
     if ("displayName" in raw) {
         if (raw.displayName !== null && typeof raw.displayName !== "string") {
             return {
@@ -646,7 +687,14 @@ function validateProfilePayload(body: unknown):
                 detail: "displayName must be a string or null",
             };
         }
-        update.display_name = raw.displayName?.trim() || null;
+        const displayName = raw.displayName?.trim() || null;
+        if (displayName && displayName.length > 200) {
+            return {
+                ok: false,
+                detail: "displayName must be 200 characters or fewer",
+            };
+        }
+        update.display_name = displayName;
     }
 
     if ("organisation" in raw) {
@@ -656,7 +704,14 @@ function validateProfilePayload(body: unknown):
                 detail: "organisation must be a string or null",
             };
         }
-        update.organisation = raw.organisation?.trim() || null;
+        const organisation = raw.organisation?.trim() || null;
+        if (organisation && organisation.length > 200) {
+            return {
+                ok: false,
+                detail: "organisation must be 200 characters or fewer",
+            };
+        }
+        update.organisation = organisation;
     }
 
     if ("tabularModel" in raw) {

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -182,7 +182,11 @@ function mcpOAuthPopupCsp(nonce: string) {
 const PROFILE_SELECT =
     "display_name, organisation, jurisdiction, practice_setting, professional_title, practice_areas, onboarding_version, password_set_at, message_credits_used, credits_reset_date, tier, title_model, tabular_model, mfa_on_login, legal_research_us, quick_actions_visible";
 // PROFILE_SELECT minus the 20260821 onboarding / password-capability columns,
-// for databases that have not applied those migrations yet.
+// for databases that have not applied those migrations yet. Migration 02
+// (password_set_at) gets its own tier so a database that applied 01 but not
+// 02 keeps its live onboarding/personalisation columns.
+const PROFILE_SELECT_NO_PASSWORD =
+    "display_name, organisation, jurisdiction, practice_setting, professional_title, practice_areas, onboarding_version, message_credits_used, credits_reset_date, tier, title_model, tabular_model, mfa_on_login, legal_research_us, quick_actions_visible";
 const PROFILE_SELECT_NO_ONBOARDING =
     "display_name, organisation, message_credits_used, credits_reset_date, tier, title_model, tabular_model, mfa_on_login, legal_research_us, quick_actions_visible";
 const ONBOARDING_PROFILE_COLUMNS = [
@@ -191,7 +195,6 @@ const ONBOARDING_PROFILE_COLUMNS = [
     "professional_title",
     "practice_areas",
     "onboarding_version",
-    "password_set_at",
 ];
 const PROFILE_SELECT_NO_QUICK_ACTIONS =
     "display_name, organisation, message_credits_used, credits_reset_date, tier, title_model, tabular_model, mfa_on_login, legal_research_us";
@@ -231,13 +234,27 @@ async function selectProfile(
     if (!full.error) return full;
     let cascadeError: unknown = full.error;
 
-    // A database that predates the 20260821 onboarding / password-capability
-    // migrations rejects the full select on the first of the new columns,
-    // which would otherwise skip every tier below (they key on *their* new
-    // column's name) and land on a select that silently resets model,
-    // legal-research and quick-action preferences to defaults. Retry without
-    // the onboarding columns: serializeProfile treats the absent fields as
-    // legacy-exempt, which matches what the migration would backfill.
+    // A database that predates the 20260821 migrations rejects the full
+    // select on the first of the new columns, which would otherwise skip
+    // every tier below (they key on *their* new column's name) and land on
+    // a select that silently resets the legal-research and quick-action
+    // preferences to defaults. Two retry tiers, most-migrated first:
+    // missing only password_set_at (migration 02) keeps the live
+    // onboarding columns; missing the migration-01 columns drops them all,
+    // and serializeProfile treats the absent fields as legacy-exempt —
+    // matching what the migration's backfill would write.
+    if (isMissingProfileColumn(cascadeError, "password_set_at")) {
+        const prePasswordQuery = db
+            .from("user_profiles")
+            .select(PROFILE_SELECT_NO_PASSWORD)
+            .eq("user_id", userId);
+        const prePassword =
+            mode === "single"
+                ? await prePasswordQuery.single()
+                : await prePasswordQuery.maybeSingle();
+        if (!prePassword.error) return prePassword;
+        cascadeError = prePassword.error;
+    }
     if (
         ONBOARDING_PROFILE_COLUMNS.some((column) =>
             isMissingProfileColumn(cascadeError, column),
@@ -678,8 +695,10 @@ function validateProfilePayload(body: unknown):
 
     // Both fields flow into every chat's system prompt via
     // buildUserPersonalisationPrompt, so an unbounded value would inflate
-    // token cost on every message. 200 matches the cap the signup trigger
-    // (handle_new_user) applies to the same columns.
+    // token cost on every message. Truncate (not reject) at 200 characters:
+    // that is exactly what the signup trigger (handle_new_user's
+    // left(..., 200)) does to the same columns, and rejection would strand
+    // any over-long value written before this cap existed.
     if ("displayName" in raw) {
         if (raw.displayName !== null && typeof raw.displayName !== "string") {
             return {
@@ -687,14 +706,8 @@ function validateProfilePayload(body: unknown):
                 detail: "displayName must be a string or null",
             };
         }
-        const displayName = raw.displayName?.trim() || null;
-        if (displayName && displayName.length > 200) {
-            return {
-                ok: false,
-                detail: "displayName must be 200 characters or fewer",
-            };
-        }
-        update.display_name = displayName;
+        update.display_name =
+            raw.displayName?.trim().slice(0, 200) || null;
     }
 
     if ("organisation" in raw) {
@@ -704,14 +717,8 @@ function validateProfilePayload(body: unknown):
                 detail: "organisation must be a string or null",
             };
         }
-        const organisation = raw.organisation?.trim() || null;
-        if (organisation && organisation.length > 200) {
-            return {
-                ok: false,
-                detail: "organisation must be 200 characters or fewer",
-            };
-        }
-        update.organisation = organisation;
+        update.organisation =
+            raw.organisation?.trim().slice(0, 200) || null;
     }
 
     if ("tabularModel" in raw) {

--- a/frontend/src/app/(pages)/settings/page.test.tsx
+++ b/frontend/src/app/(pages)/settings/page.test.tsx
@@ -9,6 +9,10 @@ const state = vi.hoisted(() => ({
     updateDisplayName: vi.fn(),
     updateOrganisation: vi.fn(),
     passwordSet: false,
+    profile: {
+        displayName: "Alex",
+        organisation: "Example LLP",
+    },
     user: {
         id: "user-1",
         email: "alex@example.com",
@@ -32,8 +36,7 @@ vi.mock("@/app/contexts/AuthContext", () => ({
 vi.mock("@/app/contexts/UserProfileContext", () => ({
     useUserProfile: () => ({
         profile: {
-            displayName: "Alex",
-            organisation: "Example LLP",
+            ...state.profile,
             passwordSet: state.passwordSet,
             tier: "Free",
         },
@@ -66,6 +69,35 @@ describe("SettingsPage Google email changes", () => {
             pendingEmail: "new@example.com",
         });
         state.passwordSet = false;
+        state.profile = {
+            displayName: "Alex",
+            organisation: "Example LLP",
+        };
+    });
+
+    it("keeps in-progress organisation text when the name autosave lands", async () => {
+        const user = userEvent.setup();
+        state.updateDisplayName.mockImplementation(async (name: string) => {
+            // Mirror the real context: a successful save refreshes the profile.
+            state.profile = { ...state.profile, displayName: name };
+            return true;
+        });
+        render(<SettingsPage />);
+
+        const name = screen.getByPlaceholderText("Enter your name");
+        const organisation = screen.getByPlaceholderText(
+            "Enter your organisation",
+        );
+        await user.clear(name);
+        await user.type(name, "Alexandra");
+        await user.click(organisation); // blurs the name field -> autosave
+        await user.type(organisation, " & Partners");
+
+        await waitFor(() =>
+            expect(state.updateDisplayName).toHaveBeenCalledWith("Alexandra"),
+        );
+        expect(organisation).toHaveValue("Example LLP & Partners");
+        expect(name).toHaveValue("Alexandra");
     });
 
     it("directs Google-created accounts without a password to Security", async () => {

--- a/frontend/src/app/(pages)/settings/page.test.tsx
+++ b/frontend/src/app/(pages)/settings/page.test.tsx
@@ -77,11 +77,25 @@ describe("SettingsPage Google email changes", () => {
 
     it("keeps in-progress organisation text when the name autosave lands", async () => {
         const user = userEvent.setup();
-        state.updateDisplayName.mockImplementation(async (name: string) => {
-            // Mirror the real context: a successful save refreshes the profile.
-            state.profile = { ...state.profile, displayName: name };
-            return true;
-        });
+        // The save must still be IN FLIGHT while the user types in the
+        // sibling field — an immediately-resolved mock closes the race
+        // window inside user.click()'s microtask flush and the test then
+        // passes even against the unfixed combined hydration effect.
+        let resolveNameSave!: () => void;
+        state.updateDisplayName.mockImplementation(
+            (name: string) =>
+                new Promise<boolean>((resolve) => {
+                    resolveNameSave = () => {
+                        // Mirror the real context: a successful save
+                        // refreshes the whole profile object.
+                        state.profile = {
+                            ...state.profile,
+                            displayName: name,
+                        };
+                        resolve(true);
+                    };
+                }),
+        );
         render(<SettingsPage />);
 
         const name = screen.getByPlaceholderText("Enter your name");
@@ -93,8 +107,10 @@ describe("SettingsPage Google email changes", () => {
         await user.click(organisation); // blurs the name field -> autosave
         await user.type(organisation, " & Partners");
 
+        expect(state.updateDisplayName).toHaveBeenCalledWith("Alexandra");
+        resolveNameSave(); // profile refresh lands mid-typing
         await waitFor(() =>
-            expect(state.updateDisplayName).toHaveBeenCalledWith("Alexandra"),
+            expect(screen.getByText("Saved")).toBeInTheDocument(),
         );
         expect(organisation).toHaveValue("Example LLP & Partners");
         expect(name).toHaveValue("Alexandra");

--- a/frontend/src/app/(pages)/settings/page.tsx
+++ b/frontend/src/app/(pages)/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
 import { PillButton } from "@/app/components/ui/pill-button";
@@ -32,6 +32,8 @@ export default function SettingsPage() {
     const router = useRouter();
     const { user, signOut, updateEmail } = useAuth();
     const { profile, updateDisplayName, updateOrganisation } = useUserProfile();
+    const displayNameInputRef = useRef<HTMLInputElement>(null);
+    const organisationInputRef = useRef<HTMLInputElement>(null);
     const [displayName, setDisplayName] = useState("");
     const [isSavingName, setIsSavingName] = useState(false);
     const [saved, setSaved] = useState(false);
@@ -53,10 +55,19 @@ export default function SettingsPage() {
     const requiresPasswordForEmailChange =
         user?.createdWithGoogle === true && profile?.passwordSet !== true;
 
+    // Each field syncs from the profile independently, and never while the
+    // user is typing in it: saving one field on blur refreshes the whole
+    // profile, and a combined sync here would wipe in-progress text from
+    // the sibling input when that refresh lands.
     useEffect(() => {
+        if (document.activeElement === displayNameInputRef.current) return;
         setDisplayName(profile?.displayName ?? "");
+    }, [profile?.displayName]);
+
+    useEffect(() => {
+        if (document.activeElement === organisationInputRef.current) return;
         setOrganisation(profile?.organisation ?? "");
-    }, [profile?.displayName, profile?.organisation]);
+    }, [profile?.organisation]);
 
     useEffect(() => {
         if (user?.email) {
@@ -230,6 +241,7 @@ export default function SettingsPage() {
                             </div>
                             <div className="space-y-2">
                                 <SettingsTextInput
+                                    ref={displayNameInputRef}
                                     type="text"
                                     value={displayName}
                                     onChange={(e) => {
@@ -262,6 +274,7 @@ export default function SettingsPage() {
                             </div>
                             <div className="space-y-2">
                                 <SettingsTextInput
+                                    ref={organisationInputRef}
                                     type="text"
                                     value={organisation}
                                     onChange={(e) => {

--- a/frontend/src/app/(pages)/settings/page.tsx
+++ b/frontend/src/app/(pages)/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
 import { PillButton } from "@/app/components/ui/pill-button";
@@ -32,8 +32,6 @@ export default function SettingsPage() {
     const router = useRouter();
     const { user, signOut, updateEmail } = useAuth();
     const { profile, updateDisplayName, updateOrganisation } = useUserProfile();
-    const displayNameInputRef = useRef<HTMLInputElement>(null);
-    const organisationInputRef = useRef<HTMLInputElement>(null);
     const [displayName, setDisplayName] = useState("");
     const [isSavingName, setIsSavingName] = useState(false);
     const [saved, setSaved] = useState(false);
@@ -55,17 +53,19 @@ export default function SettingsPage() {
     const requiresPasswordForEmailChange =
         user?.createdWithGoogle === true && profile?.passwordSet !== true;
 
-    // Each field syncs from the profile independently, and never while the
-    // user is typing in it: saving one field on blur refreshes the whole
-    // profile, and a combined sync here would wipe in-progress text from
-    // the sibling input when that refresh lands.
+    // Each field syncs from the profile independently. A combined effect
+    // (both setters, keyed on both values) wiped in-progress text from the
+    // sibling input whenever one field's blur-autosave refreshed the
+    // profile; per-field effects don't run then, because the sibling's own
+    // profile value did not change. Deliberately NO focused-input guard
+    // here: skipping the sync while focused let a profile that loads after
+    // mount leave the focused input empty, and blurring it then saved ""
+    // over the stored name.
     useEffect(() => {
-        if (document.activeElement === displayNameInputRef.current) return;
         setDisplayName(profile?.displayName ?? "");
     }, [profile?.displayName]);
 
     useEffect(() => {
-        if (document.activeElement === organisationInputRef.current) return;
         setOrganisation(profile?.organisation ?? "");
     }, [profile?.organisation]);
 
@@ -241,7 +241,6 @@ export default function SettingsPage() {
                             </div>
                             <div className="space-y-2">
                                 <SettingsTextInput
-                                    ref={displayNameInputRef}
                                     type="text"
                                     value={displayName}
                                     onChange={(e) => {
@@ -274,7 +273,6 @@ export default function SettingsPage() {
                             </div>
                             <div className="space-y-2">
                                 <SettingsTextInput
-                                    ref={organisationInputRef}
                                     type="text"
                                     value={organisation}
                                     onChange={(e) => {

--- a/frontend/src/app/(pages)/settings/personalisation/page.test.tsx
+++ b/frontend/src/app/(pages)/settings/personalisation/page.test.tsx
@@ -67,4 +67,46 @@ describe("PersonalisationPage", () => {
         );
         expect(screen.queryByText("(optional)")).not.toBeInTheDocument();
     });
+
+    it("still saves unrelated fields while an Other box is empty, and says why", async () => {
+        const user = userEvent.setup();
+        render(<PersonalisationPage />);
+
+        await user.click(
+            screen.getByRole("button", { name: "Practice areas" }),
+        );
+        await user.click(screen.getByRole("menuitemcheckbox", { name: "Other" }));
+        await user.keyboard("{Escape}");
+        expect(
+            screen.getByText("Enter your other practice area"),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: "Title" }));
+        await user.click(screen.getByRole("menuitemradio", { name: "Partner" }));
+        await waitFor(() =>
+            expect(updatePersonalisation).toHaveBeenCalledWith({
+                jurisdiction: "Singapore",
+                practiceSetting: "private_practice",
+                professionalTitle: "Partner",
+                // The half-finished Other box falls back to the stored areas.
+                practiceAreas: ["Litigation"],
+            }),
+        );
+    });
+
+    it("flushes a save that is still inside its debounce window on unmount", async () => {
+        const user = userEvent.setup();
+        const { unmount } = render(<PersonalisationPage />);
+
+        await user.click(screen.getByRole("button", { name: "Title" }));
+        await user.click(screen.getByRole("menuitemradio", { name: "Partner" }));
+        expect(updatePersonalisation).not.toHaveBeenCalled();
+
+        unmount();
+        await waitFor(() =>
+            expect(updatePersonalisation).toHaveBeenCalledWith(
+                expect.objectContaining({ professionalTitle: "Partner" }),
+            ),
+        );
+    });
 });

--- a/frontend/src/app/(pages)/settings/personalisation/page.test.tsx
+++ b/frontend/src/app/(pages)/settings/personalisation/page.test.tsx
@@ -94,6 +94,31 @@ describe("PersonalisationPage", () => {
         );
     });
 
+    it("does not drop an earlier pending edit when an Other box turns invalid", async () => {
+        const user = userEvent.setup();
+        const { unmount } = render(<PersonalisationPage />);
+
+        // Title edit is pending (still inside the debounce window)...
+        await user.click(screen.getByRole("button", { name: "Title" }));
+        await user.click(screen.getByRole("menuitemradio", { name: "Partner" }));
+        // ...when the user ticks "Other" and leaves it empty.
+        await user.click(
+            screen.getByRole("button", { name: "Practice areas" }),
+        );
+        await user.click(screen.getByRole("menuitemcheckbox", { name: "Other" }));
+        await user.keyboard("{Escape}");
+
+        unmount(); // flush: the Title change must survive
+        await waitFor(() =>
+            expect(updatePersonalisation).toHaveBeenCalledWith({
+                jurisdiction: "Singapore",
+                practiceSetting: "private_practice",
+                professionalTitle: "Partner",
+                practiceAreas: ["Litigation"],
+            }),
+        );
+    });
+
     it("flushes a save that is still inside its debounce window on unmount", async () => {
         const user = userEvent.setup();
         const { unmount } = render(<PersonalisationPage />);

--- a/frontend/src/app/(pages)/settings/personalisation/page.tsx
+++ b/frontend/src/app/(pages)/settings/personalisation/page.tsx
@@ -6,20 +6,10 @@ import {
     PersonalisationFields,
     personalisationInitialValues,
     type PersonalisationField,
-    type PersonalisationFieldGroup,
     usePersonalisationFields,
 } from "@/app/components/settings/PersonalisationFields";
 import { useUserProfile } from "@/app/contexts/UserProfileContext";
 import type { PersonalisationDetails } from "@/app/lib/mikeApi";
-
-const FIELD_GROUP: Record<PersonalisationField, PersonalisationFieldGroup> = {
-    professionalTitle: "professionalTitle",
-    practiceSetting: "practiceSetting",
-    jurisdiction: "jurisdiction",
-    otherJurisdiction: "jurisdiction",
-    practiceAreas: "practiceAreas",
-    otherPracticeArea: "practiceAreas",
-};
 
 function fieldStatus(
     field: PersonalisationField,
@@ -92,11 +82,13 @@ function PersonalisationForm({
         const snapshot = JSON.stringify(details);
         latestSnapshotRef.current = snapshot;
         flushRef.current = null;
-        if (
-            !pendingField ||
-            form.invalidGroups.includes(FIELD_GROUP[pendingField]) ||
-            snapshot === persistedSnapshotRef.current
-        ) {
+        // No per-field "is the edited group invalid" guard here: the
+        // substitution above already neutralises invalid groups, so the
+        // snapshot comparison alone decides. A guard keyed on the LAST
+        // edited field would drop an earlier still-pending change (edit
+        // Title, then tick an empty "Other" inside the debounce window —
+        // the Title edit must still be saved).
+        if (!pendingField || snapshot === persistedSnapshotRef.current) {
             return;
         }
 

--- a/frontend/src/app/(pages)/settings/personalisation/page.tsx
+++ b/frontend/src/app/(pages)/settings/personalisation/page.tsx
@@ -6,9 +6,20 @@ import {
     PersonalisationFields,
     personalisationInitialValues,
     type PersonalisationField,
+    type PersonalisationFieldGroup,
     usePersonalisationFields,
 } from "@/app/components/settings/PersonalisationFields";
 import { useUserProfile } from "@/app/contexts/UserProfileContext";
+import type { PersonalisationDetails } from "@/app/lib/mikeApi";
+
+const FIELD_GROUP: Record<PersonalisationField, PersonalisationFieldGroup> = {
+    professionalTitle: "professionalTitle",
+    practiceSetting: "practiceSetting",
+    jurisdiction: "jurisdiction",
+    otherJurisdiction: "jurisdiction",
+    practiceAreas: "practiceAreas",
+    otherPracticeArea: "practiceAreas",
+};
 
 function fieldStatus(
     field: PersonalisationField,
@@ -59,21 +70,39 @@ function PersonalisationForm({
     const latestSnapshotRef = useRef(initialSnapshot);
     const saveChainRef = useRef<Promise<void>>(Promise.resolve());
     const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const flushRef = useRef<(() => void) | null>(null);
 
     useEffect(() => {
-        const snapshot = JSON.stringify(form.details);
+        // A half-finished "Other …" box (ticked but empty) must not block
+        // saves of unrelated fields, and must never overwrite the stored
+        // value for its own group with a transient empty state — so those
+        // groups fall back to their last persisted values here.
+        const persisted = JSON.parse(
+            persistedSnapshotRef.current,
+        ) as PersonalisationDetails;
+        const details: PersonalisationDetails = {
+            ...form.details,
+            ...(form.invalidGroups.includes("jurisdiction")
+                ? { jurisdiction: persisted.jurisdiction }
+                : {}),
+            ...(form.invalidGroups.includes("practiceAreas")
+                ? { practiceAreas: persisted.practiceAreas }
+                : {}),
+        };
+        const snapshot = JSON.stringify(details);
         latestSnapshotRef.current = snapshot;
+        flushRef.current = null;
         if (
             !pendingField ||
-            form.validationError ||
+            form.invalidGroups.includes(FIELD_GROUP[pendingField]) ||
             snapshot === persistedSnapshotRef.current
         ) {
             return;
         }
 
         const field = pendingField;
-        const details = form.details;
-        const timeout = setTimeout(() => {
+        const fire = () => {
+            flushRef.current = null;
             saveChainRef.current = saveChainRef.current.then(async () => {
                 setSavingField(field);
                 setSavedField(null);
@@ -96,12 +125,14 @@ function PersonalisationForm({
                     );
                 }, 2000);
             });
-        }, 400);
+        };
+        const timeout = setTimeout(fire, 400);
+        flushRef.current = fire;
 
         return () => clearTimeout(timeout);
     }, [
         form.details,
-        form.validationError,
+        form.invalidGroups,
         pendingField,
         retryVersion,
         updatePersonalisation,
@@ -110,6 +141,9 @@ function PersonalisationForm({
     useEffect(
         () => () => {
             if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+            // A save still inside its debounce window when the user leaves
+            // the page fires immediately instead of being dropped.
+            flushRef.current?.();
         },
         [],
     );
@@ -134,6 +168,17 @@ function PersonalisationForm({
                                 fieldStatus(field, savingField, savedField)
                             }
                         />
+
+                        {form.validationError && !error && (
+                            <div
+                                className="mt-8 flex items-center justify-end text-xs"
+                                aria-live="polite"
+                            >
+                                <span className="text-red-600" role="alert">
+                                    {form.validationError}
+                                </span>
+                            </div>
+                        )}
 
                         {error && (
                             <div

--- a/frontend/src/app/components/auth/OnboardingGate.test.tsx
+++ b/frontend/src/app/components/auth/OnboardingGate.test.tsx
@@ -79,6 +79,21 @@ describe("OnboardingGate", () => {
         expect(state.replace).not.toHaveBeenCalled();
     });
 
+    it.each(["/reset-password", "/forgot-password", "/verify-mfa"])(
+        "lets incomplete users reach the credential-recovery page %s",
+        (path) => {
+            state.pathname = path;
+            render(
+                <OnboardingGate>
+                    <div>Recovery page</div>
+                </OnboardingGate>,
+            );
+
+            expect(screen.getByText("Recovery page")).toBeInTheDocument();
+            expect(state.replace).not.toHaveBeenCalled();
+        },
+    );
+
     it("redirects completed users away from onboarding", async () => {
         state.pathname = "/onboarding/practice";
         state.profile = {

--- a/frontend/src/app/components/auth/OnboardingGate.tsx
+++ b/frontend/src/app/components/auth/OnboardingGate.tsx
@@ -12,11 +12,18 @@ export function OnboardingGate({ children }: { children: ReactNode }) {
     const { user } = useAuth();
     const { profile, loading } = useUserProfile();
     const isOnboardingRoute = pathname.startsWith("/onboarding");
+    // Credential-recovery pages must stay reachable even when onboarding is
+    // incomplete: a recovery link logs the user in, and bouncing them to
+    // onboarding here would discard the recovery session before they can set
+    // a password (they'd stay locked out of their account forever).
     const isAuthTransitionRoute =
         pathname === "/login" ||
         pathname === "/signup" ||
         pathname === "/signup/check-email" ||
-        pathname === "/auth/callback";
+        pathname === "/auth/callback" ||
+        pathname === "/forgot-password" ||
+        pathname === "/reset-password" ||
+        pathname === "/verify-mfa";
     const needsOnboarding = profile?.onboardingComplete === false;
 
     useEffect(() => {

--- a/frontend/src/app/components/settings/PersonalisationFields.tsx
+++ b/frontend/src/app/components/settings/PersonalisationFields.tsx
@@ -129,6 +129,22 @@ export function usePersonalisationFields(
 
     const changed = (field: PersonalisationField) => onFieldChange?.(field);
 
+    const jurisdictionIncomplete =
+        jurisdictionChoice === OTHER_JURISDICTION_OPTION &&
+        !otherJurisdiction.trim();
+    const practiceAreasIncomplete = otherSelected && !otherArea.trim();
+    const invalidGroups = useMemo<PersonalisationFieldGroup[]>(
+        () => [
+            ...(jurisdictionIncomplete
+                ? (["jurisdiction"] as const)
+                : []),
+            ...(practiceAreasIncomplete
+                ? (["practiceAreas"] as const)
+                : []),
+        ],
+        [jurisdictionIncomplete, practiceAreasIncomplete],
+    );
+
     return {
         jurisdictionChoice,
         otherJurisdiction,
@@ -139,13 +155,12 @@ export function usePersonalisationFields(
         otherArea,
         practiceAreas,
         details,
-        validationError:
-            jurisdictionChoice === OTHER_JURISDICTION_OPTION &&
-            !otherJurisdiction.trim()
-                ? "Enter your jurisdiction of practice"
-                : otherSelected && !otherArea.trim()
-                  ? "Enter your other practice area"
-                  : null,
+        invalidGroups,
+        validationError: jurisdictionIncomplete
+            ? "Enter your jurisdiction of practice"
+            : practiceAreasIncomplete
+              ? "Enter your other practice area"
+              : null,
         setJurisdictionChoice(value: string) {
             setJurisdictionChoiceState(value);
             changed("jurisdiction");

--- a/word-addin/src/oauth-dialog/index.ts
+++ b/word-addin/src/oauth-dialog/index.ts
@@ -16,25 +16,20 @@ function setStatus(message: string): void {
 }
 
 function send(message: GoogleOAuthDialogMessage): boolean {
-  const payload = JSON.stringify(message);
+  // No legacy (option-less) retry on failure: dropping targetOrigin would
+  // weaken the receiver's origin check (session.ts skips it when the host
+  // omits event.origin), and every host this add-in supports has the
+  // DialogOrigin 1.1 set. A visible failure beats a weaker handoff.
   try {
-    Office.context.ui.messageParent(payload, {
+    Office.context.ui.messageParent(JSON.stringify(message), {
       targetOrigin: window.location.origin,
     });
     return true;
   } catch {
-    // Hosts without the DialogOrigin 1.1 requirement set reject the
-    // messageOptions overload. The legacy form is same-domain-only, which
-    // is the same restriction we were expressing explicitly above.
-    try {
-      Office.context.ui.messageParent(payload);
-      return true;
-    } catch {
-      setStatus(
-        "Could not hand the session back to Word. Close this window and try signing in again."
-      );
-      return false;
-    }
+    setStatus(
+      "Could not hand the session back to Word. Close this window and try signing in again."
+    );
+    return false;
   }
 }
 
@@ -122,16 +117,11 @@ async function runGoogleOAuth(): Promise<void> {
       accessToken: data.session.access_token,
       refreshToken: data.session.refresh_token,
     };
-    // Drop the temporary client's persisted copy of the session before
-    // handing the tokens to the task pane. scope "local" clears only this
-    // window's storage and refresh timer — it does not revoke the session
-    // the task pane is about to adopt.
-    try {
-      await supabase.auth.signOut({ scope: "local" });
-    } catch {
-      // Cleanup is best-effort; clearTemporaryAuthStorage below removes
-      // the persisted keys either way.
-    }
+    // Deliberately NO supabase.auth.signOut() here: even scope "local"
+    // POSTs /logout with the session JWT, and GoTrue revokes that session's
+    // refresh token server-side — the very token being handed to the task
+    // pane below. Removing the persisted storage keys (next line) plus
+    // autoRefreshToken:false is the complete local cleanup.
     clearTemporaryAuthStorage();
     if (send(message)) {
       setStatus("Signed in. You can return to Word.");

--- a/word-addin/src/oauth-dialog/index.ts
+++ b/word-addin/src/oauth-dialog/index.ts
@@ -15,10 +15,27 @@ function setStatus(message: string): void {
   if (element) element.textContent = message;
 }
 
-function send(message: GoogleOAuthDialogMessage): void {
-  Office.context.ui.messageParent(JSON.stringify(message), {
-    targetOrigin: window.location.origin,
-  });
+function send(message: GoogleOAuthDialogMessage): boolean {
+  const payload = JSON.stringify(message);
+  try {
+    Office.context.ui.messageParent(payload, {
+      targetOrigin: window.location.origin,
+    });
+    return true;
+  } catch {
+    // Hosts without the DialogOrigin 1.1 requirement set reject the
+    // messageOptions overload. The legacy form is same-domain-only, which
+    // is the same restriction we were expressing explicitly above.
+    try {
+      Office.context.ui.messageParent(payload);
+      return true;
+    } catch {
+      setStatus(
+        "Could not hand the session back to Word. Close this window and try signing in again."
+      );
+      return false;
+    }
+  }
 }
 
 function sendError(requestId: string, message: string): void {
@@ -32,8 +49,12 @@ function sendError(requestId: string, message: string): void {
 }
 
 function clearTemporaryAuthStorage(): void {
-  window.localStorage.removeItem(STORAGE_KEY);
-  window.localStorage.removeItem(`${STORAGE_KEY}-code-verifier`);
+  // localStorage is included only to sweep up sessions persisted there by
+  // earlier builds of this dialog; the client now writes sessionStorage.
+  for (const storage of [window.sessionStorage, window.localStorage]) {
+    storage.removeItem(STORAGE_KEY);
+    storage.removeItem(`${STORAGE_KEY}-code-verifier`);
+  }
   window.sessionStorage.removeItem(REQUEST_STORAGE_KEY);
 }
 
@@ -64,12 +85,19 @@ async function runGoogleOAuth(): Promise<void> {
     return;
   }
 
+  // This client exists only to run the PKCE round trip. Its persistence has
+  // to survive exactly one same-tab redirect (to Google and back), so it
+  // lives in sessionStorage — never localStorage, where a crash between the
+  // code exchange and cleanup would leave a full session readable on disk.
+  // The task pane's real session storage is OfficeRuntime.storage; browser
+  // storage must never hold long-lived credentials (see office-mock.ts).
   const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
     auth: {
+      autoRefreshToken: false,
       detectSessionInUrl: false,
       flowType: "pkce",
       persistSession: true,
-      storage: window.localStorage,
+      storage: window.sessionStorage,
       storageKey: STORAGE_KEY,
     },
   });
@@ -94,9 +122,20 @@ async function runGoogleOAuth(): Promise<void> {
       accessToken: data.session.access_token,
       refreshToken: data.session.refresh_token,
     };
+    // Drop the temporary client's persisted copy of the session before
+    // handing the tokens to the task pane. scope "local" clears only this
+    // window's storage and refresh timer — it does not revoke the session
+    // the task pane is about to adopt.
+    try {
+      await supabase.auth.signOut({ scope: "local" });
+    } catch {
+      // Cleanup is best-effort; clearTemporaryAuthStorage below removes
+      // the persisted keys either way.
+    }
     clearTemporaryAuthStorage();
-    setStatus("Signed in. You can return to Word.");
-    send(message);
+    if (send(message)) {
+      setStatus("Signed in. You can return to Word.");
+    }
     return;
   }
 

--- a/word-addin/src/taskpane/auth/session.ts
+++ b/word-addin/src/taskpane/auth/session.ts
@@ -377,7 +377,11 @@ export async function signInWithGoogle(): Promise<void> {
   const dialogUrl = new URL("/oauth-dialog.html", expectedOrigin);
   dialogUrl.searchParams.set("requestId", requestId);
 
-  _loading = true;
+  // Deliberately NOT `_loading = true`: that flag swaps the whole task pane
+  // for the bootstrap spinner (App.tsx renders it before the login page),
+  // which would unmount LoginPage and leave the user staring at a bare
+  // "Loading…" for the lifetime of the OAuth dialog with no way back. The
+  // login page stays mounted and shows its own "Continuing…" button state.
   _error = null;
   broadcast();
 
@@ -388,7 +392,6 @@ export async function signInWithGoogle(): Promise<void> {
       if (settled) return;
       settled = true;
       if (generation === _sessionGeneration) {
-        _loading = false;
         _error = message;
         broadcast();
       }
@@ -446,7 +449,6 @@ export async function signInWithGoogle(): Promise<void> {
                 generation
               ).then((saved) => {
                 if (saved && generation === _sessionGeneration) {
-                  _loading = false;
                   _error = null;
                   broadcast();
                 }


### PR DESCRIPTION
Review-fix stack for #365 (renders as a diff on top of that PR). Every fix below was **replicated live** on the local stack before being fixed, and re-verified live against the fixed code.

## How the base cases were replicated

Stack: repo compose services (gateway :54721), PR branch backend on :3001 and frontend on :3000, both PR migrations applied. Flows driven in Chrome; database claims proven with psql, not the UI.

- **Happy paths first (all worked):** email signup → 2-step onboarding → assistant greeting with the onboarded name; DB row shows `onboarding_version = 1` with all personalisation fields persisted. Legacy account (version 0) logs straight into the app, untouched by the gate. Simulated Google account (google identity row + magic link): gated into onboarding with Name pre-filled from Google's `full_name`, email editing blocked behind the "add a password" modal, Set-password flow flips `password_set_at` via the service-role RPC (verified against `auth.users`), and email editing unlocks after.

## Replications that motivated the fixes

1. **Reset-password lockout.** With `onboarding_version = NULL`, navigating to `/reset-password` with a session bounced to `/onboarding/profile` before the form painted — a user who abandoned onboarding could never complete a password reset. *Fixed:* recovery routes (`/reset-password`, `/forgot-password`, `/verify-mfa`) exempt from OnboardingGate; re-verified the form now renders for the same user.
2. **Empty "Other" silently froze all personalisation autosave.** Tick Practice areas → Other, leave it empty, change Title → no request fires, no status, nothing saved (DB confirmed NULL). The validation error was computed but never rendered. *Fixed:* per-group invalid tracking (an invalid group can't block unrelated saves, and falls back to its persisted value in the payload) + the message now renders inline. Re-verified: Title saves with the Other box empty, message visible.
3. **Debounced saves dropped on tab navigation.** Typing "Space Law" into Other and clicking another Settings tab within the 400 ms debounce dropped both the text and the selection (no request ever fired). *Fixed:* pending save flushes on unmount. Re-verified: "Space Law" lands in `practice_areas` despite immediate navigation.
4. **Sibling-field clobber on Account.** Typing a Display Name, tabbing into Organisation, and typing there: when the name PATCH resolved, the Organisation input reset to the stale server value mid-keystroke (still focused). *Fixed:* per-field hydration effects that skip the focused input. Re-verified with the same sequence — both values survive.
5. **Un-migrated DB silently reset settings.** Dropping the six new columns (the state of any deploy that updates code before migrations): `GET /user/profile` returned 200 but `legal_research_us=false` and `quick_actions_visible=false` came back `true` (the 42703 fallback cascade keyed on the wrong column name), and personalisation PATCHes 500'd raw. *Fixed:* a first fallback tier keyed on the six 20260821 columns + the same retry in `getUserModelSettings`. Re-verified under the same fault: saved values preserved, onboarding reported legacy-exempt.
6. **Word add-in (code-read, e2e-verified):** the OAuth dialog persisted the full session (access + refresh token) in `localStorage` with a live auto-refresh timer — now sessionStorage + `autoRefreshToken:false` + local sign-out before the handoff, and `messageParent` is guarded instead of claiming success before delivery. Clicking "Continue with Google" also blanked the whole pane to a bare "Loading…" spinner for the dialog's lifetime — the login page now stays mounted with its (previously dead) "Continuing…" state. All 30 add-in auth e2e tests pass on chromium + webkit.

## Validation

- backend: `tsc --noEmit` clean; unit suite 535 passed; `user.routes` integration file 46 passed (3 new tests)
- frontend: `tsc --noEmit` clean; 510 passed (6 new tests)
- word-addin: typecheck clean; `e2e/auth.spec.ts` 30 passed (chromium + webkit)

## Tradeoffs / design decisions (stated so they can be vetoed)

- **Gate exemptions are enumerated, not derived.** `/settings?emailChange=processed` (the email-change callback target) is still gated for un-onboarded users — exempting `/settings` wholesale would open all of Settings to them, which felt wrong to decide unilaterally. The email change itself completes server-side; only the confirmation view is deferred.
- **Autosave with an invalid "Other" group sends the persisted value for that group** rather than pausing everything — the transient empty state can never overwrite stored data, at the cost of the payload not reflecting the half-finished edit until it's completed.
- **The un-migrated-DB tier reports `onboardingVersion: 0` (legacy-exempt)** — matching what the migration backfill would write, and failing open rather than trapping existing users in onboarding during a deploy window.
- **The dialog's `messageParent` retry drops `targetOrigin`** only for hosts that reject the DialogOrigin 1.1 overload; the legacy form is same-domain-only, which is the identical restriction expressed implicitly.

## Not addressed here (PR discussion)

- **Google OAuth enabled by default with blank credentials:** on a stock local stack the "Continue with Google" button dead-ends on GoTrue's raw JSON error (replicated). Whether to default `GOTRUE_EXTERNAL_GOOGLE_ENABLED` to false or gate the button on a public flag is a product/config decision.
- **"Skip" on onboarding step 2 discards selections the user already made** (sends `{}`); relabel vs. submit-on-skip is a UX call.
- **`POST /user/onboarding` re-stamps legacy (version 0) users to 1** and has no state guard — depends on intended re-onboarding semantics.
- **Every login routes through `/onboarding/profile`** (hardcoded at 5 call sites) before the gate bounces completed users to `/assistant` — cosmetic flash, larger refactor.
- **Degraded-profile fallback asserts `passwordSet: false` as fact**, so a Google user with a password sees "create a password" copy while the profile fetch is failing.
- **Design-system sweep riding along** (FieldLabel `text-xs`→`text-sm` across 8 untouched modals, `OptionPill` duplicating `PillButtonUI` outside `frontend/src/shared`, add-in Google button markup duplicated) — worth a deliberate look or a split.
- **No real-Word smoke test** of the dialog flow is claimed anywhere in #365; Word on Mac (WKWebView) + Word on the web (popup-blocker path) should gate the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuPCULDYgVsiCanRgbEy6W


## Round 2 — adversarial verification of this PR's own fixes

Two independent agents (one empirical — ran the pre-fix vs fixed code and tests; one audit-only — worked purely from git diffs) were asked to refute every bug claim and every fix above. Their verdicts converged: all replicated bugs confirmed real (with severity corrections noted below), fixes for the gate exemption, debounce flush, backend fallback, and login-page state confirmed correct and minimal — **and they proved three defects in this PR's own first round**, now corrected in the four newest commits:

1. **`signOut({scope:"local"})` in the OAuth dialog revoked the very session being handed to the task pane** — auth-js always POSTs `/logout?scope=local`, and GoTrue deletes that session's refresh token server-side. Google sign-in would have died silently at the first token refresh, invisible to CI because the dialog file is stubbed out of e2e. The call is removed (it was also redundant); the speculative option-less `messageParent` retry is removed too since it mildly weakened the receiver's origin check.
2. **The focused-input hydration guards could save an empty display name** (profile loads while the input is focused → guard skips the sync → blur saves `""` over the stored name — measured empirically). The guards and refs are removed; the effect split alone fixes the original clobber, which was also proven empirically. The regression test was additionally shown to pass on unfixed code (the mocked save resolved too fast to open the race window) and now uses a deferred promise so it genuinely pins the fix.
3. **A residual pending-save drop:** editing Title and then ticking an empty "Other" inside the debounce window dropped the Title edit. The per-field group guard is deleted — the payload substitution plus snapshot comparison already covers it — and a deterministic test pins the sequence.

Also corrected from the audit: a database missing **only** migration 02 now keeps its live onboarding columns (dedicated fallback tier + test) instead of reporting new users as onboarding-complete; the 200-char cap **truncates** like `handle_new_user` instead of rejecting (rejection would have stranded pre-existing over-long values behind an unexplained error); the `getUserModelSettings` retry now handles a second failure explicitly and finally has tests.

Severity corrections the verifiers made to the original findings, accepted as-is: the reset-password bug is a burned recovery link + dead end rather than a *permanent* lockout (the recovery session survives the redirect, so completing onboarding un-wedges it); on the profile route only the legal-research/quick-actions booleans were reset by the missing-migration bug — the model-preference reset was real only in `getUserModelSettings`; and the dialog's storage cleanup did run on error paths, the true exposure being the crash window and refresh-timer re-writes.

Post-correction gates: backend tsc + full unit suite green, 49 tests in the touched backend files (7 new this round); frontend tsc + 512 tests green; add-in typecheck + all 30 auth e2e green on chromium and webkit.
