### PR TITLE
Sanitize user-facing backend and frontend errors

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -127,7 +127,11 @@ jobs:
       - name: Init + start Supabase, load fresh schema
         run: |
           supabase init --force --with-vscode-settings=false || supabase init --force
-          supabase start
+          # E2E uses Auth, Postgres, PostgREST, and Kong only. Document storage
+          # is provided by MinIO above, and no spec reads local email. Excluding
+          # the unused services also avoids Inbucket claiming host port 54324,
+          # which can collide with runner processes before Playwright starts.
+          supabase start -x studio,imgproxy,inbucket,analytics,vector,realtime,storage,edge-runtime,functions,meta
           DB_URL=$(supabase status -o json | jq -r '.DB_URL')
           # A fresh database runs the current schema exactly once. Historical
           # migrations only upgrade older deployments; replaying them on top of

--- a/backend/src/__tests__/integration/chat.routes.test.ts
+++ b/backend/src/__tests__/integration/chat.routes.test.ts
@@ -585,7 +585,7 @@ describe("POST /chat — streaming endpoint", () => {
 
         expect(res.status).toBe(500);
         expect(res.headers["content-type"]).not.toContain("text/event-stream");
-        expect(res.body.detail).toBe("Failed to start assistant response");
+        expect(res.body.detail).toBe("Something went wrong. Please try again.");
         expect(res.text).not.toContain('"type":"chat_id"');
         expect(findAssistantReservation()).toBeDefined();
         expect(runLLMStream).not.toHaveBeenCalled();
@@ -633,7 +633,8 @@ describe("POST /chat — streaming endpoint", () => {
             content: [
                 expect.objectContaining({
                     type: "error",
-                    message: "upstream LLM failure",
+                    message:
+                        "The response could not be completed. Please try again.",
                 }),
             ],
         });

--- a/backend/src/__tests__/integration/health.test.ts
+++ b/backend/src/__tests__/integration/health.test.ts
@@ -44,6 +44,9 @@ describe("GET /health", () => {
         const res = await request(app).get("/health");
         expect(res.status).toBe(200);
         expect(res.body).toEqual({ ok: true });
+        expect(res.headers["x-request-id"]).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+        );
     });
 });
 
@@ -107,7 +110,11 @@ describe("GET /manifest-signing-key", () => {
         const res = await request(app).get("/manifest-signing-key");
 
         expect(res.status).toBe(500);
-        expect(res.body.detail).toBe("Manifest signing key is misconfigured");
+        expect(res.body).toMatchObject({
+            code: "internal_error",
+            detail: "Something went wrong. Please try again.",
+        });
+        expect(res.body.request_id).toBe(res.headers["x-request-id"]);
     });
 });
 

--- a/backend/src/__tests__/integration/projects.routes.test.ts
+++ b/backend/src/__tests__/integration/projects.routes.test.ts
@@ -235,7 +235,7 @@ describe("projects.routes", () => {
         .set(...AUTH);
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("boom");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
 
     // Regression guard: legacy project pickers call GET /projects with no
@@ -355,7 +355,7 @@ describe("projects.routes", () => {
         .set(...AUTH);
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("boom");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
     });
 
@@ -594,7 +594,7 @@ describe("projects.routes", () => {
                 .send({ name: "Delta" });
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("insert failed");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
     });
 
@@ -776,7 +776,7 @@ describe("projects.routes", () => {
         .set(...AUTH);
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("cascade failed");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
     });
     // ── GET /projects/:projectId/export (tamper-evident manifest) ─────────
@@ -927,7 +927,7 @@ describe("projects.routes", () => {
                 .set(...AUTH);
 
             expect(res.status).toBe(500);
-      expect(res.body.detail).toBe("Failed to build project export manifest");
+      expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
     });
 });

--- a/backend/src/__tests__/integration/tabular.routes.test.ts
+++ b/backend/src/__tests__/integration/tabular.routes.test.ts
@@ -185,7 +185,7 @@ describe("tabular.routes", () => {
         .set(...AUTH);
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("boom");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
     });
 
@@ -510,7 +510,7 @@ describe("tabular.routes", () => {
                 .send({ document_ids: [], columns_config: [] });
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("insert failed");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
     });
 
@@ -661,7 +661,7 @@ describe("tabular.routes", () => {
                 .set(...AUTH);
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("delete failed");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
     });
 

--- a/backend/src/__tests__/integration/user.routes.test.ts
+++ b/backend/src/__tests__/integration/user.routes.test.ts
@@ -302,7 +302,7 @@ describe("user.routes", () => {
                 .set(...AUTH);
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("db down");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
     });
 
