### PR TITLE
Support external_ref get-or-create on POST /chat/create

### DIFF
--- a/backend/src/routes/__tests__/chat.test.ts
+++ b/backend/src/routes/__tests__/chat.test.ts
@@ -1,0 +1,134 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../middleware/auth", () => ({
+    requireAuth: (
+        _req: unknown,
+        res: { locals: Record<string, unknown> },
+        next: () => void,
+    ) => {
+        res.locals.userId = "user-1";
+        res.locals.userEmail = "user-1@example.com";
+        next();
+    },
+}));
+
+/**
+ * Chainable Supabase mock for the `chats` table only — this route's
+ * POST /create handler never touches `projects` unless a project_id is
+ * given, and none of these tests supply one.
+ */
+function makeChatsDb(existingByExternalRef: Record<string, { id: string }>) {
+    const inserted: Record<string, unknown>[] = [];
+    let nextId = 1;
+
+    function chatsBuilder() {
+        const filters: Record<string, unknown> = {};
+        const b: any = {
+            select: () => b,
+            eq: (col: string, val: unknown) => {
+                filters[col] = val;
+                return b;
+            },
+            maybeSingle: () => {
+                const externalRef = filters.external_ref as
+                    | string
+                    | undefined;
+                const match =
+                    externalRef !== undefined
+                        ? existingByExternalRef[externalRef]
+                        : undefined;
+                return Promise.resolve({ data: match ?? null, error: null });
+            },
+            insert: (row: Record<string, unknown>) => {
+                inserted.push(row);
+                const id = `new-${nextId++}`;
+                return {
+                    select: () => ({
+                        single: () =>
+                            Promise.resolve({ data: { id }, error: null }),
+                    }),
+                };
+            },
+        };
+        return b;
+    }
+
+    const db = {
+        from: (table: string) => {
+            if (table === "chats") return chatsBuilder();
+            throw new Error(`unexpected table in test: ${table}`);
+        },
+    };
+    return { db: db as any, inserted };
+}
+
+let currentDb: ReturnType<typeof makeChatsDb>["db"];
+
+vi.mock("../../lib/supabase", () => ({
+    createServerSupabase: () => currentDb,
+}));
+
+import { chatRouter } from "../chat";
+
+const app = express();
+app.use(express.json());
+app.use("/chat", chatRouter);
+
+describe("POST /chat/create", () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("creates a new chat and returns its id when no chat exists for the external_ref", async () => {
+        const { db, inserted } = makeChatsDb({});
+        currentDb = db;
+
+        const response = await request(app)
+            .post("/chat/create")
+            .send({ external_ref: "slack:C123:456.789" });
+
+        expect(response.status).toBe(200);
+        expect(response.body.id).toBeTruthy();
+        expect(inserted).toEqual([
+            {
+                user_id: "user-1",
+                project_id: null,
+                external_ref: "slack:C123:456.789",
+            },
+        ]);
+    });
+
+    it("returns the existing chat id for a repeat external_ref instead of inserting again", async () => {
+        const { db, inserted } = makeChatsDb({
+            "slack:C123:456.789": { id: "existing-chat-id" },
+        });
+        currentDb = db;
+
+        const response = await request(app)
+            .post("/chat/create")
+            .send({ external_ref: "slack:C123:456.789" });
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ id: "existing-chat-id" });
+        expect(inserted).toEqual([]);
+    });
+
+    it("still creates a chat with no external_ref, matching prior frontend behavior", async () => {
+        const { db, inserted } = makeChatsDb({});
+        currentDb = db;
+
+        const response = await request(app).post("/chat/create").send({});
+
+        expect(response.status).toBe(200);
+        expect(response.body.id).toBeTruthy();
+        expect(inserted).toEqual([
+            {
+                user_id: "user-1",
+                project_id: null,
+                external_ref: null,
+            },
+        ]);
+    });
+});

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -126,6 +126,11 @@ chatRouter.post("/create", requireAuth, async (req, res) => {
         return void res.status(400).json({ detail: parsedProjectId.detail });
     }
     const projectId = parsedProjectId.value.projectId;
+    const externalRef =
+        typeof req.body?.external_ref === "string" &&
+        req.body.external_ref.trim().length > 0
+            ? req.body.external_ref.trim().slice(0, 200)
+            : null;
     const db = createServerSupabase();
     const projectAccess = await validateAccessibleProjectId(
         projectId,
@@ -138,9 +143,25 @@ chatRouter.post("/create", requireAuth, async (req, res) => {
             .status(projectAccess.status)
             .json({ detail: projectAccess.detail });
 
+    if (externalRef) {
+        const { data: existing, error: lookupError } = await db
+            .from("chats")
+            .select("id")
+            .eq("user_id", userId)
+            .eq("external_ref", externalRef)
+            .maybeSingle();
+        if (lookupError)
+            return void res.status(500).json({ detail: lookupError.message });
+        if (existing) return void res.json({ id: existing.id });
+    }
+
     const { data, error } = await db
         .from("chats")
-        .insert({ user_id: userId, project_id: projectId ?? null })
+        .insert({
+            user_id: userId,
+            project_id: projectId ?? null,
+            external_ref: externalRef,
+        })
         .select("id")
         .single();
 


### PR DESCRIPTION
## Summary
- Adds an optional `external_ref` field to `POST /chat/create`. When provided, a repeat call with the same `(user_id, external_ref)` pair returns the existing chat's id instead of creating a new one.
- Lets an external integration (e.g. a Slack thread bridge) key a chat by a stable external identifier without tracking `chat_id` itself.
- No behavior change when `external_ref` is omitted.

## Test plan
- [x] New tests: get-or-create returns the same id on repeat calls with the same external_ref; a fresh external_ref creates a new chat; omitting external_ref entirely is unaffected (regression check)
- [x] `npx vitest run src/routes/__tests__/chat.test.ts` — 3/3 passing
- [x] Full backend suite run with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)