@@ -402,7 +402,7 @@ describe("user.routes", () => {
                 .send({ api_key: "sk-x" });
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("kms unavailable");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
 
         it("is rejected with 403 mfa_verification_required when MFA is unsatisfied", async () => {
@@ -544,7 +544,7 @@ describe("user.routes", () => {
                 .set(...AUTH);
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("export boom");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
 
         it("GET /user/export is rejected when MFA is unsatisfied", async () => {
@@ -620,7 +620,7 @@ describe("user.routes", () => {
                 .set(...AUTH);
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("auth boom");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
 
         it("DELETE /user/chats returns 500 when cleanup throws", async () => {
@@ -631,7 +631,7 @@ describe("user.routes", () => {
                 .set(...AUTH);
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("cascade failed");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
 
         it("DELETE /user/account is rejected when MFA is unsatisfied (no cleanup)", async () => {

--- a/backend/src/__tests__/integration/wordChat.routes.test.ts
+++ b/backend/src/__tests__/integration/wordChat.routes.test.ts
@@ -164,7 +164,7 @@ describe("Word chat history routes", () => {
       .set(...AUTH);
 
     expect(res.status).toBe(500);
-    expect(res.body.detail).toBe("Failed to load Word chats");
+    expect(res.body.detail).toBe("Something went wrong. Please try again.");
     expect(recordedQueries.map(({ table }) => table)).toEqual([
       "word_documents",
     ]);
@@ -181,7 +181,7 @@ describe("Word chat history routes", () => {
       .set(...AUTH);
 
     expect(res.status).toBe(500);
-    expect(res.body.detail).toBe("Failed to load Word chats");
+    expect(res.body.detail).toBe("Something went wrong. Please try again.");
   });
 
   it("returns 500 rather than 404 when a detail document lookup fails", async () => {
@@ -195,7 +195,7 @@ describe("Word chat history routes", () => {
       .set(...AUTH);
 
     expect(res.status).toBe(500);
-    expect(res.body.detail).toBe("Failed to load Word chat");
+    expect(res.body.detail).toBe("Something went wrong. Please try again.");
   });
 
   it("returns 500 rather than 404 when the scoped chat lookup fails", async () => {
@@ -209,7 +209,7 @@ describe("Word chat history routes", () => {
       .set(...AUTH);
 
     expect(res.status).toBe(500);
-    expect(res.body.detail).toBe("Failed to load Word chat");
+    expect(res.body.detail).toBe("Something went wrong. Please try again.");
     expect(
       recordedQueries.find(({ table }) => table === "word_chats")?.filters,
     ).toEqual([

--- a/backend/src/__tests__/integration/workflows.routes.test.ts
+++ b/backend/src/__tests__/integration/workflows.routes.test.ts
@@ -236,7 +236,7 @@ describe("workflows.routes", () => {
         .set(...AUTH);
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("boom");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
     });
 
@@ -306,7 +306,7 @@ describe("workflows.routes", () => {
         .set(...AUTH);
 
             expect(res.status).toBe(500);
-            expect(res.body.detail).toBe("boom");
+            expect(res.body.detail).toBe("Something went wrong. Please try again.");
         });
     });
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import { randomUUID } from "node:crypto";
 import express from "express";
 import cors from "cors";
 import helmet from "helmet";
@@ -20,6 +21,10 @@ import { sourceDocumentsRouter } from "./routes/sourceDocuments";
 import { auditRouter } from "./routes/audit";
 import { manifestPublicKey } from "./lib/manifestSigning";
 import { safeErrorLog } from "./lib/safeError";
+import {
+  handleUnhandledError,
+  protectInternalErrorResponses,
+} from "./middleware/internalErrorResponse";
 
 export const app = express();
 const isProduction = process.env.NODE_ENV === "production";
@@ -96,6 +101,13 @@ const dataDeleteLimiter = makeLimiter({
 
 app.disable("x-powered-by");
 app.set("trust proxy", envInt("TRUST_PROXY_HOPS", 1));
+app.use((_req, res, next) => {
+  const requestId = randomUUID();
+  res.locals.requestId = requestId;
+  res.setHeader("X-Request-ID", requestId);
+  next();
+});
+app.use(protectInternalErrorResponses);
 
 app.use(
   helmet({
@@ -219,3 +231,5 @@ app.get("/manifest-signing-key", (_req, res) => {
     });
   }
 });
+
+app.use(handleUnhandledError);

--- a/backend/src/lib/chat/streaming.ts
+++ b/backend/src/lib/chat/streaming.ts
@@ -5,7 +5,7 @@ import {
   type OpenAIToolSchema,
 } from "../llm";
 import { resolveRequestedModel } from "../routerModels";
-import { safeErrorMessage } from "../safeError";
+import { safeErrorLog, UserFacingError } from "../safeError";
 import { createServerSupabase } from "../supabase";
 import { buildUserMcpTools, type McpToolEvent } from "../mcpConnectors";
 import type { SourceDocument } from "../sourceDocuments";
@@ -108,7 +108,7 @@ export type AssistantEvent =
       document: SourceDocument;
     }
   | { type: "content"; text: string }
-  | { type: "error"; message: string };
+  | { type: "error"; message: string; safe_to_display?: boolean };
 
 export class AssistantStreamError extends Error {
   fullText: string;
@@ -119,6 +119,38 @@ export class AssistantStreamError extends Error {
     this.name = "AssistantStreamError";
     this.fullText = fullText;
     this.events = events;
+  }
+}
+
+export const ASSISTANT_ERROR_MESSAGE =
+  "The response could not be completed. Please try again.";
+const TOOL_ERROR_MESSAGE = "This tool could not complete its request.";
+
+function sanitizeAssistantEvent(event: AssistantEvent): AssistantEvent {
+  if (event.type === "error") {
+    return event.safe_to_display
+      ? event
+      : { ...event, message: ASSISTANT_ERROR_MESSAGE };
+  }
+  if ("error" in event && typeof event.error === "string" && event.error) {
+    return { ...event, error: TOOL_ERROR_MESSAGE };
+  }
+  return event;
+}
+
+export function sanitizeAssistantSseChunk(chunk: string): string {
+  if (!chunk.startsWith("data: ")) return chunk;
+  const payload = chunk.slice(6).trim();
+  if (!payload || payload === "[DONE]") return chunk;
+  try {
+    const parsed = JSON.parse(payload) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return chunk;
+    }
+    const sanitized = sanitizeAssistantEvent(parsed as AssistantEvent);
+    return `data: ${JSON.stringify(sanitized)}\n\n`;
+  } catch {
+    return chunk;
   }
 }
 
@@ -189,7 +221,7 @@ export async function runLLMStream(params: {
     docIndex,
     userId,
     db,
-    write,
+    write: unsafeWrite,
     extraTools,
     includeResearchTools = true,
     includeAskInputs = true,
@@ -202,6 +234,8 @@ export async function runLLMStream(params: {
     projectId,
     nonce,
   } = params;
+  const write = (chunk: string) =>
+    unsafeWrite(sanitizeAssistantSseChunk(chunk));
   const researchTools = includeResearchTools ? COURTLISTENER_TOOLS : [];
   const mcpTools = await buildUserMcpTools(userId, db);
   const conversationTools = includeAskInputs
@@ -563,12 +597,25 @@ export async function runLLMStream(params: {
       // prose telling the user to answer the picker or attach documents.
     } else if (isAbortError(err)) {
       flushPartialTurn({ emit: false });
-      throw new AssistantStreamAbortError(fullText, events);
+      throw new AssistantStreamAbortError(
+        fullText,
+        events.map(sanitizeAssistantEvent),
+      );
     } else {
       flushPartialTurn();
-      const message = safeErrorMessage(err, "Stream error");
-      events.push({ type: "error", message });
-      throw new AssistantStreamError(message, fullText, events);
+      console.error("[chat/stream] model stream failed", safeErrorLog(err));
+      const safeToDisplay = err instanceof UserFacingError;
+      const message = safeToDisplay ? err.message : ASSISTANT_ERROR_MESSAGE;
+      events.push({
+        type: "error",
+        message,
+        ...(safeToDisplay ? { safe_to_display: true } : {}),
+      });
+      throw new AssistantStreamError(
+        message,
+        fullText,
+        events.map(sanitizeAssistantEvent),
+      );
     }
   }
 
@@ -630,5 +677,9 @@ export async function runLLMStream(params: {
     write("data: [DONE]\n\n");
   }
 
-  return { fullText, events, citations };
+  return {
+    fullText,
+    events: events.map(sanitizeAssistantEvent),
+    citations,
+  };
 }

--- a/backend/src/lib/httpError.ts
+++ b/backend/src/lib/httpError.ts
@@ -1,0 +1,28 @@
+import type { Response } from "express";
+import { safeErrorLog } from "./safeError";
+
+export const INTERNAL_ERROR_CODE = "internal_error";
+export const INTERNAL_ERROR_MESSAGE =
+  "Something went wrong. Please try again.";
+
+export function sendInternalError(
+  res: Response,
+  error: unknown,
+  status = 500,
+): Response {
+  const requestId =
+    typeof res.locals.requestId === "string" ? res.locals.requestId : null;
+
+  console.error("[http/internal-error]", {
+    requestId,
+    method: res.req?.method,
+    path: res.req?.originalUrl,
+    error: safeErrorLog(error),
+  });
+
+  return res.status(status).json({
+    code: INTERNAL_ERROR_CODE,
+    detail: INTERNAL_ERROR_MESSAGE,
+    ...(requestId ? { request_id: requestId } : {}),
+  });
+}

--- a/backend/src/lib/routerModels.ts
+++ b/backend/src/lib/routerModels.ts
@@ -1,4 +1,5 @@
 import { createServerSupabase } from "./supabase";
+import { UserFacingError } from "./safeError";
 import { resolveModel } from "./llm/models";
 
 type Db = ReturnType<typeof createServerSupabase>;
@@ -76,7 +77,7 @@ export async function resolveRequestedModel(
         return resolved;
     }
     if (onOutsideSelection === "throw") {
-        throw new Error(
+        throw new UserFacingError(
             `Model ${resolved} is not in your saved ${ROUTER_LABELS[router]} models — add it in Settings → Bring Your Own Keys → Routers.`,
         );
     }

--- a/backend/src/lib/safeError.ts
+++ b/backend/src/lib/safeError.ts
@@ -10,6 +10,13 @@ const PROVIDER_KEY_PATTERNS = [
   /\bAIza[A-Za-z0-9_\-]{20,}\b/g,
 ];
 
+export class UserFacingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UserFacingError";
+  }
+}
+
 export function redactSensitiveText(value: string): string {
   let redacted = value;
   for (const pattern of SECRET_CONTEXT_PATTERNS) {

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,6 +1,8 @@
 import { Request, Response, NextFunction } from "express";
 import { createServerSupabase } from "../lib/supabase";
 import { syncProfileEmail } from "../lib/userLookup";
+import { sendInternalError } from "../lib/httpError";
+import { safeErrorLog } from "../lib/safeError";
 
 const isDev = process.env.NODE_ENV !== "production";
 const devLog = (...args: Parameters<typeof console.log>) => {
@@ -50,7 +52,7 @@ async function enforceLoginMfaIfEnabled(
       code: error.code,
     });
     if (error.code === "42703") return true;
-    res.status(500).json({ detail: error.message });
+    sendInternalError(res, error);
     return false;
   }
 
@@ -67,7 +69,14 @@ async function enforceLoginMfaIfEnabled(
       userId: res.locals.userId,
       error: assuranceError.message,
     });
-    res.status(401).json({ detail: assuranceError.message });
+    console.error(
+      "[auth/mfa] login assurance lookup failed",
+      safeErrorLog(assuranceError),
+    );
+    res.status(401).json({
+      code: "authentication_failed",
+      detail: "Unable to verify authentication. Please sign in again.",
+    });
     return false;
   }
 
@@ -165,7 +174,11 @@ export async function requireMfaIfEnrolled(
       userId: res.locals.userId,
       error: error.message,
     });
-    res.status(401).json({ detail: error.message });
+    console.error("[auth/mfa] assurance lookup failed", safeErrorLog(error));
+    res.status(401).json({
+      code: "authentication_failed",
+      detail: "Unable to verify authentication. Please sign in again.",
+    });
     return;
   }
 

--- a/backend/src/middleware/internalErrorResponse.test.ts
+++ b/backend/src/middleware/internalErrorResponse.test.ts
@@ -1,0 +1,156 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  INTERNAL_ERROR_CODE,
+  INTERNAL_ERROR_MESSAGE,
+} from "../lib/httpError";
+import {
+  handleUnhandledError,
+  protectInternalErrorResponses,
+} from "./internalErrorResponse";
+
+function testApp(status: number, body: unknown) {
+  const app = express();
+  app.use((_req, res, next) => {
+    res.locals.requestId = "req-test-123";
+    next();
+  });
+  app.use(protectInternalErrorResponses);
+  app.get("/test", (_req, res) => res.status(status).json(body));
+  return app;
+}
+
+describe("protectInternalErrorResponses", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each([500, 502, 503])(
+    "replaces raw %i responses with the public contract",
+    async (status) => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const res = await request(testApp(status, {
+        detail: "relation private_table does not exist",
+        stack: "secret stack",
+      })).get("/test");
+
+      expect(res.status).toBe(status);
+      expect(res.body).toEqual({
+        code: INTERNAL_ERROR_CODE,
+        detail: INTERNAL_ERROR_MESSAGE,
+        request_id: "req-test-123",
+      });
+      expect(res.text).not.toContain("private_table");
+      expect(res.text).not.toContain("secret stack");
+      expect(consoleError).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("does not rewrite intentional client errors", async () => {
+    const body = { code: "invalid_filename", detail: "Filename is required" };
+    const res = await request(testApp(400, body)).get("/test");
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual(body);
+  });
+
+  it("strips extra fields from an otherwise sanitized 5xx response", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const res = await request(
+      testApp(500, {
+        code: INTERNAL_ERROR_CODE,
+        detail: INTERNAL_ERROR_MESSAGE,
+        request_id: "untrusted-request-id",
+        stack: "secret stack",
+      }),
+    ).get("/test");
+
+    expect(res.body).toEqual({
+      code: INTERNAL_ERROR_CODE,
+      detail: INTERNAL_ERROR_MESSAGE,
+      request_id: "req-test-123",
+    });
+    expect(res.text).not.toContain("secret stack");
+    expect(consoleError).toHaveBeenCalledOnce();
+  });
+
+  it("sanitizes an unhandled route exception", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const app = express();
+    app.use((_req, res, next) => {
+      res.locals.requestId = "req-thrown-123";
+      next();
+    });
+    app.use(protectInternalErrorResponses);
+    app.get("/test", () => {
+      throw new Error("database password appeared in a stack");
+    });
+    app.use(handleUnhandledError);
+
+    const res = await request(app).get("/test");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({
+      code: INTERNAL_ERROR_CODE,
+      detail: INTERNAL_ERROR_MESSAGE,
+      request_id: "req-thrown-123",
+    });
+    expect(res.text).not.toContain("database password");
+    expect(consoleError).toHaveBeenCalledOnce();
+  });
+
+  it("returns a safe 400 response for malformed JSON", async () => {
+    const app = express();
+    app.use((_req, res, next) => {
+      res.locals.requestId = "req-json-123";
+      next();
+    });
+    app.use(protectInternalErrorResponses);
+    app.use(express.json());
+    app.post("/test", (_req, res) => res.sendStatus(204));
+    app.use(handleUnhandledError);
+
+    const res = await request(app)
+      .post("/test")
+      .set("Content-Type", "application/json")
+      .send('{"secret":');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      code: "invalid_json",
+      detail: "Request body must contain valid JSON.",
+      request_id: "req-json-123",
+    });
+    expect(res.text).not.toContain("secret");
+  });
+
+  it("returns a safe 413 response for oversized JSON", async () => {
+    const app = express();
+    app.use((_req, res, next) => {
+      res.locals.requestId = "req-size-123";
+      next();
+    });
+    app.use(protectInternalErrorResponses);
+    app.use(express.json({ limit: "10b" }));
+    app.post("/test", (_req, res) => res.sendStatus(204));
+    app.use(handleUnhandledError);
+
+    const res = await request(app)
+      .post("/test")
+      .set("Content-Type", "application/json")
+      .send(JSON.stringify({ secret: "a very long internal payload" }));
+
+    expect(res.status).toBe(413);
+    expect(res.body).toEqual({
+      code: "request_too_large",
+      detail: "The request body is too large.",
+      request_id: "req-size-123",
+    });
+    expect(res.text).not.toContain("secret");
+  });
+});

--- a/backend/src/middleware/internalErrorResponse.ts
+++ b/backend/src/middleware/internalErrorResponse.ts
@@ -1,0 +1,112 @@
+import type {
+  ErrorRequestHandler,
+  NextFunction,
+  Request,
+  Response,
+} from "express";
+import {
+  INTERNAL_ERROR_CODE,
+  INTERNAL_ERROR_MESSAGE,
+  sendInternalError,
+} from "../lib/httpError";
+import { safeErrorLog } from "../lib/safeError";
+
+type ErrorBody = {
+  code?: unknown;
+  detail?: unknown;
+  request_id?: unknown;
+};
+
+export function protectInternalErrorResponses(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const originalJson = res.json.bind(res);
+
+  res.json = ((body?: unknown) => {
+    if (res.statusCode < 500) return originalJson(body);
+
+    const requestId =
+      typeof res.locals.requestId === "string" ? res.locals.requestId : null;
+    const publicBody = {
+      code: INTERNAL_ERROR_CODE,
+      detail: INTERNAL_ERROR_MESSAGE,
+      ...(requestId ? { request_id: requestId } : {}),
+    };
+    const errorBody =
+      body && typeof body === "object" && !Array.isArray(body)
+        ? (body as ErrorBody)
+        : null;
+    const hasUnexpectedFields =
+      errorBody &&
+      Object.keys(errorBody).some(
+        (key) => !["code", "detail", "request_id"].includes(key),
+      );
+    if (
+      errorBody?.code === INTERNAL_ERROR_CODE &&
+      errorBody.detail === INTERNAL_ERROR_MESSAGE &&
+      !hasUnexpectedFields
+    ) {
+      return originalJson(publicBody);
+    }
+
+    console.error("[http/sanitized-internal-error]", {
+      requestId,
+      method: req.method,
+      path: req.originalUrl,
+      status: res.statusCode,
+      error: safeErrorLog(errorBody?.detail ?? body),
+    });
+
+    return originalJson(publicBody);
+  }) as Response["json"];
+
+  next();
+}
+
+/**
+ * Final Express error boundary. Route handlers should still return intentional
+ * 4xx responses themselves, but an unexpected thrown/rejected error must never
+ * fall through to Express's HTML error response (which can include a stack in
+ * development).
+ */
+export const handleUnhandledError: ErrorRequestHandler = (
+  error,
+  _req,
+  res,
+  next,
+) => {
+  if (res.headersSent) {
+    next(error);
+    return;
+  }
+
+  const bodyParserError = error as { status?: unknown; type?: unknown };
+  const requestId =
+    typeof res.locals.requestId === "string" ? res.locals.requestId : null;
+  if (
+    bodyParserError.status === 400 &&
+    bodyParserError.type === "entity.parse.failed"
+  ) {
+    res.status(400).json({
+      code: "invalid_json",
+      detail: "Request body must contain valid JSON.",
+      ...(requestId ? { request_id: requestId } : {}),
+    });
+    return;
+  }
+  if (
+    bodyParserError.status === 413 &&
+    bodyParserError.type === "entity.too.large"
+  ) {
+    res.status(413).json({
+      code: "request_too_large",
+      detail: "The request body is too large.",
+      ...(requestId ? { request_id: requestId } : {}),
+    });
+    return;
+  }
+
+  sendInternalError(res, error);
+};

--- a/backend/src/routes/__tests__/models.test.ts
+++ b/backend/src/routes/__tests__/models.test.ts
@@ -26,6 +26,10 @@ vi.mock("../../lib/userApiKeys", () => ({
 }));
 
 import { modelsRouter } from "../models";
+import {
+    INTERNAL_ERROR_CODE,
+    INTERNAL_ERROR_MESSAGE,
+} from "../../lib/httpError";
 
 const app = express();
 app.use("/models", modelsRouter);
@@ -125,9 +129,11 @@ describe("GET /models/openrouter", () => {
         const response = await request(app).get("/models/openrouter");
 
         expect(response.status).toBe(502);
-        expect(response.body.detail).toContain(
-            "OpenRouter model catalog request failed (401)",
-        );
+        expect(response.body).toEqual({
+            code: INTERNAL_ERROR_CODE,
+            detail: INTERNAL_ERROR_MESSAGE,
+        });
+        expect(response.text).not.toContain("invalid key");
     });
 });
 
@@ -320,6 +326,9 @@ describe("GET /models/opencode-go", () => {
     });
 
     it("reports an upstream failure as a bad gateway", async () => {
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
         vi.stubGlobal(
             "fetch",
             vi.fn().mockResolvedValue(new Response("nope", { status: 401 })),
@@ -328,6 +337,12 @@ describe("GET /models/opencode-go", () => {
         const response = await request(app).get("/models/opencode-go");
 
         expect(response.status).toBe(502);
-        expect(response.body.detail).toContain("(401)");
+        expect(response.body).toEqual({
+            code: INTERNAL_ERROR_CODE,
+            detail: INTERNAL_ERROR_MESSAGE,
+        });
+        expect(response.text).not.toContain("nope");
+        expect(consoleError).toHaveBeenCalledOnce();
+        consoleError.mockRestore();
     });
 });

--- a/backend/src/routes/audit.ts
+++ b/backend/src/routes/audit.ts
@@ -6,6 +6,7 @@ import { Router } from "express";
 import { requireAuth, requireMfaIfEnrolled } from "../middleware/auth";
 import { createServerSupabase } from "../lib/supabase";
 import { normalizeDisplayName } from "../lib/userLookup";
+import { sendInternalError } from "../lib/httpError";
 
 export const auditRouter = Router();
 auditRouter.use(requireAuth);
@@ -194,7 +195,7 @@ auditRouter.get("/", async (req, res) => {
   if (!parsed.ok) return void res.status(400).json({ detail: parsed.error });
   const q = parsed.query;
   const { data, error, count } = await queryEvents(db, userId, email, q);
-  if (error) return void res.status(500).json({ detail: error.message });
+  if (error) return void sendInternalError(res, error);
   res.json({
     events: data ?? [],
     total: count ?? 0,
@@ -223,7 +224,7 @@ auditRouter.get("/export", requireMfaIfEnrolled, async (req, res) => {
   const q = parsed.query;
   q.page = 1;
   const { data, error } = await queryEvents(db, userId, email, q, false);
-  if (error) return void res.status(500).json({ detail: error.message });
+  if (error) return void sendInternalError(res, error);
   const header =
     "created_at,user,action,status,title,application,project_id,model";
   const rows = ((data ?? []) as Record<string, unknown>[]).map((e) =>

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -11,6 +11,7 @@ import {
     appendAskInputsResponseToLastAssistantMessage,
     appendAssistantEventsToLastAssistantMessage,
     AssistantStreamError,
+    ASSISTANT_ERROR_MESSAGE,
     buildCancelledAssistantMessage,
     extractCitations,
     generateSpotlightNonce,
@@ -29,8 +30,9 @@ import {
 } from "../lib/chat";
 import { getUserModelSettings } from "../lib/userSettings";
 import { checkProjectAccess } from "../lib/access";
-import { safeErrorLog, safeErrorMessage } from "../lib/safeError";
+import { safeErrorLog } from "../lib/safeError";
 import { generateAssistantChatTitle } from "../lib/chatTitle";
+import { sendInternalError } from "../lib/httpError";
 
 export const chatRouter = Router();
 
@@ -113,7 +115,7 @@ chatRouter.get("/", requireAuth, async (req, res) => {
         p_limit: limit,
         p_offset: offset,
     });
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.json(data ?? []);
 });
 
@@ -144,7 +146,7 @@ chatRouter.post("/create", requireAuth, async (req, res) => {
         .select("id")
         .single();
 
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.json({ id: data.id });
 });
 
@@ -317,7 +319,7 @@ chatRouter.delete("/:chatId", requireAuth, async (req, res) => {
         .eq("id", chatId)
         .eq("user_id", userId);
 
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.status(204).send();
 });
 
@@ -736,7 +738,7 @@ chatRouter.post("/", requireAuth, async (req, res) => {
             return;
         }
         console.error("[chat/stream] error:", safeErrorLog(err));
-        const message = safeErrorMessage(err, "Stream error");
+        const message = ASSISTANT_ERROR_MESSAGE;
         const errorEvents =
             err instanceof AssistantStreamError
                 ? stripTransientAssistantEvents(err.events)

--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { requireAuth } from "../middleware/auth";
 import { createServerSupabase } from "../lib/supabase";
 import { recordAudit } from "../lib/audit";
+import { sendInternalError } from "../lib/httpError";
 import {
   buildContentDisposition,
   downloadFile,
@@ -69,7 +70,7 @@ documentsRouter.get("/", requireAuth, async (req, res) => {
     .is("project_id", null)
     .or("library_kind.eq.file,library_kind.is.null")
     .order("created_at", { ascending: false });
-  if (error) return void res.status(500).json({ detail: error.message });
+  if (error) return void sendInternalError(res, error);
   const docs = (data ?? []) as unknown as {
     id: string;
     current_version_id?: string | null;
@@ -190,7 +191,7 @@ documentsRouter.post("/download-zip", requireAuth, async (req, res) => {
     .select("id, current_version_id, user_id, project_id")
     .in("id", document_ids);
 
-  if (error) return void res.status(500).json({ detail: error.message });
+  if (error) return void sendInternalError(res, error);
   // Filter to docs the user actually has access to (own + shared-project).
   const accessChecks = await Promise.all(
     (rawDocs ?? []).map(async (d) => ({
@@ -916,9 +917,10 @@ documentsRouter.put(
           .filter((path): path is string => !!path)
           .map((path) => deleteFile(path).catch(() => {})),
       );
-      return void res.status(500).json({
-        detail: updateErr?.message ?? "Failed to replace version.",
-      });
+      return void sendInternalError(
+        res,
+        updateErr ?? new Error("Version replacement returned no data"),
+      );
     }
 
     await Promise.all(
@@ -962,7 +964,7 @@ documentsRouter.delete(
       .eq("document_id", documentId)
       .is("deleted_at", null);
     if (versionsErr) {
-      return void res.status(500).json({ detail: versionsErr.message });
+      return void sendInternalError(res, versionsErr);
     }
 
     const rows = (versions ?? []) as {
@@ -1008,7 +1010,7 @@ documentsRouter.delete(
         })
         .eq("id", documentId);
       if (updateErr) {
-        return void res.status(500).json({ detail: updateErr.message });
+        return void sendInternalError(res, updateErr);
       }
     }
 
@@ -1024,7 +1026,7 @@ documentsRouter.delete(
       .eq("document_id", documentId)
       .is("deleted_at", null);
     if (deleteErr) {
-      return void res.status(500).json({ detail: deleteErr.message });
+      return void sendInternalError(res, deleteErr);
     }
 
     await Promise.all(
@@ -1471,9 +1473,7 @@ export async function handleDocumentUpload(
     return void res.status(201).json(responseDoc);
   } catch (e) {
     await db.from("documents").update({ status: "error" }).eq("id", doc.id);
-    return void res
-      .status(500)
-      .json({ detail: `Document processing failed: ${String(e)}` });
+    return void sendInternalError(res, e);
   }
 }
 

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -10,6 +10,7 @@ import { singleFileUpload } from "../lib/upload";
 import { handleDocumentUpload } from "./documents";
 import { parsePaginationQuery, type PaginationParams } from "../lib/pagination";
 import { normalizeSearchTerm } from "../lib/search";
+import { sendInternalError } from "../lib/httpError";
 
 export const libraryRouter = Router();
 
@@ -254,7 +255,7 @@ libraryRouter.get("/:kind", requireAuth, async (req, res) => {
       p_sort_key: sort.key,
       p_sort_direction: sort.direction,
     });
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
 
     const rows = (data ?? []) as Record<string, unknown>[];
     return void res.json({
@@ -363,7 +364,7 @@ libraryRouter.get("/:kind/filter-options", requireAuth, async (req, res) => {
     p_user_id: userId,
     p_library_kind: kind,
   });
-  if (error) return void res.status(500).json({ detail: error.message });
+  if (error) return void sendInternalError(res, error);
   const row = (data?.[0] ?? {}) as { file_types?: unknown };
   res.json({
     fileTypes: Array.isArray(row.file_types)
@@ -395,7 +396,7 @@ libraryRouter.get("/:kind/ids", requireAuth, async (req, res) => {
       p_limit: LIBRARY_IDS_PAGE_SIZE,
       p_offset: offset,
     });
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     const rows = (data ?? []) as { id: string }[];
     if (rows.length === 0) break;
     ids.push(...rows.map((row) => row.id));
@@ -439,7 +440,7 @@ libraryRouter.post(
         batch,
       );
       if (result.error)
-        return void res.status(500).json({ detail: result.error.message });
+        return void sendInternalError(res, result.error);
       deletedIds.push(...result.deletedIds);
     }
     res.json({ deletedIds });
@@ -479,7 +480,7 @@ libraryRouter.get(
       .select("*")
       .eq("user_id", userId)
       .eq("library_kind", kind);
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
 
     const folders = data ?? [];
     const foldersById = new Map(
@@ -533,7 +534,7 @@ libraryRouter.post("/:kind/folders", requireAuth, async (req, res) => {
     })
     .select("*")
     .single();
-  if (error) return void res.status(500).json({ detail: error.message });
+  if (error) return void sendInternalError(res, error);
   res.status(201).json(data);
 });
 
@@ -618,7 +619,7 @@ libraryRouter.delete(
     .eq("user_id", userId)
     .eq("library_kind", kind);
   if (foldersError)
-    return void res.status(500).json({ detail: foldersError.message });
+    return void sendInternalError(res, foldersError);
   if (!(allFolders ?? []).some((folder) => folder.id === folderId)) {
     return void res.status(404).json({ detail: "Folder not found" });
   }
@@ -655,7 +656,7 @@ libraryRouter.delete(
     [...folderIds],
   );
     if (docsError)
-      return void res.status(500).json({ detail: docsError.message });
+      return void sendInternalError(res, docsError);
 
   const docIds = (docs ?? []).map((doc) => doc.id as string);
     const deleteDocsResult = await deleteLibraryDocumentsAndVersionFiles(
@@ -665,9 +666,7 @@ libraryRouter.delete(
     docIds,
   );
     if (deleteDocsResult.error)
-      return void res
-        .status(500)
-        .json({ detail: deleteDocsResult.error.message });
+      return void sendInternalError(res, deleteDocsResult.error);
 
   const { error } = await db
     .from("library_folders")
@@ -675,7 +674,7 @@ libraryRouter.delete(
     .eq("id", folderId)
     .eq("user_id", userId)
     .eq("library_kind", kind);
-  if (error) return void res.status(500).json({ detail: error.message });
+  if (error) return void sendInternalError(res, error);
   res.status(204).send();
   },
 );

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -4,6 +4,7 @@ import { authHeaders } from "../lib/llm/ollama";
 import { isSupportedOpenCodeGoModel } from "../lib/llm/models";
 import { createServerSupabase } from "../lib/supabase";
 import { getUserApiKeys } from "../lib/userApiKeys";
+import { sendInternalError } from "../lib/httpError";
 
 export const modelsRouter = Router();
 
@@ -82,9 +83,14 @@ modelsRouter.get("/openrouter", requireAuth, async (_req, res) => {
         );
         if (!response.ok) {
             const detail = await response.text().catch(() => "");
-            return void res.status(502).json({
-                detail: `OpenRouter model catalog request failed (${response.status})${detail ? `: ${detail}` : ""}`,
-            });
+            sendInternalError(
+                res,
+                new Error(
+                    `OpenRouter model catalog request failed (${response.status})${detail ? `: ${detail}` : ""}`,
+                ),
+                502,
+            );
+            return;
         }
 
         const payload = (await response.json()) as {
@@ -116,12 +122,7 @@ modelsRouter.get("/openrouter", requireAuth, async (_req, res) => {
         });
         res.json({ models });
     } catch (error) {
-        res.status(500).json({
-            detail:
-                error instanceof Error
-                    ? error.message
-                    : "Failed to list OpenRouter models.",
-        });
+        sendInternalError(res, error);
     }
 });
 
@@ -146,9 +147,14 @@ modelsRouter.get("/vercel", requireAuth, async (_req, res) => {
         const response = await fetch(`${baseUrl}/models`);
         if (!response.ok) {
             const detail = await response.text().catch(() => "");
-            return void res.status(502).json({
-                detail: `Vercel AI Gateway model catalog request failed (${response.status})${detail ? `: ${detail}` : ""}`,
-            });
+            sendInternalError(
+                res,
+                new Error(
+                    `Vercel AI Gateway model catalog request failed (${response.status})${detail ? `: ${detail}` : ""}`,
+                ),
+                502,
+            );
+            return;
         }
 
         const payload = (await response.json()) as {
@@ -214,12 +220,7 @@ modelsRouter.get("/vercel", requireAuth, async (_req, res) => {
         });
         res.json({ models });
     } catch (error) {
-        res.status(500).json({
-            detail:
-                error instanceof Error
-                    ? error.message
-                    : "Failed to list Vercel AI Gateway models.",
-        });
+        sendInternalError(res, error);
     }
 });
 
@@ -250,9 +251,14 @@ modelsRouter.get("/opencode-go", requireAuth, async (_req, res) => {
         });
         if (!response.ok) {
             const detail = await response.text().catch(() => "");
-            return void res.status(502).json({
-                detail: `OpenCode Go model catalog request failed (${response.status})${detail ? `: ${detail}` : ""}`,
-            });
+            sendInternalError(
+                res,
+                new Error(
+                    `OpenCode Go model catalog request failed (${response.status})${detail ? `: ${detail}` : ""}`,
+                ),
+                502,
+            );
+            return;
         }
 
         const payload = (await response.json()) as {
@@ -276,11 +282,6 @@ modelsRouter.get("/opencode-go", requireAuth, async (_req, res) => {
         );
         res.json({ models });
     } catch (error) {
-        res.status(500).json({
-            detail:
-                error instanceof Error
-                    ? error.message
-                    : "Failed to list OpenCode Go models.",
-        });
+        sendInternalError(res, error);
     }
 });

--- a/backend/src/routes/projectChat.ts
+++ b/backend/src/routes/projectChat.ts
@@ -10,6 +10,7 @@ import {
     appendAskInputsResponseToLastAssistantMessage,
     appendAssistantEventsToLastAssistantMessage,
     AssistantStreamError,
+    ASSISTANT_ERROR_MESSAGE,
     buildCancelledAssistantMessage,
     extractCitations,
     generateSpotlightNonce,
@@ -30,7 +31,7 @@ import {
     getUserModelSettings,
 } from "../lib/userSettings";
 import { checkProjectAccess } from "../lib/access";
-import { safeErrorLog, safeErrorMessage } from "../lib/safeError";
+import { safeErrorLog } from "../lib/safeError";
 import { generateAssistantChatTitle } from "../lib/chatTitle";
 
 const PROJECT_SYSTEM_PROMPT_EXTRA = `PROJECT CONTEXT:
@@ -402,7 +403,7 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
             return;
         }
         console.error("[project-chat/stream] error:", safeErrorLog(err));
-        const message = safeErrorMessage(err, "Stream error");
+        const message = ASSISTANT_ERROR_MESSAGE;
         const errorEvents = err instanceof AssistantStreamError
             ? stripTransientAssistantEvents(err.events)
             : [{ type: "error" as const, message }];

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -9,6 +9,7 @@ import {
   contentSha256,
 } from "../lib/documentVersions";
 import { safeErrorLog } from "../lib/safeError";
+import { sendInternalError } from "../lib/httpError";
 import {
   buildProjectExportManifest,
   projectManifestFilename,
@@ -274,7 +275,7 @@ projectsRouter.get("/", requireAuth, async (req, res) => {
       p_limit: pagination.limit,
       p_offset: pagination.offset,
     });
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     return void res.json(data ?? []);
   }
 
@@ -298,7 +299,7 @@ projectsRouter.get("/", requireAuth, async (req, res) => {
     : { p_user_id: userId, p_user_email: normalizedUserEmail ?? null };
 
   const { data, error } = await db.rpc("get_projects_overview", rpcArgs);
-  if (error) return void res.status(500).json({ detail: error.message });
+  if (error) return void sendInternalError(res, error);
 
   const projects = (data ?? []) as { id: string }[];
   if (!includeDocuments || projects.length === 0) {
@@ -322,9 +323,9 @@ projectsRouter.get("/", requireAuth, async (req, res) => {
       .order("created_at", { ascending: true }),
   ]);
   if (docsError)
-    return void res.status(500).json({ detail: docsError.message });
+    return void sendInternalError(res, docsError);
   if (foldersError)
-    return void res.status(500).json({ detail: foldersError.message });
+    return void sendInternalError(res, foldersError);
 
   const docsTyped = (docs ?? []) as unknown as {
     id: string;
@@ -408,7 +409,7 @@ projectsRouter.post("/", requireAuth, async (req, res) => {
     })
     .select("*")
     .single();
-  if (error) return void res.status(500).json({ detail: error.message });
+  if (error) return void sendInternalError(res, error);
   res.status(201).json({ ...data, documents: [] });
 });
 
@@ -440,7 +441,7 @@ async function handleProjectDirectorySearch(req: Request, res: Response) {
   const projectResults = await Promise.all(projectQueries);
   const projectError = projectResults.find((result) => result.error)?.error;
   if (projectError)
-    return void res.status(500).json({ detail: projectError.message });
+    return void sendInternalError(res, projectError);
   const projectsById = new Map<string, Record<string, unknown>>();
   for (const result of projectResults) {
     for (const project of result.data ?? []) {
@@ -457,7 +458,7 @@ async function handleProjectDirectorySearch(req: Request, res: Response) {
     .ilike("filename", `%${escaped}%`)
     .is("deleted_at", null);
   if (versionsError)
-    return void res.status(500).json({ detail: versionsError.message });
+    return void sendInternalError(res, versionsError);
 
   const versionIds = (versions ?? []).map((version) => version.id as string);
   let matchedDocuments: Record<string, unknown>[] = [];
@@ -467,7 +468,7 @@ async function handleProjectDirectorySearch(req: Request, res: Response) {
       .select("*")
       .in("project_id", accessibleProjectIds)
       .in("current_version_id", versionIds);
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     matchedDocuments = (data ?? []) as Record<string, unknown>[];
     await attachLatestVersionNumbers(
       db,
@@ -532,7 +533,7 @@ projectsRouter.get("/:projectId/directory", requireAuth, async (req, res) => {
     pagination,
   );
   if (result.error)
-    return void res.status(500).json({ detail: result.error.message });
+    return void sendInternalError(res, result.error);
   res.json({
     documents: result.documents,
     folders: result.folders,
@@ -550,7 +551,7 @@ projectsRouter.get("/filter-options", requireAuth, async (req, res) => {
     p_user_id: userId,
     p_user_email: normalizedUserEmail ?? null,
   });
-  if (error) return void res.status(500).json({ detail: error.message });
+  if (error) return void sendInternalError(res, error);
 
   const row = (data?.[0] ?? {}) as {
     practices?: unknown;
@@ -610,7 +611,7 @@ projectsRouter.get("/ids", requireAuth, async (req, res) => {
       pagination: { limit: PROJECT_IDS_PAGE_SIZE, offset },
     });
     const { data, error } = await db.rpc("get_project_ids_overview", rpcArgs);
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
 
     const rows = (data ?? []) as { id: string; user_id: string }[];
     if (rows.length === 0) break;
@@ -799,8 +800,7 @@ projectsRouter.delete("/:projectId", requireAuth, async (req, res) => {
       return void res.status(404).json({ detail: "Project not found" });
     res.status(204).send();
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    res.status(500).json({ detail });
+    sendInternalError(res, err);
   }
 });
 
@@ -1155,7 +1155,7 @@ projectsRouter.get("/:projectId/chats", requireAuth, async (req, res) => {
     .select("*")
     .eq("project_id", projectId)
     .order("created_at", { ascending: false });
-  if (error) return void res.status(500).json({ detail: error.message });
+  if (error) return void sendInternalError(res, error);
   const chats = data ?? [];
   await attachChatCreatorLabels(db, chats);
   res.json(chats);
@@ -1202,7 +1202,7 @@ projectsRouter.post("/:projectId/folders", requireAuth, async (req, res) => {
     })
     .select("*")
     .single();
-  if (error) return void res.status(500).json({ detail: error.message });
+  if (error) return void sendInternalError(res, error);
   res.status(201).json(data);
 });
 
@@ -1292,7 +1292,7 @@ projectsRouter.delete(
     .select("id, parent_folder_id")
     .eq("project_id", projectId);
   if (foldersError)
-    return void res.status(500).json({ detail: foldersError.message });
+    return void sendInternalError(res, foldersError);
   if (!(allFolders ?? []).some((f) => f.id === folderId))
     return void res.status(404).json({ detail: "Folder not found" });
 
@@ -1320,7 +1320,7 @@ projectsRouter.delete(
     .eq("project_id", projectId)
     .in("folder_id", [...folderIds]);
     if (docsError)
-      return void res.status(500).json({ detail: docsError.message });
+      return void sendInternalError(res, docsError);
 
   const docIds = (docs ?? []).map((d) => d.id as string);
   const deleteDocsError = await deleteProjectDocumentsAndVersionFiles(
@@ -1329,14 +1329,14 @@ projectsRouter.delete(
     docIds,
   );
   if (deleteDocsError)
-    return void res.status(500).json({ detail: deleteDocsError.message });
+    return void sendInternalError(res, deleteDocsError);
 
     const { error } = await db
       .from("project_subfolders")
       .delete()
       .eq("id", folderId)
       .eq("project_id", projectId);
-  if (error) return void res.status(500).json({ detail: error.message });
+  if (error) return void sendInternalError(res, error);
   res.status(204).send();
   },
 );
@@ -1539,9 +1539,7 @@ export async function handleDocumentUpload(
     return void res.status(201).json(responseDoc);
   } catch (e) {
     await db.from("documents").update({ status: "error" }).eq("id", doc.id);
-    return void res
-      .status(500)
-      .json({ detail: `Document processing failed: ${String(e)}` });
+    return void sendInternalError(res, e);
   }
 }
 

--- a/backend/src/routes/quickActions.ts
+++ b/backend/src/routes/quickActions.ts
@@ -7,6 +7,7 @@ import {
 import { requireAuth } from "../middleware/auth";
 import { createServerSupabase } from "../lib/supabase";
 import { ensureDefaultWorkflows } from "../lib/workflowCatalog";
+import { sendInternalError } from "../lib/httpError";
 
 export const quickActionsRouter = Router();
 
@@ -157,7 +158,7 @@ quickActionsRouter.get(
       .eq("surface", surface)
       .order("sort_order", { ascending: true })
       .order("created_at", { ascending: true });
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.json(
       await withWorkflowDetails(
         (data ?? []) as QuickActionRow[],
@@ -222,9 +223,10 @@ quickActionsRouter.post(
       .select("*")
       .single();
     if (error || !data) {
-      return void res
-        .status(500)
-        .json({ detail: error?.message ?? "Create failed" });
+      return void sendInternalError(
+        res,
+        error ?? new Error("Quick action create returned no data"),
+      );
     }
     res.status(201).json({ ...data, workflow });
   }),
@@ -324,7 +326,7 @@ quickActionsRouter.delete(
       .delete()
       .eq("id", req.params.quickActionId)
       .eq("user_id", userId);
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.status(204).send();
   }),
 );

--- a/backend/src/routes/sourceDocuments.ts
+++ b/backend/src/routes/sourceDocuments.ts
@@ -4,6 +4,7 @@ import { getCourtlistenerCaseOpinions } from "../lib/courtlistener";
 import { createServerSupabase } from "../lib/supabase";
 import { getUserModelSettings } from "../lib/userSettings";
 import { caseClusterId, normalizeCaseDocument } from "../lib/sourceDocuments";
+import { sendInternalError } from "../lib/httpError";
 
 export const sourceDocumentsRouter = Router();
 
@@ -60,8 +61,6 @@ sourceDocumentsRouter.get("/:documentId", async (req, res) => {
       }),
     );
   } catch (error) {
-    const detail =
-      error instanceof Error ? error.message : "Failed to load document";
-    return res.status(502).json({ detail });
+    return sendInternalError(res, error, 502);
   }
 });

--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { requireAuth } from "../middleware/auth";
 import { createServerSupabase } from "../lib/supabase";
 import { recordAudit } from "../lib/audit";
+import { sendInternalError } from "../lib/httpError";
 import { downloadFile } from "../lib/storage";
 import { attachActiveVersionPaths } from "../lib/documentVersions";
 import { docxToPdf, normalizeDocxZipPaths } from "../lib/convert";
@@ -14,6 +15,7 @@ import { extractPresentationText } from "../lib/officeText";
 import { spreadsheetToLLMText } from "../lib/spreadsheet";
 import {
     AssistantStreamError,
+    ASSISTANT_ERROR_MESSAGE,
     buildCancelledAssistantMessage,
     isAbortError,
     runLLMStream,
@@ -35,7 +37,7 @@ import {
     ensureReviewAccess,
     filterAccessibleDocumentIds,
 } from "../lib/access";
-import { safeErrorLog, safeErrorMessage } from "../lib/safeError";
+import { safeErrorLog } from "../lib/safeError";
 import {
     findMissingUserEmails,
     loadProfileUsersByEmail,
@@ -516,7 +518,7 @@ tabularRouter.get("/", requireAuth, async (req, res) => {
         "get_tabular_reviews_overview",
         rpcArgs,
     );
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
 
     res.json(data ?? []);
 });
@@ -562,7 +564,7 @@ tabularRouter.get("/ids", requireAuth, async (req, res) => {
             "get_tabular_review_ids_overview",
             rpcArgs,
         );
-        if (error) return void res.status(500).json({ detail: error.message });
+        if (error) return void sendInternalError(res, error);
 
         const rows = (data ?? []) as { id: string; user_id: string }[];
         if (rows.length === 0) break;
@@ -622,9 +624,10 @@ tabularRouter.post("/", requireAuth, async (req, res) => {
         .select("*")
         .single();
     if (error || !review)
-        return void res
-            .status(500)
-            .json({ detail: error?.message ?? "Failed to create review" });
+        return void sendInternalError(
+            res,
+            error ?? new Error("Review create returned no data"),
+        );
 
     try {
         await createRowsForReview(
@@ -751,7 +754,7 @@ tabularRouter.get("/:reviewId", requireAuth, async (req, res) => {
         .select("*")
         .eq("review_id", reviewId);
     if (cellsError)
-        return void res.status(500).json({ detail: cellsError.message });
+        return void sendInternalError(res, cellsError);
     const rows = await loadReviewRows(db, reviewId);
     const rowDocIds = rows.flatMap((row) => row.source_document_ids ?? []);
     const docIds = Array.isArray(review.document_ids)
@@ -964,9 +967,10 @@ tabularRouter.patch("/:reviewId", requireAuth, async (req, res) => {
         .select("*")
         .single();
     if (updateError || !updatedReview)
-        return void res.status(500).json({
-            detail: updateError?.message ?? "Failed to update review",
-        });
+        return void sendInternalError(
+            res,
+            updateError ?? new Error("Review update returned no data"),
+        );
 
     const rowShapeChanged =
         Array.isArray(req.body.document_ids) ||
@@ -1008,7 +1012,7 @@ tabularRouter.delete("/:reviewId", requireAuth, async (req, res) => {
         .delete()
         .eq("id", reviewId)
         .eq("user_id", userId);
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.status(204).send();
 });
 
@@ -1041,7 +1045,7 @@ tabularRouter.post("/:reviewId/clear-cells", requireAuth, async (req, res) => {
         .update({ content: null, status: "pending" })
         .eq("review_id", reviewId)
         .in("row_id", row_ids);
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.status(204).send();
 });
 
@@ -1192,7 +1196,7 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
         .select("*")
         .eq("review_id", reviewId);
     if (cellsError)
-        return void res.status(500).json({ detail: cellsError.message });
+        return void sendInternalError(res, cellsError);
     const cellMap = new Map<string, Record<string, unknown>>();
     for (const cell of cells ?? [])
         cellMap.set(`${cell.row_id}:${cell.column_index}`, cell);
@@ -1319,7 +1323,7 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
         console.error("[tabular/generate] stream error", safeErrorLog(err));
         try {
             write(
-                `data: ${JSON.stringify({ type: "error", message: safeErrorMessage(err, "Stream error") })}\n\ndata: [DONE]\n\n`,
+                `data: ${JSON.stringify({ type: "error", message: ASSISTANT_ERROR_MESSAGE })}\n\ndata: [DONE]\n\n`,
             );
         } catch {
             /* ignore */
@@ -1374,7 +1378,7 @@ tabularRouter.delete(
             .delete()
             .eq("id", chatId)
             .eq("user_id", userId);
-        if (error) return void res.status(500).json({ detail: error.message });
+        if (error) return void sendInternalError(res, error);
         res.status(204).send();
     },
 );
@@ -1397,7 +1401,7 @@ tabularRouter.patch(
             .update({ title: title.slice(0, 200) })
             .eq("id", chatId)
             .eq("user_id", userId);
-        if (error) return void res.status(500).json({ detail: error.message });
+        if (error) return void sendInternalError(res, error);
         res.status(204).send();
     },
 );
@@ -1770,7 +1774,7 @@ tabularRouter.post("/:reviewId/chat", requireAuth, async (req, res) => {
             return;
         }
         console.error("[tabular/chat] error", safeErrorLog(err));
-        const message = safeErrorMessage(err, "Stream error");
+        const message = ASSISTANT_ERROR_MESSAGE;
         const errorEvents =
             err instanceof AssistantStreamError
                 ? stripTransientAssistantEvents(err.events)

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -3,6 +3,7 @@ import { Router } from "express";
 import { requireAuth, requireMfaIfEnrolled } from "../middleware/auth";
 import { createServerSupabase } from "../lib/supabase";
 import { recordAudit } from "../lib/audit";
+import { sendInternalError } from "../lib/httpError";
 import {
     DEFAULT_TABULAR_MODEL,
     DEFAULT_TITLE_MODEL,
@@ -678,7 +679,7 @@ userRouter.post("/profile", requireAuth, async (_req, res) => {
     const userId = res.locals.userId as string;
     const db = createServerSupabase();
     const error = await ensureProfileRow(db, userId);
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.json({ ok: true });
 });
 
@@ -707,7 +708,7 @@ userRouter.get("/profile", requireAuth, async (_req, res) => {
         repairMissing: true,
         apiKeyStatus,
     });
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.json({ ...data, apiKeyStatus });
 });
 
@@ -720,14 +721,14 @@ userRouter.patch("/profile", requireAuth, async (req, res) => {
     const db = createServerSupabase();
     const ensureError = await ensureProfileRow(db, userId);
     if (ensureError)
-        return void res.status(500).json({ detail: ensureError.message });
+        return void sendInternalError(res, ensureError);
 
     const { error: updateError } = await db
         .from("user_profiles")
         .update(parsed.update)
         .eq("user_id", userId);
     if (updateError)
-        return void res.status(500).json({ detail: updateError.message });
+        return void sendInternalError(res, updateError);
 
     for (const slug of ROUTER_SLUGS) {
         const models = parsed.routerModels?.[slug];
@@ -735,15 +736,13 @@ userRouter.patch("/profile", requireAuth, async (req, res) => {
         try {
             await replaceUserRouterModels(userId, slug, models, db);
         } catch (routerModelsError) {
-            return void res.status(500).json({
-                detail: errorMessage(routerModelsError),
-            });
+            return void sendInternalError(res, routerModelsError);
         }
     }
 
     const apiKeyStatus = await getUserApiKeyStatus(userId, db);
     const { data, error } = await loadProfile(db, userId, { apiKeyStatus });
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.json({ ...data, apiKeyStatus });
 });
 
@@ -762,9 +761,7 @@ userRouter.patch(
         if (parsed.value) {
             const factorCheck = await userHasVerifiedTotpFactor(db, userId);
             if (!factorCheck.ok) {
-                return void res.status(500).json({
-                    detail: factorCheck.error.message,
-                });
+                return void sendInternalError(res, factorCheck.error);
             }
             if (!factorCheck.hasVerifiedTotp) {
                 return void res.status(400).json({
@@ -775,7 +772,7 @@ userRouter.patch(
 
         const ensureError = await ensureProfileRow(db, userId);
         if (ensureError)
-            return void res.status(500).json({ detail: ensureError.message });
+            return void sendInternalError(res, ensureError);
 
         const { error: updateError } = await db
             .from("user_profiles")
@@ -785,11 +782,11 @@ userRouter.patch(
             })
             .eq("user_id", userId);
         if (updateError)
-            return void res.status(500).json({ detail: updateError.message });
+            return void sendInternalError(res, updateError);
 
         const apiKeyStatus = await getUserApiKeyStatus(userId, db);
         const { data, error } = await loadProfile(db, userId, { apiKeyStatus });
-        if (error) return void res.status(500).json({ detail: error.message });
+        if (error) return void sendInternalError(res, error);
         res.json({ ...data, apiKeyStatus });
     },
 );
@@ -833,7 +830,7 @@ userRouter.put(
                 provider,
                 error: detail,
             });
-            res.status(500).json({ detail });
+            sendInternalError(res, err);
         }
     },
 );
@@ -852,7 +849,7 @@ userRouter.get("/mcp-connectors", requireAuth, async (_req, res) => {
             userId,
             error: detail,
         });
-        res.status(500).json({ detail });
+        sendInternalError(res, err);
     }
 });
 
@@ -874,7 +871,7 @@ userRouter.get(
                 connectorId: req.params.connectorId,
                 error: detail,
             });
-            res.status(404).json({ detail });
+            res.status(404).json({ detail: "Connector not found" });
         }
     },
 );
@@ -913,7 +910,9 @@ userRouter.post(
                 userId,
                 error: detail,
             });
-            res.status(400).json({ detail });
+            res.status(400).json({
+                detail: "Connector settings are invalid or the server could not be reached.",
+            });
         }
     },
 );
@@ -973,7 +972,9 @@ userRouter.patch(
                 connectorId: req.params.connectorId,
                 error: detail,
             });
-            res.status(400).json({ detail });
+            res.status(400).json({
+                detail: "Connector settings are invalid or the server could not be reached.",
+            });
         }
     },
 );
@@ -996,7 +997,7 @@ userRouter.delete(
                 connectorId: req.params.connectorId,
                 error: detail,
             });
-            res.status(500).json({ detail });
+            sendInternalError(res, err);
         }
     },
 );
@@ -1025,7 +1026,9 @@ userRouter.post(
                 connectorId: req.params.connectorId,
                 error: detail,
             });
-            res.status(400).json({ detail });
+            res.status(400).json({
+                detail: "Connector authorization could not be started.",
+            });
         }
     },
 );
@@ -1071,7 +1074,15 @@ userRouter.get("/mcp-connectors/oauth/callback", async (req, res) => {
         res.status(400)
             .set("Content-Security-Policy", mcpOAuthPopupCsp(nonce))
             .type("html")
-            .send(mcpOAuthPopupHtml({ success: false, detail }, nonce));
+            .send(
+                mcpOAuthPopupHtml(
+                    {
+                        success: false,
+                        detail: "Connector authorization could not be completed.",
+                    },
+                    nonce,
+                ),
+            );
     }
 });
 
@@ -1100,10 +1111,12 @@ userRouter.post(
             if (err instanceof McpOAuthRequiredError) {
                 return void res.status(401).json({
                     code: err.code,
-                    detail,
+                    detail: "This connector needs to be authorized again.",
                 });
             }
-            res.status(400).json({ detail });
+            res.status(400).json({
+                detail: "Connector tools could not be refreshed.",
+            });
         }
     },
 );
@@ -1137,7 +1150,9 @@ userRouter.patch(
                 toolId: req.params.toolId,
                 error: detail,
             });
-            res.status(400).json({ detail });
+            res.status(400).json({
+                detail: "Connector tool settings could not be updated.",
+            });
         }
     },
 );
@@ -1155,7 +1170,7 @@ userRouter.delete(
             await deleteUserAccountData(db, userId, userEmail);
             const { error } = await db.auth.admin.deleteUser(userId);
             if (error)
-                return void res.status(500).json({ detail: error.message });
+                return void sendInternalError(res, error);
             res.status(204).send();
         } catch (err) {
             const detail = errorMessage(err);
@@ -1163,7 +1178,7 @@ userRouter.delete(
                 userId,
                 error: detail,
             });
-            res.status(500).json({ detail });
+            sendInternalError(res, err);
         }
     },
 );
@@ -1185,7 +1200,7 @@ userRouter.delete(
                 userId,
                 error: detail,
             });
-            res.status(500).json({ detail });
+            sendInternalError(res, err);
         }
     },
 );
@@ -1207,7 +1222,7 @@ userRouter.delete(
                 userId,
                 error: detail,
             });
-            res.status(500).json({ detail });
+            sendInternalError(res, err);
         }
     },
 );
@@ -1229,7 +1244,7 @@ userRouter.delete(
                 userId,
                 error: detail,
             });
-            res.status(500).json({ detail });
+            sendInternalError(res, err);
         }
     },
 );
@@ -1260,7 +1275,7 @@ userRouter.get(
         } catch (err) {
             const detail = errorMessage(err);
             console.error("[user/export] failed", { userId, error: detail });
-            res.status(500).json({ detail });
+            sendInternalError(res, err);
         }
     },
 );
@@ -1294,7 +1309,7 @@ userRouter.get(
                 userId,
                 error: detail,
             });
-            res.status(500).json({ detail });
+            sendInternalError(res, err);
         }
     },
 );
@@ -1332,7 +1347,7 @@ userRouter.get(
                 userId,
                 error: detail,
             });
-            res.status(500).json({ detail });
+            sendInternalError(res, err);
         }
     },
 );

--- a/backend/src/routes/wordChat.ts
+++ b/backend/src/routes/wordChat.ts
@@ -4,6 +4,7 @@ import { requireAuth } from "../middleware/auth";
 import { createServerSupabase } from "../lib/supabase";
 import {
   AssistantStreamError,
+  ASSISTANT_ERROR_MESSAGE,
   ACTIVE_WORD_DOCUMENT_ID,
   buildCancelledAssistantMessage,
   buildDocContext,
@@ -26,7 +27,7 @@ import {
   withoutEmptyAssistantReservations,
 } from "../lib/chat";
 import { getUserModelSettings } from "../lib/userSettings";
-import { safeErrorLog, safeErrorMessage } from "../lib/safeError";
+import { safeErrorLog } from "../lib/safeError";
 import {
   persistWordDocumentEdits,
   WORD_EDIT_FORMATS,
@@ -911,7 +912,7 @@ wordChatRouter.post("/", requireAuth, async (req, res) => {
       return;
     }
     console.error("[word-chat] stream error", safeErrorLog(error));
-    const message = safeErrorMessage(error, "Stream error");
+    const message = ASSISTANT_ERROR_MESSAGE;
     const errorEvents =
       error instanceof AssistantStreamError
         ? stripTransientAssistantEvents(error.events)

--- a/backend/src/routes/workflowAddons.ts
+++ b/backend/src/routes/workflowAddons.ts
@@ -16,6 +16,7 @@ import {
 } from "../lib/storage";
 import { contentTypeForDocumentType } from "../lib/documentTypes";
 import { contentSha256 } from "../lib/documentVersions";
+import { sendInternalError } from "../lib/httpError";
 
 export const workflowAddonsRouter = Router();
 
@@ -43,7 +44,7 @@ workflowAddonsRouter.get(
     if (type === "assistant" || type === "tabular")
       query = query.eq("type", type);
     const { data, error } = await query.order("title", { ascending: true });
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.json(data ?? []);
   }),
 );
@@ -71,7 +72,7 @@ workflowAddonsRouter.get(
         .eq("addon_id", data.id)
         .order("created_at", { ascending: true });
       if (referencesError) {
-        return void res.status(500).json({ detail: referencesError.message });
+        return void sendInternalError(res, referencesError);
       }
       references = assistantReferences;
     }
@@ -112,9 +113,10 @@ workflowAddonsRouter.post(
       .select("*")
       .single();
     if (error || !workflow) {
-      return void res
-        .status(500)
-        .json({ detail: error?.message ?? "Import failed" });
+      return void sendInternalError(
+        res,
+        error ?? new Error("Workflow add-on import returned no data"),
+      );
     }
 
     const createdStoragePaths: string[] = [];

--- a/backend/src/routes/workflows.ts
+++ b/backend/src/routes/workflows.ts
@@ -29,6 +29,7 @@ import {
   contentTypeForDocumentType,
 } from "../lib/documentTypes";
 import { contentSha256 } from "../lib/documentVersions";
+import { sendInternalError } from "../lib/httpError";
 import {
   deleteFile,
   getSignedUrl,
@@ -139,11 +140,7 @@ async function ensureDefaultsForRequest(
     await ensureDefaultWorkflows(userId, db);
     return true;
   } catch (error) {
-    const detail =
-      error && typeof error === "object" && "message" in error
-        ? String(error.message)
-        : "Failed to install default workflows";
-    res.status(500).json({ detail });
+    sendInternalError(res, error);
     return false;
   }
 }
@@ -456,7 +453,7 @@ workflowsRouter.get(
         jurisdiction: normalizeSearchTerm(req.query.jurisdiction),
       });
       const { data, error } = await db.rpc("get_workflows_overview", rpcArgs);
-      if (error) return void res.status(500).json({ detail: error.message });
+      if (error) return void sendInternalError(res, error);
       const workflows = ((data ?? []) as WorkflowRecord[]).map(
         withDatabaseWorkflowSummary,
       );
@@ -469,7 +466,7 @@ workflowsRouter.get(
       p_type: workflowType,
     });
     if (error) {
-      return void res.status(500).json({ detail: error.message });
+      return void sendInternalError(res, error);
     }
 
     const databaseWorkflows = ((data ?? []) as WorkflowRecord[]).map(
@@ -518,7 +515,7 @@ workflowsRouter.get(
       p_type: type,
       p_scope: scope,
     });
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
 
     const row = (data?.[0] ?? {}) as Record<string, unknown>;
     const strings = (value: unknown) =>
@@ -574,7 +571,7 @@ workflowsRouter.get(
         "get_workflow_ids_overview",
         rpcArgs,
       );
-      if (error) return void res.status(500).json({ detail: error.message });
+      if (error) return void sendInternalError(res, error);
       const rows = (data ?? []) as { id: string; user_id: string }[];
       if (rows.length === 0) break;
       ids.push(...rows);
@@ -652,7 +649,7 @@ workflowsRouter.post(
         details: error.details,
         hint: error.hint,
       });
-      return void res.status(500).json({ detail: error.message });
+      return void sendInternalError(res, error);
     }
     devLog("[workflows/create] inserted", {
       id: data?.id,
@@ -746,7 +743,7 @@ workflowsRouter.delete(
       .eq("id", workflowId)
       .eq("user_id", userId)
       .select("id");
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     if ((deleted ?? []).length > 0) {
       await Promise.all(
         (referenceDocuments ?? []).map((reference) =>
@@ -769,7 +766,7 @@ workflowsRouter.get(
       .from("hidden_workflows")
       .select("workflow_id")
       .eq("user_id", userId);
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.json((data ?? []).map((r) => r.workflow_id));
   }),
 );
@@ -790,7 +787,7 @@ workflowsRouter.post(
         { user_id: userId, workflow_id },
         { onConflict: "user_id,workflow_id" },
       );
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.status(204).send();
   }),
 );
@@ -808,7 +805,7 @@ workflowsRouter.delete(
       .delete()
       .eq("user_id", userId)
       .eq("workflow_id", workflowId);
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.status(204).send();
   }),
 );
@@ -842,7 +839,7 @@ workflowsRouter.post(
       .eq("user_id", userId)
       .maybeSingle();
     if (workflowError) {
-      return void res.status(500).json({ detail: workflowError.message });
+      return void sendInternalError(res, workflowError);
     }
     if (!workflow) {
       return void res
@@ -887,7 +884,7 @@ workflowsRouter.post(
       .eq("status", "pending")
       .maybeSingle();
     if (pendingError) {
-      return void res.status(500).json({ detail: pendingError.message });
+      return void sendInternalError(res, pendingError);
     }
 
     if (pendingSubmission) {
@@ -905,9 +902,10 @@ workflowsRouter.post(
         .select("id, status, submitted_at, updated_at, reviewed_at")
         .single();
       if (updateError || !updated) {
-        return void res.status(500).json({
-          detail: updateError?.message ?? "Failed to update submission",
-        });
+        return void sendInternalError(
+          res,
+          updateError ?? new Error("Submission update returned no data"),
+        );
       }
       return void res.json({
         ...toOpenSourceSubmissionSummary(updated as OpenSourceSubmissionRow),
@@ -932,9 +930,10 @@ workflowsRouter.post(
       .select("id, status, submitted_at, updated_at, reviewed_at")
       .single();
     if (createError || !created) {
-      return void res.status(500).json({
-        detail: createError?.message ?? "Failed to create submission",
-      });
+      return void sendInternalError(
+        res,
+        createError ?? new Error("Submission create returned no data"),
+      );
     }
 
     res.status(201).json({
@@ -969,7 +968,7 @@ workflowsRouter.get(
       )
       .eq("workflow_id", req.params.workflowId)
       .order("created_at", { ascending: true });
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.json(data ?? []);
   }),
 );
@@ -1041,9 +1040,10 @@ workflowsRouter.post(
       .single();
     if (error || !data) {
       await deleteFile(storagePath).catch(() => {});
-      return void res
-        .status(500)
-        .json({ detail: error?.message ?? "Upload failed" });
+      return void sendInternalError(
+        res,
+        error ?? new Error("Reference upload returned no data"),
+      );
     }
     res.status(201).json(data);
   }),
@@ -1157,9 +1157,10 @@ workflowsRouter.put(
       .single();
     if (error || !data) {
       await deleteFile(storagePath).catch(() => {});
-      return void res
-        .status(500)
-        .json({ detail: error?.message ?? "Replacement failed" });
+      return void sendInternalError(
+        res,
+        error ?? new Error("Reference replacement returned no data"),
+      );
     }
     if (current.storage_path !== storagePath) {
       await deleteFile(current.storage_path).catch(() => {});
@@ -1202,7 +1203,7 @@ workflowsRouter.delete(
       .from("workflow_reference_documents")
       .delete()
       .eq("id", reference.id);
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.status(204).send();
   }),
 );
@@ -1280,7 +1281,7 @@ workflowsRouter.get(
       .select("id, shared_with_email, allow_edit, created_at")
       .eq("workflow_id", workflowId)
       .order("created_at", { ascending: true });
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
 
     res.json(shares ?? []);
   }),
@@ -1376,7 +1377,7 @@ workflowsRouter.post(
     const { error } = await db
       .from("workflow_shares")
       .upsert(rows, { onConflict: "workflow_id,shared_with_email" });
-    if (error) return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
 
     res.status(204).send();
   }),

--- a/frontend/src/app/(pages)/settings/connectors/page.tsx
+++ b/frontend/src/app/(pages)/settings/connectors/page.tsx
@@ -37,6 +37,7 @@ import {
     startMcpConnectorOAuth,
     updateMcpConnector,
 } from "@/app/lib/mikeApi";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 import { settingsGlassIconButtonClassName } from "../settingsStyles";
 import { SettingsSection } from "../SettingsSection";
 import { SettingsToggle } from "../SettingsToggle";
@@ -157,7 +158,7 @@ export default function ConnectorsPage() {
             setConnectors(await listMcpConnectors());
         } catch (err) {
             setError(
-                err instanceof Error ? err.message : "Failed to load connectors.",
+                userFacingApiError(err, "Failed to load connectors."),
             );
         } finally {
             setLoading(false);
@@ -227,9 +228,10 @@ export default function ConnectorsPage() {
             replaceConnector(await getMcpConnector(connectorId));
         } catch (err) {
             setDetailError(
-                err instanceof Error
-                    ? err.message
-                    : "Failed to load connector details.",
+                userFacingApiError(
+                    err,
+                    "Failed to load connector details.",
+                ),
             );
         } finally {
             setLoadingConnectorId((current) =>
@@ -255,8 +257,7 @@ export default function ConnectorsPage() {
                 setPendingMfaAction(action);
                 return;
             }
-            const message =
-                err instanceof Error ? err.message : "Action failed.";
+            const message = userFacingApiError(err, "Action failed.");
             if (action.type === "create") setAddError(message);
             else if (action.type === "save") setDetailError(message);
             else setError(message);
@@ -409,9 +410,7 @@ export default function ConnectorsPage() {
                 setAddStep("form");
                 setAddAuthMessage(null);
                 setAddError(
-                    err instanceof Error
-                        ? err.message
-                        : "Failed to add connector.",
+                    userFacingApiError(err, "Failed to add connector."),
                 );
             } finally {
                 setBusyKey(null);

--- a/frontend/src/app/(pages)/settings/page.tsx
+++ b/frontend/src/app/(pages)/settings/page.tsx
@@ -142,7 +142,7 @@ export default function SettingsPage() {
                 setEmail(user?.pendingEmail || user?.email || "");
                 setEmailWarning({
                     title: "Email already registered",
-                    message,
+                    message: "An account with this email already exists.",
                 });
                 return;
             }
@@ -157,7 +157,7 @@ export default function SettingsPage() {
                 return;
             }
 
-            setEmailStatus(message);
+            setEmailStatus("Failed to update email. Please try again.");
         } finally {
             setIsSavingEmail(false);
         }

--- a/frontend/src/app/(pages)/settings/security/page.tsx
+++ b/frontend/src/app/(pages)/settings/security/page.tsx
@@ -21,6 +21,15 @@ import { SettingsSection } from "../SettingsSection";
 import { SettingsToggle } from "../SettingsToggle";
 import { useAuth } from "@/app/contexts/AuthContext";
 import { browserAuthCallbackUrl } from "@/app/lib/authRedirects";
+import {
+    knownErrorCodeMessage,
+    userFacingApiError,
+} from "@/app/lib/userFacingError";
+
+const MFA_VERIFICATION_ERROR_MESSAGES = {
+    mfa_verification_failed: "The verification code is invalid or expired.",
+    otp_expired: "The verification code is invalid or expired.",
+} as const;
 
 type MfaFactor = {
     id: string;
@@ -200,7 +209,7 @@ export default function SecurityPage() {
             traceMfa("[security/mfa] list factors failed", {
                 error: factorResult.error.message,
             });
-            setStatus(factorResult.error.message);
+            setStatus("MFA settings could not be loaded. Please try again.");
             setFactors([]);
         } else {
             const verifiedTotp = (factorResult.data.totp ?? []) as MfaFactor[];
@@ -217,7 +226,7 @@ export default function SecurityPage() {
             traceMfa("[security/mfa] assurance lookup failed", {
                 error: aalResult.error.message,
             });
-            setStatus(aalResult.error.message);
+            setStatus("MFA settings could not be loaded. Please try again.");
             setCurrentLevel(null);
             setNextLevel(null);
         } else {
@@ -291,11 +300,10 @@ export default function SecurityPage() {
             setVerificationCode("");
             setSetupKeyCopied(false);
         } catch (error) {
-            setStatus(
-                error instanceof Error
-                    ? error.message
-                    : "Failed to start MFA setup.",
-            );
+            traceMfa("[security/mfa] setup failed", {
+                errorType: error instanceof Error ? error.name : typeof error,
+            });
+            setStatus("Failed to start MFA setup. Please try again.");
         } finally {
             setBusy(false);
         }
@@ -345,9 +353,11 @@ export default function SecurityPage() {
             await refreshMfaState();
         } catch (error) {
             setStatus(
-                error instanceof Error
-                    ? error.message
-                    : "Failed to verify MFA code.",
+                knownErrorCodeMessage(
+                    error,
+                    MFA_VERIFICATION_ERROR_MESSAGES,
+                    "Failed to verify the MFA code. Please try again.",
+                ),
             );
         } finally {
             setBusy(false);
@@ -377,7 +387,10 @@ export default function SecurityPage() {
         const { data, error } =
             await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
         if (error) {
-            setStatus(error.message);
+            traceMfa("[security/mfa] state verification failed", {
+                errorType: error.name,
+            });
+            setStatus("MFA settings could not be verified. Please try again.");
             return;
         }
 
@@ -403,7 +416,10 @@ export default function SecurityPage() {
                 setPendingUnenrollFactorId(factorId);
                 return;
             }
-            setStatus(error.message);
+            traceMfa("[security/mfa] disable failed", {
+                errorType: error.name,
+            });
+            setStatus("MFA could not be disabled. Please try again.");
             return;
         }
 
@@ -427,9 +443,10 @@ export default function SecurityPage() {
             await saveLoginPreference(enabled);
         } catch (error) {
             setStatus(
-                error instanceof Error
-                    ? error.message
-                    : "Failed to update login authentication preference.",
+                userFacingApiError(
+                    error,
+                    "Failed to update login authentication preference.",
+                ),
             );
         } finally {
             setSavingLoginPreference(false);
@@ -449,9 +466,10 @@ export default function SecurityPage() {
                 setPendingLoginPreference(enabled);
             } else {
                 setStatus(
-                    error instanceof Error
-                        ? error.message
-                        : "Failed to update login authentication preference.",
+                    userFacingApiError(
+                        error,
+                        "Failed to update login authentication preference.",
+                    ),
                 );
             }
         } finally {

--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -41,14 +41,14 @@ function AuthCallbackContent() {
                 const { error: exchangeError } =
                     await supabase.auth.exchangeCodeForSession(code);
                 if (exchangeError) {
-                    setError(exchangeError.message);
+                    setError("This confirmation link is invalid or has expired.");
                     return;
                 }
             } else {
                 const { data, error: sessionError } =
                     await supabase.auth.getSession();
                 if (sessionError) {
-                    setError(sessionError.message);
+                    setError("Authentication could not be completed. Please try again.");
                     return;
                 }
                 if (!data.session) {

--- a/frontend/src/app/components/assistant/QuickActionsModal.tsx
+++ b/frontend/src/app/components/assistant/QuickActionsModal.tsx
@@ -10,6 +10,7 @@ import { FieldLabel, FormTextInput } from "../ui/form-field";
 import { ToggleSwitch } from "../ui/toggle-switch";
 import { SearchBar } from "../ui/search-bar";
 import { listWorkflows } from "@/app/lib/mikeApi";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 
 type Screen = "list" | "details" | "create";
 
@@ -102,11 +103,7 @@ export function QuickActionsModal({
       await onSave(selected);
       resetToList();
     } catch (reason) {
-      setError(
-        reason instanceof Error
-          ? reason.message
-          : "Could not save quick action.",
-      );
+      setError(userFacingApiError(reason, "Could not save quick action."));
     } finally {
       setSaving(false);
     }
@@ -125,11 +122,7 @@ export function QuickActionsModal({
       });
       resetToList();
     } catch (reason) {
-      setError(
-        reason instanceof Error
-          ? reason.message
-          : "Could not create quick action.",
-      );
+      setError(userFacingApiError(reason, "Could not create quick action."));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/app/components/assistant/message/eventUtils.ts
+++ b/frontend/src/app/components/assistant/message/eventUtils.ts
@@ -1,9 +1,13 @@
 import type { AssistantEvent } from "../../shared/types";
 
 export function eventErrorMessage(event: AssistantEvent): string | null {
-    if (event.type === "error") return event.message;
+    if (event.type === "error") {
+        return event.safe_to_display
+            ? event.message
+            : "Sorry, something went wrong.";
+    }
     if ("error" in event && typeof event.error === "string" && event.error) {
-        return event.error;
+        return "Sorry, something went wrong.";
     }
     return null;
 }

--- a/frontend/src/app/components/documents/DocTable.tsx
+++ b/frontend/src/app/components/documents/DocTable.tsx
@@ -42,6 +42,7 @@ import { useAuth } from "@/app/contexts/AuthContext";
 import { WarningPopup } from "@/app/components/popups/WarningPopup";
 import { UploadOverlay } from "@/app/components/assistant/UploadOverlay";
 import { ConfirmPopup } from "@/app/components/popups/ConfirmPopup";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 import {
     formatUnsupportedDocumentWarning,
     partitionSupportedDocumentFiles,
@@ -179,24 +180,6 @@ interface DocTableProps {
     documentTypeOptions?: TableFilterOption<string>[];
     autoLoadOnScroll?: boolean;
     defaultSort?: DocumentSort | null;
-}
-
-function apiErrorDetail(error: unknown): string | null {
-    if (!(error instanceof Error)) return null;
-    try {
-        const parsed = JSON.parse(error.message) as unknown;
-        if (
-            parsed &&
-            typeof parsed === "object" &&
-            "detail" in parsed &&
-            typeof parsed.detail === "string"
-        ) {
-            return parsed.detail;
-        }
-    } catch {
-        // Non-JSON errors can fall through to the plain message below.
-    }
-    return error.message || null;
 }
 
 function documentTypeValue(doc: Document): string {
@@ -1245,7 +1228,12 @@ export function DocTable({
         } catch (err) {
             console.error("Existing document version drop failed", err);
             restoreDocumentToLocalState(sourceDoc, sourceSnapshot);
-            setCollectionActionWarning(apiErrorDetail(err) ?? "Could not save this document as a new version.");
+            setCollectionActionWarning(
+                userFacingApiError(
+                    err,
+                    "Could not save this document as a new version.",
+                ),
+            );
         } finally {
             setUploadingVersionDocIds((prev) => {
                 const next = new Set(prev);
@@ -2406,7 +2394,10 @@ export function DocTable({
             setSelectionCameFromSelectAll(true);
         } catch (error) {
             setCollectionActionWarning(
-                apiErrorDetail(error) ?? "All matching files could not be selected. Please try again.",
+                userFacingApiError(
+                    error,
+                    "All matching files could not be selected. Please try again.",
+                ),
             );
         } finally {
             setSelectingAllDocuments(false);

--- a/frontend/src/app/components/modals/PeopleModal.tsx
+++ b/frontend/src/app/components/modals/PeopleModal.tsx
@@ -212,12 +212,8 @@ export function PeopleModal({
         try {
             const next = [...sharedWith, email];
             await onSharedWithChange(next);
-        } catch (e) {
-            throw new Error(
-                e instanceof Error
-                    ? e.message
-                    : "Couldn't add the member. Try again.",
-            );
+        } catch {
+            throw new Error("Couldn't add the member. Try again.");
         } finally {
             setBusy(null);
         }
@@ -233,12 +229,8 @@ export function PeopleModal({
                 (e) => e.toLowerCase() !== email.toLowerCase(),
             );
             await onSharedWithChange(next);
-        } catch (e) {
-            setError(
-                e instanceof Error
-                    ? e.message
-                    : "Couldn't remove the member. Try again.",
-            );
+        } catch {
+            setError("Couldn't remove the member. Try again.");
         } finally {
             setBusy(null);
             setRemovingEmail(null);

--- a/frontend/src/app/components/popups/MfaVerificationPopup.tsx
+++ b/frontend/src/app/components/popups/MfaVerificationPopup.tsx
@@ -72,7 +72,7 @@ export function MfaVerificationPopup({
                 devLog("[mfa-popup] list factors failed", {
                     error: listError.message,
                 });
-                setError(listError.message);
+                setError("Authenticator verification could not be loaded.");
                 setFactors([]);
                 setSelectedFactorId("");
             } else {
@@ -110,7 +110,7 @@ export function MfaVerificationPopup({
             devLog("[mfa-popup] verification failed", {
                 error: verifyError.message,
             });
-            setError(verifyError.message);
+            setError("The verification code is invalid or expired.");
             return;
         }
 

--- a/frontend/src/app/components/projects/NewProjectModal.tsx
+++ b/frontend/src/app/components/projects/NewProjectModal.tsx
@@ -15,6 +15,7 @@ import { useAuth } from "@/app/contexts/AuthContext";
 import { Modal } from "../modals/Modal";
 import { FieldLabel, FormTextInput } from "../ui/form-field";
 import { ProjectPracticeField } from "./ProjectPracticeField";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 
 interface Props {
     open: boolean;
@@ -89,7 +90,7 @@ export function NewProjectModal({ open, onClose, onCreated }: Props) {
             resetForm();
             onClose();
         } catch (err: unknown) {
-            setError((err as Error).message || "Failed to create project");
+            setError(userFacingApiError(err, "Failed to create project"));
         } finally {
             setLoading(false);
         }

--- a/frontend/src/app/components/shared/AddUserInput.tsx
+++ b/frontend/src/app/components/shared/AddUserInput.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/app/lib/mikeApi";
 import { PillButton } from "@/app/components/ui/pill-button";
 import { cn } from "@/app/lib/utils";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -65,9 +66,10 @@ export function AddUserInput({
             setInput("");
         } catch (err) {
             setError(
-                err instanceof Error
-                    ? err.message
-                    : "Could not add this user. Try again.",
+                userFacingApiError(
+                    err,
+                    "Could not add this user. Try again.",
+                ),
             );
         } finally {
             setChecking(false);

--- a/frontend/src/app/components/shared/types.ts
+++ b/frontend/src/app/components/shared/types.ts
@@ -154,7 +154,7 @@ export type AskInputsResponseEvent = {
 
 export type AssistantEvent =
     | { type: "reasoning"; text: string; isStreaming?: boolean }
-    | { type: "error"; message: string }
+    | { type: "error"; message: string; safe_to_display?: boolean }
     | {
           type: "tool_call_start";
           name: string;

--- a/frontend/src/app/components/workflows/NewWorkflowModal.tsx
+++ b/frontend/src/app/components/workflows/NewWorkflowModal.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { MessageSquare, Table2, Upload } from "lucide-react";
 import { createWorkflow, updateWorkflow } from "@/app/lib/mikeApi";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 import type { Workflow } from "../shared/types";
 import { PRACTICE_OPTIONS } from "./practices";
 import { Modal } from "../modals/Modal";
@@ -371,7 +372,12 @@ export function NewWorkflowModal({
             resetForm();
             onClose();
         } catch (err: unknown) {
-            setError((err as Error).message || `Failed to ${isEditing ? "update" : "create"} workflow`);
+            setError(
+                userFacingApiError(
+                    err,
+                    `Failed to ${isEditing ? "update" : "create"} workflow`,
+                ),
+            );
         } finally {
             setLoading(false);
         }

--- a/frontend/src/app/components/workflows/OpenSourceWorkflowModal.tsx
+++ b/frontend/src/app/components/workflows/OpenSourceWorkflowModal.tsx
@@ -10,6 +10,7 @@ import {
     FieldLabel,
     FormTextInput,
 } from "@/app/components/ui/form-field";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 
 type OpenSourceContributorMode = "named" | "anonymous";
 type OpenSourceStatus = "idle" | "loading" | "complete";
@@ -114,9 +115,10 @@ export function OpenSourceWorkflowModal({
         } catch (err) {
             setStatus("idle");
             setError(
-                err instanceof Error
-                    ? err.message
-                    : "Failed to submit workflow for review.",
+                userFacingApiError(
+                    err,
+                    "Failed to submit workflow for review.",
+                ),
             );
         }
     }

--- a/frontend/src/app/components/workflows/WorkflowList.tsx
+++ b/frontend/src/app/components/workflows/WorkflowList.tsx
@@ -35,6 +35,7 @@ import { workflowDetailPath } from "./workflowRoutes";
 import { ConfirmPopup } from "../popups/ConfirmPopup";
 import { WorkflowAddonPreviewModal } from "./WorkflowAddonPreviewModal";
 import { TableLoadMoreRow } from "@/app/components/shared/TableLoadMoreRow";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 import {
   SkeletonDot,
   SkeletonLine,
@@ -131,7 +132,6 @@ export function WorkflowList({
   >("idle");
   const [importingAddonId, setImportingAddonId] = useState<string | null>(null);
   const [bulkImportingAddons, setBulkImportingAddons] = useState(false);
-  const [loadError, setLoadError] = useState("");
   const [addonsError, setAddonsError] = useState("");
   const [actionError, setActionError] = useState("");
   const workflowActionsRef = useRef<HTMLDivElement>(null);
@@ -176,9 +176,7 @@ export function WorkflowList({
     listWorkflowAddons()
       .then(setAddons)
       .catch((error) => {
-        setAddonsError(
-          error instanceof Error ? error.message : "Unable to load add-ons.",
-        );
+        setAddonsError(userFacingApiError(error, "Unable to load add-ons."));
       })
       .finally(() => setAddonsLoading(false));
   }, []);
@@ -311,9 +309,10 @@ export function WorkflowList({
       router.push(workflowDetailPath(workflow));
     } catch (error) {
       setActionError(
-        error instanceof Error
-          ? `Could not import "${addon.title}": ${error.message}`
-          : `Could not import "${addon.title}".`,
+        userFacingApiError(
+          error,
+          `Could not import "${addon.title}".`,
+        ),
       );
     } finally {
       setImportingAddonId(null);
@@ -531,7 +530,7 @@ export function WorkflowList({
           key={activeTab}
           workflows={visibleWorkflows}
           loading={loading}
-          error={workflowsError?.message || loadError}
+          error={workflowsError ? "Unable to load workflows." : ""}
           onOpen={setSelected}
           onEdit={setEditingWorkflow}
           onDelete={(workflow) => requestWorkflowDeletion([workflow])}

--- a/frontend/src/app/components/workflows/WorkflowReferenceFiles.tsx
+++ b/frontend/src/app/components/workflows/WorkflowReferenceFiles.tsx
@@ -20,6 +20,7 @@ import {
   formatUnsupportedDocumentWarning,
   partitionSupportedDocumentFiles,
 } from "@/app/lib/documentUploadValidation";
+import { userFacingApiError } from "@/app/lib/userFacingError";
 import { EmptyState } from "@/app/components/ui/empty-state";
 import { ConfirmPopup } from "../popups/ConfirmPopup";
 import { FileTypeIcon } from "../shared/FileTypeIcon";
@@ -99,11 +100,7 @@ export const WorkflowReferenceFiles = forwardRef<
       setFiles(await listWorkflowReferenceFiles(workflowId));
       setError("");
     } catch (caught) {
-      setError(
-        caught instanceof Error
-          ? caught.message
-          : "Unable to load reference files.",
-      );
+      setError(userFacingApiError(caught, "Unable to load reference files."));
     } finally {
       setLoading(false);
     }
@@ -147,9 +144,7 @@ export const WorkflowReferenceFiles = forwardRef<
         setFiles((current) => [...current, created]);
       }
     } catch (caught) {
-      appendWarning(
-        caught instanceof Error ? caught.message : "Upload failed.",
-      );
+      appendWarning(userFacingApiError(caught, "Upload failed."));
     } finally {
       uploadInFlightRef.current = false;
       setBusyId(null);
@@ -164,9 +159,7 @@ export const WorkflowReferenceFiles = forwardRef<
       await replaceWorkflowReferenceFile(workflowId, target.id, file);
       await reload();
     } catch (caught) {
-      setError(
-        caught instanceof Error ? caught.message : "Replacement failed.",
-      );
+      setError(userFacingApiError(caught, "Replacement failed."));
     } finally {
       replaceTargetRef.current = null;
       setBusyId(null);
@@ -182,7 +175,7 @@ export const WorkflowReferenceFiles = forwardRef<
       anchor.download = resolved.filename || file.filename;
       anchor.click();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : "Download failed.");
+      setError(userFacingApiError(caught, "Download failed."));
     } finally {
       setBusyId(null);
     }
@@ -197,7 +190,7 @@ export const WorkflowReferenceFiles = forwardRef<
       await deleteWorkflowReferenceFile(workflowId, file.id);
       setFiles((current) => current.filter((item) => item.id !== file.id));
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : "Delete failed.");
+      setError(userFacingApiError(caught, "Delete failed."));
     } finally {
       setBusyId(null);
       setPendingDeleteFile(null);

--- a/frontend/src/app/hooks/useAssistantChat.sse.test.ts
+++ b/frontend/src/app/hooks/useAssistantChat.sse.test.ts
@@ -164,20 +164,33 @@ describe("useAssistantChat SSE parsing", () => {
         ]);
     });
 
-    it("surfaces an error event on the assistant message and stops loading", async () => {
+    it("sanitizes an unexpected error event and stops loading", async () => {
         const { assistant, result } = await sendAndGetAssistant([
             'data: {"type":"content_delta","text":"Part"}\n\n',
             'data: {"type":"error","message":"model unavailable"}\n\n',
         ]);
 
-        expect(assistant?.error).toBe("model unavailable");
+        expect(assistant?.error).toBe("Sorry, something went wrong.");
         // Streamed content is finalized before the error event is appended.
         expect(assistant?.events).toEqual([
             { type: "content", text: "Part" },
-            { type: "error", message: "model unavailable" },
+            { type: "error", message: "Sorry, something went wrong." },
         ]);
         expect(result.current.isResponseLoading).toBe(false);
         expect(result.current.isLoadingCitations).toBe(false);
+    });
+
+    it("preserves an explicitly safe, actionable error event", async () => {
+        const { assistant } = await sendAndGetAssistant([
+            'data: {"type":"error","message":"Select a saved model first.","safe_to_display":true}\n\n',
+        ]);
+
+        expect(assistant?.error).toBe("Select a saved model first.");
+        expect(assistant?.events).toContainEqual({
+            type: "error",
+            message: "Select a saved model first.",
+            safe_to_display: true,
+        });
     });
 
     it("falls back to a readable message for blank error events", async () => {
@@ -241,7 +254,7 @@ describe("useAssistantChat SSE parsing", () => {
         const assistant = result.current.messages.findLast(
             (m) => m.role === "assistant",
         );
-        expect(assistant?.error).toBe("HTTP 429: quota exceeded");
+        expect(assistant?.error).toBe("Sorry, something went wrong.");
         expect(result.current.isResponseLoading).toBe(false);
     });
 

--- a/frontend/src/app/hooks/useAssistantChat.ts
+++ b/frontend/src/app/hooks/useAssistantChat.ts
@@ -17,8 +17,10 @@ interface UseAssistantChatOptions {
   projectId?: string;
 }
 
-function readableStreamError(value: unknown): string {
-  if (typeof value === "string" && value.trim()) return value.trim();
+function readableStreamError(value: unknown, safeToDisplay: boolean): string {
+  if (safeToDisplay && typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
   return "Sorry, something went wrong.";
 }
 
@@ -374,8 +376,8 @@ export function useAssistantChat({
           }));
 
       if (!response.ok) {
-        const errText = await response.text();
-        throw new Error(`HTTP ${response.status}: ${errText}`);
+        await response.body?.cancel().catch(() => {});
+        throw new Error(`Chat request failed with status ${response.status}`);
       }
 
       const reader = response.body?.getReader();
@@ -429,13 +431,21 @@ export function useAssistantChat({
             }
 
             if (data.type === "error") {
-              const message = readableStreamError(data.message);
+              const safeToDisplay = data.safe_to_display === true;
+              const message = readableStreamError(
+                data.message,
+                safeToDisplay,
+              );
               clearStreamingPlaceholders();
               finalizeStreamingContent();
               finalizeStreamingReasoning();
               eventsRef.current = [
                 ...eventsRef.current,
-                { type: "error", message },
+                {
+                  type: "error",
+                  message,
+                  ...(safeToDisplay ? { safe_to_display: true } : {}),
+                },
               ];
               const snapshot = [...eventsRef.current];
               updateLatestAssistantMessage((assistantMessage) => ({
@@ -1338,10 +1348,7 @@ export function useAssistantChat({
         });
       } else {
         finalizeStreamingContent();
-        const errorMessage =
-          error instanceof Error && error.message
-            ? error.message
-            : "Sorry, something went wrong.";
+        const errorMessage = "Sorry, something went wrong.";
         setMessages((prev) => {
           const assistantIndex = [...prev]
             .map((message, index) => ({ message, index }))

--- a/frontend/src/app/hooks/useFetchDocxBytes.ts
+++ b/frontend/src/app/hooks/useFetchDocxBytes.ts
@@ -102,9 +102,9 @@ export function useFetchDocxBytes(
                 setBytes(buf);
                 setDownloadUrl(url);
             })
-            .catch((e: unknown) => {
+            .catch(() => {
                 if (cancelled) return;
-                setError(e instanceof Error ? e.message : String(e));
+                setError("This document could not be loaded. Please try again.");
             })
             .finally(() => {
                 inFlight.delete(key);

--- a/frontend/src/app/lib/authRedirects.test.ts
+++ b/frontend/src/app/lib/authRedirects.test.ts
@@ -53,16 +53,16 @@ describe("authErrorDescription", () => {
     it("reads provider errors from query parameters or implicit-flow hashes", () => {
         expect(
             authErrorDescription("?error_description=Expired+link", ""),
-        ).toBe("Expired link");
+        ).toBe("This confirmation link is invalid or has expired.");
         expect(
             authErrorDescription("", "#error=access_denied"),
-        ).toBe("access_denied");
+        ).toBe("Authentication was cancelled or denied.");
         expect(authErrorDescription("?error=query_error", "")).toBe(
-            "query_error",
+            "Authentication could not be completed. Please try again.",
         );
         expect(
             authErrorDescription("", "#error_description=Invalid+request"),
-        ).toBe("Invalid request");
+        ).toBe("This confirmation link is invalid or has expired.");
         expect(authErrorDescription("", "")).toBeNull();
     });
 });

--- a/frontend/src/app/lib/authRedirects.test.ts
+++ b/frontend/src/app/lib/authRedirects.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
     authCallbackUrl,
     authErrorDescription,
     browserAuthCallbackUrl,
     safeAuthNext,
 } from "./authRedirects";
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
 
 describe("safeAuthNext", () => {
     it("allows known internal destinations with query parameters", () => {
@@ -46,6 +50,12 @@ describe("authCallbackUrl", () => {
         expect(browserAuthCallbackUrl("/reset-password")).toBe(
             "http://localhost:3000/auth/callback?next=%2Freset-password",
         );
+    });
+
+    it("does not build a browser callback during server rendering", () => {
+        vi.stubGlobal("window", undefined);
+
+        expect(browserAuthCallbackUrl("/reset-password")).toBeUndefined();
     });
 });
 

--- a/frontend/src/app/lib/authRedirects.ts
+++ b/frontend/src/app/lib/authRedirects.ts
@@ -44,10 +44,18 @@ export function authErrorDescription(
 ): string | null {
     const query = new URLSearchParams(search);
     const fragment = new URLSearchParams(hash.replace(/^#/, ""));
-    return (
+    const error = (
         query.get("error_description") ||
         query.get("error") ||
         fragment.get("error_description") ||
         fragment.get("error")
     );
+    if (!error) return null;
+    if (/expired|invalid/i.test(error)) {
+        return "This confirmation link is invalid or has expired.";
+    }
+    if (/access.denied|cancel/i.test(error)) {
+        return "Authentication was cancelled or denied.";
+    }
+    return "Authentication could not be completed. Please try again.";
 }

--- a/frontend/src/app/lib/mikeApi.test.ts
+++ b/frontend/src/app/lib/mikeApi.test.ts
@@ -347,18 +347,38 @@ describe("apiRequest plumbing (via thin wrappers)", () => {
         await expect(getUserProfile()).rejects.toMatchObject({
             status: 500,
             code: null,
-            message: "API error: 500",
+            message: "Something went wrong. Please try again.",
         });
     });
 
-    it("uses the raw body text for non-JSON error responses", async () => {
+    it("discards raw JSON details from 5xx responses and keeps the request ID", async () => {
+        fetchMock.mockResolvedValue(
+            jsonResponse(
+                {
+                    code: "internal_error",
+                    detail: "schema cache exposed an internal function name",
+                    request_id: "req-public-123",
+                },
+                { status: 500 },
+            ),
+        );
+
+        await expect(getUserProfile()).rejects.toMatchObject({
+            status: 500,
+            code: "internal_error",
+            requestId: "req-public-123",
+            message: "Something went wrong. Please try again.",
+        });
+    });
+
+    it("does not expose non-JSON server error responses", async () => {
         fetchMock.mockResolvedValue(
             new Response("upstream exploded", { status: 502 }),
         );
 
         await expect(getUserProfile()).rejects.toMatchObject({
             status: 502,
-            message: "upstream exploded",
+            message: "Something went wrong. Please try again.",
         });
     });
 
@@ -367,7 +387,7 @@ describe("apiRequest plumbing (via thin wrappers)", () => {
 
         await expect(getUserProfile()).rejects.toMatchObject({
             status: 503,
-            message: "API error: 503",
+            message: "Something went wrong. Please try again.",
         });
     });
 
@@ -518,10 +538,12 @@ describe("downloadDocumentsZip", () => {
         });
     });
 
-    it("throws a plain Error carrying the response text", async () => {
+    it("does not expose a non-JSON error response", async () => {
         fetchMock.mockResolvedValue(new Response("bad ids", { status: 400 }));
 
-        await expect(downloadDocumentsZip(["x"])).rejects.toThrow("bad ids");
+        await expect(downloadDocumentsZip(["x"])).rejects.toThrow(
+            "The request could not be completed. Please try again.",
+        );
     });
 });
 
@@ -1579,7 +1601,7 @@ describe("multipart upload endpoints", () => {
         expect(init.headers).toEqual({ Authorization: "Bearer token-123" });
     });
 
-    it("upload failures throw a plain Error with the response text, not MikeApiError", async () => {
+    it("multipart upload failures use the sanitized API error contract", async () => {
         fetchMock.mockImplementation(() =>
             Promise.resolve(new Response("file too large", { status: 413 })),
         );
@@ -1588,15 +1610,17 @@ describe("multipart upload endpoints", () => {
             (e: unknown) => e,
         );
 
-        expect(error).toBeInstanceOf(Error);
-        expect(error).not.toBeInstanceOf(MikeApiError);
-        expect((error as Error).message).toBe("file too large");
+        expect(error).toBeInstanceOf(MikeApiError);
+        expect(error).toMatchObject({
+            status: 413,
+            message: "The request could not be completed. Please try again.",
+        });
 
         await expect(uploadStandaloneDocument(file)).rejects.toThrow(
-            "file too large",
+            "The request could not be completed. Please try again.",
         );
         await expect(uploadLibraryDocument("files", file)).rejects.toThrow(
-            "file too large",
+            "The request could not be completed. Please try again.",
         );
     });
 
@@ -1632,7 +1656,9 @@ describe("multipart upload endpoints", () => {
         fetchMock.mockResolvedValue(new Response("nope", { status: 409 }));
         await expect(
             replaceDocumentVersionFile("d1", "v1", file),
-        ).rejects.toThrow("nope");
+        ).rejects.toThrow(
+            "The request could not be completed. Please try again.",
+        );
     });
 
     it("uploads workflow reference files as authenticated multipart data", async () => {
@@ -1746,7 +1772,7 @@ describe("query and payload defaults", () => {
         fetchMock.mockResolvedValue(new Response("", { status: 500 }));
 
         await expect(downloadDocumentsZip(["d1"])).rejects.toThrow(
-            "API error: 500",
+            "Something went wrong. Please try again.",
         );
     });
 

--- a/frontend/src/app/lib/mikeApi.test.ts
+++ b/frontend/src/app/lib/mikeApi.test.ts
@@ -1641,6 +1641,17 @@ describe("multipart upload endpoints", () => {
         expect(body.get("filename")).toBeNull();
     });
 
+    it("uploadDocumentVersion uses the sanitized API error contract", async () => {
+        fetchMock.mockResolvedValue(
+            new Response("database connection failed", { status: 500 }),
+        );
+
+        await expect(uploadDocumentVersion("d1", file)).rejects.toMatchObject({
+            status: 500,
+            message: "Something went wrong. Please try again.",
+        });
+    });
+
     it("replaceDocumentVersionFile PUTs to the version file route and surfaces errors", async () => {
         fetchMock.mockResolvedValue(jsonResponse({ id: "v1" }));
 

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -59,18 +59,26 @@ const devLog = (...args: Parameters<typeof console.log>) => {
 export class MikeApiError extends Error {
     status: number;
     code: string | null;
+    requestId: string | null;
 
     constructor(args: {
         message: string;
         status: number;
         code?: string | null;
+        requestId?: string | null;
     }) {
         super(args.message);
         this.name = "MikeApiError";
         this.status = args.status;
         this.code = args.code ?? null;
+        this.requestId = args.requestId ?? null;
     }
 }
+
+export const INTERNAL_ERROR_MESSAGE =
+    "Something went wrong. Please try again.";
+export const MALFORMED_ERROR_RESPONSE_MESSAGE =
+    "The request could not be completed. Please try again.";
 
 export function isMfaRequiredError(error: unknown) {
     return (
@@ -146,18 +154,26 @@ async function toApiError(response: Response, path: string) {
         const parsed = JSON.parse(text) as {
             detail?: unknown;
             code?: unknown;
+            request_id?: unknown;
         };
+        const requestId =
+            typeof parsed.request_id === "string"
+                ? parsed.request_id
+                : response.headers.get("x-request-id");
         devLog("[mike-api] non-ok response", {
             path,
             status: response.status,
             code: parsed.code,
-            detail: parsed.detail,
+            requestId,
         });
         return new MikeApiError({
             status: response.status,
             code: typeof parsed.code === "string" ? parsed.code : null,
+            requestId,
             message:
-                typeof parsed.detail === "string" && parsed.detail
+                response.status >= 500
+                    ? INTERNAL_ERROR_MESSAGE
+                    : typeof parsed.detail === "string" && parsed.detail
                     ? parsed.detail
                     : `API error: ${response.status}`,
         });
@@ -165,11 +181,15 @@ async function toApiError(response: Response, path: string) {
         devLog("[mike-api] non-ok non-json response", {
             path,
             status: response.status,
-            bodyPreview: text.slice(0, 200),
+            requestId: response.headers.get("x-request-id"),
         });
         return new MikeApiError({
             status: response.status,
-            message: text || `API error: ${response.status}`,
+            requestId: response.headers.get("x-request-id"),
+            message:
+                response.status >= 500
+                    ? INTERNAL_ERROR_MESSAGE
+                    : MALFORMED_ERROR_RESPONSE_MESSAGE,
         });
     }
 }
@@ -972,7 +992,8 @@ export async function uploadLibraryDocument(
         headers: { ...authHeaders },
         body: form,
     });
-    if (!response.ok) throw new Error(await response.text());
+    if (!response.ok)
+        throw await toApiError(response, `/library/${kind}/documents`);
     return response.json() as Promise<Document>;
 }
 
@@ -1098,7 +1119,11 @@ export async function uploadDocumentVersion(
             body: form,
         },
     );
-    if (!response.ok) throw new Error(await response.text());
+    if (!response.ok)
+        throw await toApiError(
+            response,
+            `/single-documents/${documentId}/versions`,
+        );
     return response.json() as Promise<DocumentVersion>;
 }
 
@@ -1120,7 +1145,11 @@ export async function replaceDocumentVersionFile(
             body: form,
         },
     );
-    if (!response.ok) throw new Error(await response.text());
+    if (!response.ok)
+        throw await toApiError(
+            response,
+            `/single-documents/${documentId}/versions/${versionId}/file`,
+        );
     return response.json() as Promise<DocumentVersion>;
 }
 
@@ -1184,7 +1213,8 @@ export async function uploadProjectDocument(
             body: form,
         },
     );
-    if (!response.ok) throw new Error(await response.text());
+    if (!response.ok)
+        throw await toApiError(response, `/projects/${projectId}/documents`);
     return response.json() as Promise<Document>;
 }
 
@@ -1197,7 +1227,8 @@ export async function uploadStandaloneDocument(file: File): Promise<Document> {
         headers: { ...authHeaders },
         body: form,
     });
-    if (!response.ok) throw new Error(await response.text());
+    if (!response.ok)
+        throw await toApiError(response, "/single-documents");
     return response.json() as Promise<Document>;
 }
 
@@ -1251,8 +1282,7 @@ export async function downloadDocumentsZip(
         body: JSON.stringify({ document_ids: documentIds }),
     });
     if (!response.ok) {
-        const detail = await response.text();
-        throw new Error(detail || `API error: ${response.status}`);
+        throw await toApiError(response, "/single-documents/download-zip");
     }
     return response.blob();
 }

--- a/frontend/src/app/lib/userFacingError.test.ts
+++ b/frontend/src/app/lib/userFacingError.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { MikeApiError } from "./mikeApi";
+import {
+    knownErrorCodeMessage,
+    userFacingApiError,
+} from "./userFacingError";
+
+describe("userFacingApiError", () => {
+    it("allows intentional client-error details", () => {
+        const error = new MikeApiError({
+            status: 400,
+            message: "The filename is required.",
+        });
+
+        expect(userFacingApiError(error, "Fallback")).toBe(
+            "The filename is required.",
+        );
+    });
+
+    it("does not expose server or plain exception messages", () => {
+        expect(
+            userFacingApiError(
+                new MikeApiError({
+                    status: 500,
+                    message: "relation user_profiles does not exist",
+                }),
+                "Please try again.",
+            ),
+        ).toBe("Please try again.");
+        expect(
+            userFacingApiError(
+                new Error("getaddrinfo ENOTFOUND internal-db"),
+                "Please try again.",
+            ),
+        ).toBe("Please try again.");
+    });
+});
+
+describe("knownErrorCodeMessage", () => {
+    it("maps allowlisted codes and hides unknown ones", () => {
+        const messages = { invalid_credentials: "Incorrect credentials." };
+        expect(
+            knownErrorCodeMessage(
+                { code: "invalid_credentials" },
+                messages,
+                "Unable to log in.",
+            ),
+        ).toBe("Incorrect credentials.");
+        expect(
+            knownErrorCodeMessage(
+                { code: "internal_provider_error" },
+                messages,
+                "Unable to log in.",
+            ),
+        ).toBe("Unable to log in.");
+    });
+});

--- a/frontend/src/app/lib/userFacingError.test.ts
+++ b/frontend/src/app/lib/userFacingError.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { MikeApiError } from "./mikeApi";
 import {
+    errorCode,
     knownErrorCodeMessage,
     userFacingApiError,
 } from "./userFacingError";
@@ -34,6 +35,30 @@ describe("userFacingApiError", () => {
             ),
         ).toBe("Please try again.");
     });
+
+    it("rejects non-client statuses and empty client-error messages", () => {
+        expect(
+            userFacingApiError(
+                new MikeApiError({ status: 399, message: "Unexpected" }),
+                "Fallback",
+            ),
+        ).toBe("Fallback");
+        expect(
+            userFacingApiError(
+                new MikeApiError({ status: 400, message: "" }),
+                "Fallback",
+            ),
+        ).toBe("Fallback");
+    });
+});
+
+describe("errorCode", () => {
+    it("returns null for values without a string code", () => {
+        expect(errorCode(null)).toBeNull();
+        expect(errorCode("invalid_credentials")).toBeNull();
+        expect(errorCode({})).toBeNull();
+        expect(errorCode({ code: 403 })).toBeNull();
+    });
 });
 
 describe("knownErrorCodeMessage", () => {
@@ -50,6 +75,16 @@ describe("knownErrorCodeMessage", () => {
             knownErrorCodeMessage(
                 { code: "internal_provider_error" },
                 messages,
+                "Unable to log in.",
+            ),
+        ).toBe("Unable to log in.");
+    });
+
+    it("uses the fallback when no error code is available", () => {
+        expect(
+            knownErrorCodeMessage(
+                new Error("provider failed"),
+                { invalid_credentials: "Incorrect credentials." },
                 "Unable to log in.",
             ),
         ).toBe("Unable to log in.");

--- a/frontend/src/app/lib/userFacingError.ts
+++ b/frontend/src/app/lib/userFacingError.ts
@@ -1,0 +1,32 @@
+import { MikeApiError } from "./mikeApi";
+
+export function userFacingApiError(
+    error: unknown,
+    fallback: string,
+): string {
+    if (
+        error instanceof MikeApiError &&
+        error.status >= 400 &&
+        error.status < 500 &&
+        error.message
+    ) {
+        return error.message;
+    }
+    return fallback;
+}
+
+export function errorCode(error: unknown): string | null {
+    if (!error || typeof error !== "object" || !("code" in error)) {
+        return null;
+    }
+    return typeof error.code === "string" ? error.code : null;
+}
+
+export function knownErrorCodeMessage(
+    error: unknown,
+    messages: Readonly<Record<string, string>>,
+    fallback: string,
+): string {
+    const code = errorCode(error);
+    return code ? messages[code] ?? fallback : fallback;
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -13,6 +13,12 @@ import {
     authGlassCardClassName,
     authInputClassName,
 } from "@/app/components/auth/authStyles";
+import { knownErrorCodeMessage } from "@/app/lib/userFacingError";
+
+const LOGIN_ERROR_MESSAGES = {
+    invalid_credentials: "The email or password is incorrect.",
+    email_not_confirmed: "Confirm your email address before logging in.",
+} as const;
 
 export default function LoginPage() {
     const router = useRouter();
@@ -44,9 +50,11 @@ export default function LoginPage() {
             router.push("/assistant");
         } catch (error: unknown) {
             setError(
-                error instanceof Error
-                    ? error.message
-                    : "An error occurred during login",
+                knownErrorCodeMessage(
+                    error,
+                    LOGIN_ERROR_MESSAGES,
+                    "Unable to log in right now. Please try again.",
+                ),
             );
         } finally {
             setLoading(false);

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -79,12 +79,8 @@ function ResetPasswordContent() {
             if (updateError) throw updateError;
             await supabase.auth.signOut({ scope: "global" });
             setSuccess(true);
-        } catch (updateError) {
-            setError(
-                updateError instanceof Error
-                    ? updateError.message
-                    : "Unable to update your password.",
-            );
+        } catch {
+            setError("Unable to update your password. Please try again.");
         } finally {
             setLoading(false);
         }

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -15,6 +15,15 @@ import {
     authGlassCardClassName,
     authInputClassName,
 } from "@/app/components/auth/authStyles";
+import { knownErrorCodeMessage } from "@/app/lib/userFacingError";
+
+const SIGNUP_ERROR_MESSAGES = {
+    user_already_exists: "An account with this email already exists.",
+    email_exists: "An account with this email already exists.",
+    over_email_send_rate_limit:
+        "Too many signup emails were requested. Please wait and try again.",
+    weak_password: "Choose a stronger password and try again.",
+} as const;
 import {
     MIN_PASSWORD_LENGTH,
     minimumPasswordMessage,
@@ -118,9 +127,11 @@ function SignupContent() {
             }
         } catch (error: unknown) {
             setError(
-                error instanceof Error
-                    ? error.message
-                    : "An error occurred during signup",
+                knownErrorCodeMessage(
+                    error,
+                    SIGNUP_ERROR_MESSAGES,
+                    "Unable to create your account right now. Please try again.",
+                ),
             );
         } finally {
             setLoading(false);

--- a/frontend/src/app/verify-mfa/page.tsx
+++ b/frontend/src/app/verify-mfa/page.tsx
@@ -90,13 +90,9 @@ export default function VerifyMfaPage() {
                         "No verified authenticator factor is available for this account.",
                     );
                 }
-            } catch (loadError) {
+            } catch {
                 if (cancelled) return;
-                setError(
-                    loadError instanceof Error
-                        ? loadError.message
-                        : "Unable to load authenticator verification.",
-                );
+                setError("Unable to load authenticator verification.");
             } finally {
                 if (!cancelled) setLoading(false);
             }
@@ -122,7 +118,7 @@ export default function VerifyMfaPage() {
         setVerifying(false);
 
         if (verifyError) {
-            setError(verifyError.message);
+            setError("The verification code is invalid or expired.");
             return;
         }
 


### PR DESCRIPTION
## Summary

- add a canonical backend error response with safe messages and request IDs
- sanitize unhandled HTTP errors, provider failures, authentication failures, and assistant SSE errors
- prevent frontend API clients and UI components from rendering raw internal errors
- preserve intentional 4xx messages and explicitly trusted actionable assistant errors
- add regression coverage for raw 5xx bodies, thrown errors, malformed and oversized JSON, request IDs, API responses, and SSE events

## Testing

- Backend: 714 tests passed
- Backend TypeScript build passed
- Frontend: 485 tests passed
- Frontend TypeScript check passed
- Frontend ESLint passed with no errors (35 existing warnings)