### PR TITLE
Support folder uploads and multi-row document actions

### DIFF
--- a/backend/migrations/20260822_01_resolve_folder_upload_paths.sql
+++ b/backend/migrations/20260822_01_resolve_folder_upload_paths.sql
@@ -1,0 +1,241 @@
+-- Resolve uploaded folder paths against the complete server-side hierarchy.
+-- Advisory transaction locks serialize path creation within one project or
+-- one user library so two concurrent folder uploads cannot create the same
+-- path. Existing top-level folders are reported to the caller before any
+-- mutation so the UI can ask whether to delete and replace them or create a
+-- suffixed copy. The `reuse` mode is reserved for nested segments after that
+-- top-level choice has already been made.
+
+create or replace function public.resolve_project_folder_path(
+  target_project_id uuid,
+  target_user_id uuid,
+  base_folder_id uuid,
+  path_segments text[],
+  conflict_resolution text default 'error'
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  current_parent_id uuid := base_folder_id;
+  folder_row public.project_subfolders%rowtype;
+  resolved_folders jsonb := '[]'::jsonb;
+  segment text;
+  resolved_name text;
+  first_resolved_name text;
+  candidate_name text;
+  suffix integer;
+  segment_index integer;
+begin
+  if conflict_resolution not in ('error', 'reuse', 'rename') then
+    raise exception 'Invalid folder conflict resolution';
+  end if;
+  if coalesce(array_length(path_segments, 1), 0) = 0
+     or array_length(path_segments, 1) > 100 then
+    raise exception 'Folder path must contain between 1 and 100 segments';
+  end if;
+  if base_folder_id is not null and not exists (
+    select 1 from public.project_subfolders
+    where id = base_folder_id and project_id = target_project_id
+  ) then
+    raise exception 'Parent folder not found';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended('project-folder-path:' || target_project_id::text, 0)
+  );
+
+  for segment_index in 1..array_length(path_segments, 1) loop
+    segment := btrim(path_segments[segment_index]);
+    if segment = '' or length(segment) > 255 then
+      raise exception 'Folder names must contain between 1 and 255 characters';
+    end if;
+    resolved_name := segment;
+
+    select * into folder_row
+    from public.project_subfolders
+    where project_id = target_project_id
+      and parent_folder_id is not distinct from current_parent_id
+      and lower(btrim(name)) = lower(segment)
+    order by created_at, id
+    limit 1;
+
+    if folder_row.id is not null and segment_index = 1 then
+      suffix := 2;
+      loop
+        candidate_name := segment || ' (' || suffix || ')';
+        exit when not exists (
+          select 1 from public.project_subfolders
+          where project_id = target_project_id
+            and parent_folder_id is not distinct from current_parent_id
+            and lower(btrim(name)) = lower(candidate_name)
+        );
+        suffix := suffix + 1;
+      end loop;
+
+      if conflict_resolution = 'error' then
+        return jsonb_build_object(
+          'conflict', true,
+          'folder_name', folder_row.name,
+          'existing_folder_id', folder_row.id,
+          'suggested_name', candidate_name
+        );
+      elsif conflict_resolution = 'rename' then
+        folder_row := null;
+        resolved_name := candidate_name;
+      end if;
+    end if;
+
+    if folder_row.id is null then
+      insert into public.project_subfolders (
+        project_id, user_id, name, parent_folder_id
+      ) values (
+        target_project_id, target_user_id, resolved_name, current_parent_id
+      ) returning * into folder_row;
+    end if;
+
+    if segment_index = 1 then
+      first_resolved_name := folder_row.name;
+    end if;
+    current_parent_id := folder_row.id;
+    resolved_folders := resolved_folders || jsonb_build_array(to_jsonb(folder_row));
+    folder_row := null;
+  end loop;
+
+  return jsonb_build_object(
+    'conflict', false,
+    'folder_id', current_parent_id,
+    'resolved_name', first_resolved_name,
+    'folders', resolved_folders
+  );
+end;
+$$;
+
+create or replace function public.resolve_library_folder_path(
+  target_user_id uuid,
+  target_library_kind text,
+  base_folder_id uuid,
+  path_segments text[],
+  conflict_resolution text default 'error'
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  current_parent_id uuid := base_folder_id;
+  folder_row public.library_folders%rowtype;
+  resolved_folders jsonb := '[]'::jsonb;
+  segment text;
+  resolved_name text;
+  first_resolved_name text;
+  candidate_name text;
+  suffix integer;
+  segment_index integer;
+begin
+  if target_library_kind not in ('file', 'template') then
+    raise exception 'Invalid library kind';
+  end if;
+  if conflict_resolution not in ('error', 'reuse', 'rename') then
+    raise exception 'Invalid folder conflict resolution';
+  end if;
+  if coalesce(array_length(path_segments, 1), 0) = 0
+     or array_length(path_segments, 1) > 100 then
+    raise exception 'Folder path must contain between 1 and 100 segments';
+  end if;
+  if base_folder_id is not null and not exists (
+    select 1 from public.library_folders
+    where id = base_folder_id
+      and user_id = target_user_id
+      and library_kind = target_library_kind
+  ) then
+    raise exception 'Parent folder not found';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended(
+      'library-folder-path:' || target_user_id::text || ':' || target_library_kind,
+      0
+    )
+  );
+
+  for segment_index in 1..array_length(path_segments, 1) loop
+    segment := btrim(path_segments[segment_index]);
+    if segment = '' or length(segment) > 255 then
+      raise exception 'Folder names must contain between 1 and 255 characters';
+    end if;
+    resolved_name := segment;
+
+    select * into folder_row
+    from public.library_folders
+    where user_id = target_user_id
+      and library_kind = target_library_kind
+      and parent_folder_id is not distinct from current_parent_id
+      and lower(btrim(name)) = lower(segment)
+    order by created_at, id
+    limit 1;
+
+    if folder_row.id is not null and segment_index = 1 then
+      suffix := 2;
+      loop
+        candidate_name := segment || ' (' || suffix || ')';
+        exit when not exists (
+          select 1 from public.library_folders
+          where user_id = target_user_id
+            and library_kind = target_library_kind
+            and parent_folder_id is not distinct from current_parent_id
+            and lower(btrim(name)) = lower(candidate_name)
+        );
+        suffix := suffix + 1;
+      end loop;
+
+      if conflict_resolution = 'error' then
+        return jsonb_build_object(
+          'conflict', true,
+          'folder_name', folder_row.name,
+          'existing_folder_id', folder_row.id,
+          'suggested_name', candidate_name
+        );
+      elsif conflict_resolution = 'rename' then
+        folder_row := null;
+        resolved_name := candidate_name;
+      end if;
+    end if;
+
+    if folder_row.id is null then
+      insert into public.library_folders (
+        user_id, library_kind, name, parent_folder_id
+      ) values (
+        target_user_id, target_library_kind, resolved_name, current_parent_id
+      ) returning * into folder_row;
+    end if;
+
+    if segment_index = 1 then
+      first_resolved_name := folder_row.name;
+    end if;
+    current_parent_id := folder_row.id;
+    resolved_folders := resolved_folders || jsonb_build_array(to_jsonb(folder_row));
+    folder_row := null;
+  end loop;
+
+  return jsonb_build_object(
+    'conflict', false,
+    'folder_id', current_parent_id,
+    'resolved_name', first_resolved_name,
+    'folders', resolved_folders
+  );
+end;
+$$;
+
+revoke all on function public.resolve_project_folder_path(uuid, uuid, uuid, text[], text)
+  from public, anon, authenticated;
+grant execute on function public.resolve_project_folder_path(uuid, uuid, uuid, text[], text)
+  to service_role;
+
+revoke all on function public.resolve_library_folder_path(uuid, text, uuid, text[], text)
+  from public, anon, authenticated;
+grant execute on function public.resolve_library_folder_path(uuid, text, uuid, text[], text)
+  to service_role;

--- a/backend/migrations/20260822_01_resolve_folder_upload_paths.sql
+++ b/backend/migrations/20260822_01_resolve_folder_upload_paths.sql
@@ -2,9 +2,9 @@
 -- Advisory transaction locks serialize path creation within one project or
 -- one user library so two concurrent folder uploads cannot create the same
 -- path. Existing top-level folders are reported to the caller before any
--- mutation so the UI can ask whether to delete and replace them or create a
--- suffixed copy. The `reuse` mode is reserved for nested segments after that
--- top-level choice has already been made.
+-- mutation so the UI can confirm that the upload will use a suffixed name.
+-- The `reuse` mode is reserved for nested segments after that top-level choice
+-- has already been made.
 
 create or replace function public.resolve_project_folder_path(
   target_project_id uuid,

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -2293,6 +2293,248 @@ as $$
   offset greatest(coalesce(p_offset, 0), 0);
 $$;
 
++-- Resolve uploaded folder paths against the complete server-side hierarchy.
+-- Advisory transaction locks serialize path creation within one project or
+-- one user library so two concurrent folder uploads cannot create the same
+-- path. Existing top-level folders are reported to the caller before any
+-- mutation so the UI can ask whether to delete and replace them or create a
+-- suffixed copy. The `reuse` mode is reserved for nested segments after that
+-- top-level choice has already been made.
+
+create or replace function public.resolve_project_folder_path(
+  target_project_id uuid,
+  target_user_id uuid,
+  base_folder_id uuid,
+  path_segments text[],
+  conflict_resolution text default 'error'
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  current_parent_id uuid := base_folder_id;
+  folder_row public.project_subfolders%rowtype;
+  resolved_folders jsonb := '[]'::jsonb;
+  segment text;
+  resolved_name text;
+  first_resolved_name text;
+  candidate_name text;
+  suffix integer;
+  segment_index integer;
+begin
+  if conflict_resolution not in ('error', 'reuse', 'rename') then
+    raise exception 'Invalid folder conflict resolution';
+  end if;
+  if coalesce(array_length(path_segments, 1), 0) = 0
+     or array_length(path_segments, 1) > 100 then
+    raise exception 'Folder path must contain between 1 and 100 segments';
+  end if;
+  if base_folder_id is not null and not exists (
+    select 1 from public.project_subfolders
+    where id = base_folder_id and project_id = target_project_id
+  ) then
+    raise exception 'Parent folder not found';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended('project-folder-path:' || target_project_id::text, 0)
+  );
+
+  for segment_index in 1..array_length(path_segments, 1) loop
+    segment := btrim(path_segments[segment_index]);
+    if segment = '' or length(segment) > 255 then
+      raise exception 'Folder names must contain between 1 and 255 characters';
+    end if;
+    resolved_name := segment;
+
+    select * into folder_row
+    from public.project_subfolders
+    where project_id = target_project_id
+      and parent_folder_id is not distinct from current_parent_id
+      and lower(btrim(name)) = lower(segment)
+    order by created_at, id
+    limit 1;
+
+    if folder_row.id is not null and segment_index = 1 then
+      suffix := 2;
+      loop
+        candidate_name := segment || ' (' || suffix || ')';
+        exit when not exists (
+          select 1 from public.project_subfolders
+          where project_id = target_project_id
+            and parent_folder_id is not distinct from current_parent_id
+            and lower(btrim(name)) = lower(candidate_name)
+        );
+        suffix := suffix + 1;
+      end loop;
+
+      if conflict_resolution = 'error' then
+        return jsonb_build_object(
+          'conflict', true,
+          'folder_name', folder_row.name,
+          'existing_folder_id', folder_row.id,
+          'suggested_name', candidate_name
+        );
+      elsif conflict_resolution = 'rename' then
+        folder_row := null;
+        resolved_name := candidate_name;
+      end if;
+    end if;
+
+    if folder_row.id is null then
+      insert into public.project_subfolders (
+        project_id, user_id, name, parent_folder_id
+      ) values (
+        target_project_id, target_user_id, resolved_name, current_parent_id
+      ) returning * into folder_row;
+    end if;
+
+    if segment_index = 1 then
+      first_resolved_name := folder_row.name;
+    end if;
+    current_parent_id := folder_row.id;
+    resolved_folders := resolved_folders || jsonb_build_array(to_jsonb(folder_row));
+    folder_row := null;
+  end loop;
+
+  return jsonb_build_object(
+    'conflict', false,
+    'folder_id', current_parent_id,
+    'resolved_name', first_resolved_name,
+    'folders', resolved_folders
+  );
+end;
+$$;
+
+create or replace function public.resolve_library_folder_path(
+  target_user_id uuid,
+  target_library_kind text,
+  base_folder_id uuid,
+  path_segments text[],
+  conflict_resolution text default 'error'
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  current_parent_id uuid := base_folder_id;
+  folder_row public.library_folders%rowtype;
+  resolved_folders jsonb := '[]'::jsonb;
+  segment text;
+  resolved_name text;
+  first_resolved_name text;
+  candidate_name text;
+  suffix integer;
+  segment_index integer;
+begin
+  if target_library_kind not in ('file', 'template') then
+    raise exception 'Invalid library kind';
+  end if;
+  if conflict_resolution not in ('error', 'reuse', 'rename') then
+    raise exception 'Invalid folder conflict resolution';
+  end if;
+  if coalesce(array_length(path_segments, 1), 0) = 0
+     or array_length(path_segments, 1) > 100 then
+    raise exception 'Folder path must contain between 1 and 100 segments';
+  end if;
+  if base_folder_id is not null and not exists (
+    select 1 from public.library_folders
+    where id = base_folder_id
+      and user_id = target_user_id
+      and library_kind = target_library_kind
+  ) then
+    raise exception 'Parent folder not found';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended(
+      'library-folder-path:' || target_user_id::text || ':' || target_library_kind,
+      0
+    )
+  );
+
+  for segment_index in 1..array_length(path_segments, 1) loop
+    segment := btrim(path_segments[segment_index]);
+    if segment = '' or length(segment) > 255 then
+      raise exception 'Folder names must contain between 1 and 255 characters';
+    end if;
+    resolved_name := segment;
+
+    select * into folder_row
+    from public.library_folders
+    where user_id = target_user_id
+      and library_kind = target_library_kind
+      and parent_folder_id is not distinct from current_parent_id
+      and lower(btrim(name)) = lower(segment)
+    order by created_at, id
+    limit 1;
+
+    if folder_row.id is not null and segment_index = 1 then
+      suffix := 2;
+      loop
+        candidate_name := segment || ' (' || suffix || ')';
+        exit when not exists (
+          select 1 from public.library_folders
+          where user_id = target_user_id
+            and library_kind = target_library_kind
+            and parent_folder_id is not distinct from current_parent_id
+            and lower(btrim(name)) = lower(candidate_name)
+        );
+        suffix := suffix + 1;
+      end loop;
+
+      if conflict_resolution = 'error' then
+        return jsonb_build_object(
+          'conflict', true,
+          'folder_name', folder_row.name,
+          'existing_folder_id', folder_row.id,
+          'suggested_name', candidate_name
+        );
+      elsif conflict_resolution = 'rename' then
+        folder_row := null;
+        resolved_name := candidate_name;
+      end if;
+    end if;
+
+    if folder_row.id is null then
+      insert into public.library_folders (
+        user_id, library_kind, name, parent_folder_id
+      ) values (
+        target_user_id, target_library_kind, resolved_name, current_parent_id
+      ) returning * into folder_row;
+    end if;
+
+    if segment_index = 1 then
+      first_resolved_name := folder_row.name;
+    end if;
+    current_parent_id := folder_row.id;
+    resolved_folders := resolved_folders || jsonb_build_array(to_jsonb(folder_row));
+    folder_row := null;
+  end loop;
+
+  return jsonb_build_object(
+    'conflict', false,
+    'folder_id', current_parent_id,
+    'resolved_name', first_resolved_name,
+    'folders', resolved_folders
+  );
+end;
+$$;
+
+revoke all on function public.resolve_project_folder_path(uuid, uuid, uuid, text[], text)
+  from public, anon, authenticated;
+grant execute on function public.resolve_project_folder_path(uuid, uuid, uuid, text[], text)
+  to service_role;
+
+revoke all on function public.resolve_library_folder_path(uuid, text, uuid, text[], text)
+  from public, anon, authenticated;
+grant execute on function public.resolve_library_folder_path(uuid, text, uuid, text[], text)
+  to service_role;
+
 -- ---------------------------------------------------------------------------
 -- Direct client grant hardening
 -- ---------------------------------------------------------------------------

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -2293,7 +2293,7 @@ as $$
   offset greatest(coalesce(p_offset, 0), 0);
 $$;
 
-+-- Resolve uploaded folder paths against the complete server-side hierarchy.
+-- Resolve uploaded folder paths against the complete server-side hierarchy.
 -- Advisory transaction locks serialize path creation within one project or
 -- one user library so two concurrent folder uploads cannot create the same
 -- path. Existing top-level folders are reported to the caller before any

--- a/backend/src/__tests__/integration/projects.routes.test.ts
+++ b/backend/src/__tests__/integration/projects.routes.test.ts
@@ -614,9 +614,11 @@ describe("projects.routes", () => {
         .send({ segments: ["NDAs"] });
 
       expect(res.status).toBe(500);
-      expect(res.body).toEqual({
-        detail: "Could not prepare this folder upload. Please try again.",
+      expect(res.body).toMatchObject({
+        code: "internal_error",
+        detail: "Something went wrong. Please try again.",
       });
+      expect(res.body.request_id).toEqual(expect.any(String));
       expect(JSON.stringify(res.body)).not.toContain(rawError);
       expect(consoleError).toHaveBeenCalled();
       consoleError.mockRestore();

--- a/backend/src/__tests__/integration/projects.routes.test.ts
+++ b/backend/src/__tests__/integration/projects.routes.test.ts
@@ -537,7 +537,7 @@ describe("projects.routes", () => {
       });
     });
 
-    it("marks project replacement conflicts as owner-only", async () => {
+    it("returns project folder conflicts without replacement permissions", async () => {
       checkProjectAccess.mockResolvedValue({
         ok: true,
         isOwner: false,
@@ -559,14 +559,16 @@ describe("projects.routes", () => {
         .send({ segments: ["NDAs"] });
 
       expect(res.status).toBe(200);
-      expect(res.body).toMatchObject({
+      expect(res.body).toEqual({
         conflict: true,
-        can_replace: false,
+        folder_name: "NDAs",
+        existing_folder_id: "folder-1",
         suggested_name: "NDAs (2)",
       });
+      expect(res.body).not.toHaveProperty("can_replace");
     });
 
-    it("returns a replaceable conflict for the user's library", async () => {
+    it("returns library folder conflicts without replacement permissions", async () => {
       supabaseState.rpc = {
         data: {
           conflict: true,
@@ -583,11 +585,13 @@ describe("projects.routes", () => {
         .send({ segments: ["NDAs"] });
 
       expect(res.status).toBe(200);
-      expect(res.body).toMatchObject({
+      expect(res.body).toEqual({
         conflict: true,
-        can_replace: true,
+        folder_name: "NDAs",
+        existing_folder_id: "folder-1",
         suggested_name: "NDAs (3)",
       });
+      expect(res.body).not.toHaveProperty("can_replace");
     });
 
     it("rejects malformed path segments before calling the RPC", async () => {

--- a/backend/src/__tests__/integration/projects.routes.test.ts
+++ b/backend/src/__tests__/integration/projects.routes.test.ts
@@ -503,6 +503,107 @@ describe("projects.routes", () => {
     });
   });
 
+  describe("folder upload path resolution", () => {
+    it("resolves a project path through the atomic RPC", async () => {
+      const captured = captureRpcArgs();
+      supabaseState.rpc = {
+        data: {
+          conflict: false,
+          folder_id: "folder-2",
+          resolved_name: "NDAs (2)",
+          folders: [],
+        },
+        error: null,
+      };
+
+      const res = await request(app)
+        .post("/projects/p1/folder-paths/resolve")
+        .set(...AUTH)
+        .send({
+          segments: ["NDAs"],
+          base_folder_id: null,
+          conflict_resolution: "rename",
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.resolved_name).toBe("NDAs (2)");
+      expect(captured.name).toBe("resolve_project_folder_path");
+      expect(captured.args).toEqual({
+        target_project_id: "p1",
+        target_user_id: "u1",
+        base_folder_id: null,
+        path_segments: ["NDAs"],
+        conflict_resolution: "rename",
+      });
+    });
+
+    it("marks project replacement conflicts as owner-only", async () => {
+      checkProjectAccess.mockResolvedValue({
+        ok: true,
+        isOwner: false,
+        project: { id: "p1", user_id: "u2", shared_with: ["u1@test.local"] },
+      });
+      supabaseState.rpc = {
+        data: {
+          conflict: true,
+          folder_name: "NDAs",
+          existing_folder_id: "folder-1",
+          suggested_name: "NDAs (2)",
+        },
+        error: null,
+      };
+
+      const res = await request(app)
+        .post("/projects/p1/folder-paths/resolve")
+        .set(...AUTH)
+        .send({ segments: ["NDAs"] });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        conflict: true,
+        can_replace: false,
+        suggested_name: "NDAs (2)",
+      });
+    });
+
+    it("returns a replaceable conflict for the user's library", async () => {
+      supabaseState.rpc = {
+        data: {
+          conflict: true,
+          folder_name: "NDAs",
+          existing_folder_id: "folder-1",
+          suggested_name: "NDAs (3)",
+        },
+        error: null,
+      };
+
+      const res = await request(app)
+        .post("/library/files/folder-paths/resolve")
+        .set(...AUTH)
+        .send({ segments: ["NDAs"] });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        conflict: true,
+        can_replace: true,
+        suggested_name: "NDAs (3)",
+      });
+    });
+
+    it("rejects malformed path segments before calling the RPC", async () => {
+      const captured = captureRpcArgs();
+
+      const res = await request(app)
+        .post("/library/files/folder-paths/resolve")
+        .set(...AUTH)
+        .send({ segments: ["NDAs", 42] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.detail).toBe("Invalid folder path");
+      expect(captured.name).toBeUndefined();
+    });
+  });
+
     // ── POST /projects (create) ───────────────────────────────────────────
     describe("POST /projects", () => {
         it("returns 400 when name is missing/blank", async () => {

--- a/backend/src/__tests__/integration/projects.routes.test.ts
+++ b/backend/src/__tests__/integration/projects.routes.test.ts
@@ -594,6 +594,34 @@ describe("projects.routes", () => {
       expect(res.body).not.toHaveProperty("can_replace");
     });
 
+    it.each([
+      ["project", "/projects/p1/folder-paths/resolve"],
+      ["library", "/library/files/folder-paths/resolve"],
+    ])("does not expose raw %s folder RPC errors", async (_scope, path) => {
+      const rawError =
+        "Could not find resolve_project_folder_path in the schema cache";
+      supabaseState.rpc = {
+        data: null,
+        error: { message: rawError },
+      };
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const res = await request(app)
+        .post(path)
+        .set(...AUTH)
+        .send({ segments: ["NDAs"] });
+
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({
+        detail: "Could not prepare this folder upload. Please try again.",
+      });
+      expect(JSON.stringify(res.body)).not.toContain(rawError);
+      expect(consoleError).toHaveBeenCalled();
+      consoleError.mockRestore();
+    });
+
     it("rejects malformed path segments before calling the RPC", async () => {
       const captured = captureRpcArgs();
 

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -566,8 +566,7 @@ libraryRouter.post(
       path_segments: segments,
       conflict_resolution: conflictResolution,
     });
-    if (error)
-      return void res.status(500).json({ detail: error.message });
+    if (error) return void sendInternalError(res, error);
     res.json(data);
   },
 );

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -458,8 +458,18 @@ libraryRouter.post(
     if (!kind)
       return void res.status(404).json({ detail: "Library not found" });
     const db = createServerSupabase();
+    const folderId =
+      typeof req.body?.folder_id === "string" && req.body.folder_id.trim()
+        ? req.body.folder_id.trim()
+        : null;
+    if (folderId) {
+      const folder = await loadLibraryFolder(db, userId, kind, folderId);
+      if (!folder)
+        return void res.status(404).json({ detail: "Folder not found" });
+    }
     await handleDocumentUpload(req, res, userId, null, db, {
       libraryKind: kind,
+      libraryFolderId: folderId,
     });
   },
 );
@@ -501,6 +511,67 @@ libraryRouter.get(
     }
 
     res.json({ folders: path });
+  },
+);
+
+// POST /library/:kind/folder-paths/resolve
+libraryRouter.post(
+  "/:kind/folder-paths/resolve",
+  requireAuth,
+  async (req, res) => {
+    const userId = res.locals.userId as string;
+    const kind = normalizeLibraryKind(req.params.kind);
+    if (!kind)
+      return void res.status(404).json({ detail: "Library not found" });
+    const body = req.body as {
+      base_folder_id?: string | null;
+      segments?: unknown;
+      conflict_resolution?: unknown;
+    };
+    const rawSegments = Array.isArray(body.segments) ? body.segments : [];
+    const segments = Array.isArray(body.segments)
+      ? body.segments
+          .filter((segment): segment is string => typeof segment === "string")
+          .map((segment) => segment.trim())
+      : [];
+    if (
+      rawSegments.length !== segments.length ||
+      segments.length === 0 ||
+      segments.length > 100 ||
+      segments.some((segment) => !segment || segment.length > 255)
+    ) {
+      return void res.status(400).json({ detail: "Invalid folder path" });
+    }
+    const conflictResolution =
+      body.conflict_resolution === "reuse" ||
+      body.conflict_resolution === "rename"
+        ? body.conflict_resolution
+        : "error";
+    const baseFolderId =
+      typeof body.base_folder_id === "string" && body.base_folder_id.trim()
+        ? body.base_folder_id.trim()
+        : null;
+
+    const db = createServerSupabase();
+    if (baseFolderId) {
+      const parent = await loadLibraryFolder(db, userId, kind, baseFolderId);
+      if (!parent)
+        return void res.status(404).json({ detail: "Parent folder not found" });
+    }
+
+    const { data, error } = await db.rpc("resolve_library_folder_path", {
+      target_user_id: userId,
+      target_library_kind: kind,
+      base_folder_id: baseFolderId,
+      path_segments: segments,
+      conflict_resolution: conflictResolution,
+    });
+    if (error)
+      return void res.status(500).json({ detail: error.message });
+    if (data && typeof data === "object" && "conflict" in data && data.conflict) {
+      return void res.json({ ...data, can_replace: true });
+    }
+    res.json(data);
   },
 );
 

--- a/backend/src/routes/library.ts
+++ b/backend/src/routes/library.ts
@@ -568,9 +568,6 @@ libraryRouter.post(
     });
     if (error)
       return void res.status(500).json({ detail: error.message });
-    if (data && typeof data === "object" && "conflict" in data && data.conflict) {
-      return void res.json({ ...data, can_replace: true });
-    }
     res.json(data);
   },
 );

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -1227,8 +1227,16 @@ projectsRouter.post(
       path_segments: segments,
       conflict_resolution: conflictResolution,
     });
-    if (error)
-      return void res.status(500).json({ detail: error.message });
+    if (error) {
+      console.error("[projects/folder-paths/resolve] failed", {
+        projectId,
+        userId,
+        error: safeErrorLog(error),
+      });
+      return void res.status(500).json({
+        detail: "Could not prepare this folder upload. Please try again.",
+      });
+    }
     res.json(data);
   },
 );

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -1131,7 +1131,17 @@ projectsRouter.post(
     if (!access.ok)
       return void res.status(404).json({ detail: "Project not found" });
 
-    await handleDocumentUpload(req, res, userId, projectId, db);
+    const folderId =
+      typeof req.body?.folder_id === "string" && req.body.folder_id.trim()
+        ? req.body.folder_id.trim()
+        : null;
+    if (folderId) {
+      const folder = await loadProjectFolder(db, projectId, folderId);
+      if (!folder)
+        return void res.status(404).json({ detail: "Folder not found" });
+    }
+
+    await handleDocumentUpload(req, res, userId, projectId, db, folderId);
   },
 );
 
@@ -1162,6 +1172,69 @@ projectsRouter.get("/:projectId/chats", requireAuth, async (req, res) => {
 });
 
 // ── Folder routes ─────────────────────────────────────────────────────────────
+
+// POST /projects/:projectId/folder-paths/resolve
+projectsRouter.post(
+  "/:projectId/folder-paths/resolve",
+  requireAuth,
+  async (req, res) => {
+    const userId = res.locals.userId as string;
+    const userEmail = res.locals.userEmail as string | undefined;
+    const { projectId } = req.params;
+    const body = req.body as {
+      base_folder_id?: string | null;
+      segments?: unknown;
+      conflict_resolution?: unknown;
+    };
+    const rawSegments = Array.isArray(body.segments) ? body.segments : [];
+    const segments = Array.isArray(body.segments)
+      ? body.segments
+          .filter((segment): segment is string => typeof segment === "string")
+          .map((segment) => segment.trim())
+      : [];
+    if (
+      rawSegments.length !== segments.length ||
+      segments.length === 0 ||
+      segments.length > 100 ||
+      segments.some((segment) => !segment || segment.length > 255)
+    ) {
+      return void res.status(400).json({ detail: "Invalid folder path" });
+    }
+    const conflictResolution =
+      body.conflict_resolution === "reuse" ||
+      body.conflict_resolution === "rename"
+        ? body.conflict_resolution
+        : "error";
+    const baseFolderId =
+      typeof body.base_folder_id === "string" && body.base_folder_id.trim()
+        ? body.base_folder_id.trim()
+        : null;
+
+    const db = createServerSupabase();
+    const access = await checkProjectAccess(projectId, userId, userEmail, db);
+    if (!access.ok)
+      return void res.status(404).json({ detail: "Project not found" });
+    if (baseFolderId) {
+      const parent = await loadProjectFolder(db, projectId, baseFolderId);
+      if (!parent)
+        return void res.status(404).json({ detail: "Parent folder not found" });
+    }
+
+    const { data, error } = await db.rpc("resolve_project_folder_path", {
+      target_project_id: projectId,
+      target_user_id: userId,
+      base_folder_id: baseFolderId,
+      path_segments: segments,
+      conflict_resolution: conflictResolution,
+    });
+    if (error)
+      return void res.status(500).json({ detail: error.message });
+    if (data && typeof data === "object" && "conflict" in data && data.conflict) {
+      return void res.json({ ...data, can_replace: access.isOwner });
+    }
+    res.json(data);
+  },
+);
 
 // POST /projects/:projectId/folders
 projectsRouter.post("/:projectId/folders", requireAuth, async (req, res) => {
@@ -1400,6 +1473,7 @@ export async function handleDocumentUpload(
   userId: string,
   projectId: string | null,
   db: ReturnType<typeof createServerSupabase>,
+  folderId: string | null = null,
 ) {
   const file = req.file;
   if (!file) return void res.status(400).json({ detail: "file is required" });
@@ -1420,6 +1494,7 @@ export async function handleDocumentUpload(
       project_id: projectId,
       user_id: userId,
       status: "processing",
+      folder_id: folderId,
     })
     .select("*")
     .single();

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -1229,9 +1229,6 @@ projectsRouter.post(
     });
     if (error)
       return void res.status(500).json({ detail: error.message });
-    if (data && typeof data === "object" && "conflict" in data && data.conflict) {
-      return void res.json({ ...data, can_replace: access.isOwner });
-    }
     res.json(data);
   },
 );

--- a/e2e/project-management.spec.ts
+++ b/e2e/project-management.spec.ts
@@ -210,7 +210,10 @@ test("create a folder inside a project", async ({ page }) => {
        "Add Subfolder" to "Folder" (a TabPillButton wired to the root
        createFolderAction — ProjectDocumentsView). Clicking it still renders the
        autofocused "Folder name" input at root level (creatingIn === null). */
-    const addSubfolderBtn = page.getByRole("button", { name: "Folder" });
+    const addSubfolderBtn = page.getByRole("button", {
+        name: "Folder",
+        exact: true,
+    });
     await waitForProjectLoaded(page, addSubfolderBtn);
 
     /* Clicking "Add Subfolder" sets creatingFolderIn = null (root level). */

--- a/frontend/src/app/(pages)/tabular-reviews/page.tsx
+++ b/frontend/src/app/(pages)/tabular-reviews/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useDebouncedValue } from "@/app/hooks/useDebouncedValue";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ChevronDown, Loader2, Plus } from "lucide-react";
+import { ChevronDown, Loader2 } from "lucide-react";
 import {
     RowActionMenuItems,
     RowActions,
@@ -588,7 +588,6 @@ export default function TabularReviewsPage() {
                                     disabled={creating}
                                     className="mt-4 px-3"
                                 >
-                                    <Plus className="h-3.5 w-3.5" />
                                     Create
                                 </PillButton>
                             </>

--- a/frontend/src/app/components/documents/DocTable.tsx
+++ b/frontend/src/app/components/documents/DocTable.tsx
@@ -51,10 +51,13 @@ import {
 import {
     collectDroppedDocumentUploadEntries,
     dataTransferHasDirectory,
+    DOCUMENT_UPLOAD_CONCURRENCY,
     documentUploadEntriesFromFiles,
     documentUploadFolderSegments,
     documentUploadProgressEntries,
+    MAX_DOCUMENTS_PER_DIRECTORY_UPLOAD,
     resolveDocumentUploadRootFolder,
+    settleWithConcurrency,
     type DocumentUploadEntry,
     type DocumentUploadFolderPathResolution,
     type DocumentUploadProgressEntry,
@@ -1223,6 +1226,14 @@ export function DocTable({
         const supportedEntries = entries.filter((entry) =>
             supportedFiles.has(entry.file),
         );
+        if (
+            supportedEntries.length > MAX_DOCUMENTS_PER_DIRECTORY_UPLOAD
+        ) {
+            setCollectionActionWarning(
+                `You can upload up to ${MAX_DOCUMENTS_PER_DIRECTORY_UPLOAD} supported documents at a time. Nothing was uploaded.`,
+            );
+            return;
+        }
         const progressEntries = documentUploadProgressEntries(supportedEntries);
         setCollectionUploadProgress({
             parentFolderId: baseFolderId,
@@ -1321,11 +1332,13 @@ export function DocTable({
                 return pending;
             };
 
-            const results = await Promise.allSettled(
-                supportedEntries.map(async (entry) => {
+            const results = await settleWithConcurrency(
+                supportedEntries,
+                DOCUMENT_UPLOAD_CONCURRENCY,
+                async (entry) => {
                     const folderId = await resolveEntryFolder(entry);
                     return operations.uploadDocument(entry.file, folderId);
-                }),
+                },
             );
             const uploaded = results.flatMap((result) =>
                 result.status === "fulfilled" ? [result.value] : [],

--- a/frontend/src/app/components/documents/DocTable.tsx
+++ b/frontend/src/app/components/documents/DocTable.tsx
@@ -49,6 +49,24 @@ import {
     SUPPORTED_DOCUMENT_ACCEPT,
 } from "@/app/lib/documentUploadValidation";
 import {
+    collectDroppedDocumentUploadEntries,
+    dataTransferHasDirectory,
+    documentUploadEntriesFromFiles,
+    documentUploadFolderSegments,
+    documentUploadProgressEntries,
+    resolveDocumentUploadRootFolder,
+    type DocumentUploadEntry,
+    type DocumentUploadFolderPathResolution,
+    type DocumentUploadProgressEntry,
+} from "@/app/lib/documentDirectoryUpload";
+import {
+    MULTI_DOCUMENT_DRAG_TYPE,
+    readDocumentDragPayload,
+    selectedDocumentRange,
+    SINGLE_DOCUMENT_DRAG_TYPE,
+    writeDocumentDragPayload,
+} from "@/app/lib/docTableSelection";
+import {
     DOC_NAME_COL_W,
     DocIcon,
     DocVersionHistory,
@@ -120,9 +138,17 @@ const SORT_KEY_LABELS: Record<DocumentSortKey, string> = {
 };
 
 interface DocTableOperations {
-    uploadDocument: (file: File) => Promise<Document>;
+    uploadDocument: (
+        file: File,
+        folderId?: string | null,
+    ) => Promise<Document>;
     refreshCollection: () => Promise<void>;
     createFolder: (name: string, parentFolderId?: string | null) => Promise<DocTableFolder>;
+    resolveFolderPath: (
+        segments: string[],
+        baseFolderId: string | null,
+        conflictResolution?: "error" | "reuse" | "rename",
+    ) => Promise<DocumentUploadFolderPathResolution<DocTableFolder>>;
     renameFolder: (folderId: string, name: string) => Promise<DocTableFolder>;
     deleteFolder: (folderId: string) => Promise<void>;
     moveFolder: (folderId: string, parentFolderId: string | null) => Promise<DocTableFolder>;
@@ -147,6 +173,7 @@ interface DocTableProps {
         onSelect: (documents: Document[]) => void,
     ) => ReactNode;
     onAddDocumentsActionChange?: (action: (() => void) | null) => void;
+    onUploadFolderActionChange?: (action: (() => void) | null) => void;
     onCreateFolderActionChange?: (action: (() => void) | null) => void;
     onFolderViewBackActionChange?: (action: (() => void) | null) => void;
     onFolderViewChange?: (path: DocTableFolderBreadcrumb[]) => void;
@@ -282,6 +309,7 @@ export function DocTable({
     emptyStateTitle,
     renderAddDocumentsModal,
     onAddDocumentsActionChange,
+    onUploadFolderActionChange,
     onCreateFolderActionChange,
     onFolderViewBackActionChange,
     onFolderViewChange,
@@ -325,6 +353,9 @@ export function DocTable({
     const [sort, setSort] = useState<DocumentSort | null>(null);
     const serverQueryActive = serverDocuments !== null;
     const documentUploadInputRef = useRef<HTMLInputElement>(null);
+    const directoryUploadInputRef = useRef<HTMLInputElement>(null);
+    const tableRootRef = useRef<HTMLDivElement>(null);
+    const selectionAnchorIdRef = useRef<string | null>(null);
     const autoLoadTriggeredRef = useRef(false);
     const loadingRef = useRef(loading);
     const renderAddDocumentsModalRef = useRef(renderAddDocumentsModal);
@@ -348,6 +379,16 @@ export function DocTable({
         onAddDocumentsActionChange?.(openAddDocuments);
         return () => onAddDocumentsActionChange?.(null);
     }, [onAddDocumentsActionChange, openAddDocuments]);
+
+    const openUploadFolder = useCallback(() => {
+        if (loadingRef.current) return;
+        directoryUploadInputRef.current?.click();
+    }, []);
+
+    useEffect(() => {
+        onUploadFolderActionChange?.(openUploadFolder);
+        return () => onUploadFolderActionChange?.(null);
+    }, [onUploadFolderActionChange, openUploadFolder]);
 
     // Version-history expansion (per-doc). versionsByDocId caches fetched
     // versions so toggling closed + open again doesn't refetch. loadingIds
@@ -546,7 +587,18 @@ export function DocTable({
     const [dragOverVersionDocId, setDragOverVersionDocId] = useState<string | null>(null);
     const [uploadingVersionDocIds, setUploadingVersionDocIds] = useState<Set<string>>(() => new Set());
     const [versionUploadTargetDoc, setVersionUploadTargetDoc] = useState<Document | null>(null);
-    const [uploadingDroppedFilenames, setUploadingDroppedFilenames] = useState<string[]>([]);
+    const [collectionUploadProgress, setCollectionUploadProgress] = useState<{
+        parentFolderId: string | null;
+        entries: DocumentUploadProgressEntry[];
+    } | null>(null);
+    const [folderUploadConflict, setFolderUploadConflict] = useState<{
+        folderName: string;
+        suggestedName: string;
+        canReplace: boolean;
+    } | null>(null);
+    const folderUploadConflictResolverRef = useRef<
+        ((choice: "replace" | "rename" | "cancel") => void) | null
+    >(null);
     const [deletingDocIds, setDeletingDocIds] = useState<Set<string>>(() => new Set());
     const [documentUploadWarning, setDocumentUploadWarning] = useState<string | null>(null);
     const [documentRenameWarning, setDocumentRenameWarning] = useState<string | null>(null);
@@ -564,6 +616,14 @@ export function DocTable({
         documentCount: number;
     } | null>(null);
     const [pendingDeleteFolderStatus, setPendingDeleteFolderStatus] = useState<"idle" | "deleting" | "deleted">("idle");
+
+    useEffect(
+        () => () => {
+            folderUploadConflictResolverRef.current?.("cancel");
+            folderUploadConflictResolverRef.current = null;
+        },
+        [],
+    );
 
     const openCreateFolder = useCallback(() => {
         if (loadingRef.current) return;
@@ -584,6 +644,7 @@ export function DocTable({
         setSelectionCameFromSelectAll(false);
         setConfirmDeleteAllOpen(false);
         setContextMenu(null);
+        selectionAnchorIdRef.current = null;
         setTypeFilter(null);
         setSort(null);
     }, [scopeKey]);
@@ -1100,7 +1161,10 @@ export function DocTable({
 
     function hasMovePayload(dt: DataTransfer): boolean {
         return Array.from(dt.types).some(
-            (type) => type === "application/mike-doc" || type === "application/mike-folder",
+            (type) =>
+                type === SINGLE_DOCUMENT_DRAG_TYPE ||
+                type === MULTI_DOCUMENT_DRAG_TYPE ||
+                type === "application/mike-folder",
         );
     }
 
@@ -1109,7 +1173,7 @@ export function DocTable({
     }
 
     function hasDocumentPayload(dt: DataTransfer): boolean {
-        return Array.from(dt.types).includes("application/mike-doc");
+        return Array.from(dt.types).includes(SINGLE_DOCUMENT_DRAG_TYPE);
     }
 
     function currentVersionNumber(doc: Document): number | null {
@@ -1120,19 +1184,193 @@ export function DocTable({
         return !!(doc?.user_id && user?.id && doc.user_id !== user.id);
     }
 
-    async function handleDropCollectionFiles(files: File[]) {
-        if (files.length === 0) return;
-        const { supported, unsupported } = partitionSupportedDocumentFiles(files);
+    function requestFolderUploadConflictChoice(conflict: {
+        folder_name: string;
+        suggested_name: string;
+        can_replace: boolean;
+    }): Promise<"replace" | "rename" | "cancel"> {
+        folderUploadConflictResolverRef.current?.("cancel");
+        setFolderUploadConflict({
+            folderName: conflict.folder_name,
+            suggestedName: conflict.suggested_name,
+            canReplace: conflict.can_replace,
+        });
+        return new Promise((resolve) => {
+            folderUploadConflictResolverRef.current = resolve;
+        });
+    }
+
+    function finishFolderUploadConflict(
+        choice: "replace" | "rename" | "cancel",
+    ) {
+        const resolve = folderUploadConflictResolverRef.current;
+        folderUploadConflictResolverRef.current = null;
+        setFolderUploadConflict(null);
+        resolve?.(choice);
+    }
+
+    async function handleCollectionUploadEntries(
+        entries: DocumentUploadEntry[],
+        baseFolderId: string | null = viewedFolderIdRef.current,
+    ) {
+        if (entries.length === 0) return;
+        const { supported, unsupported } = partitionSupportedDocumentFiles(
+            entries.map((entry) => entry.file),
+        );
         setDocumentUploadWarning(formatUnsupportedDocumentWarning(unsupported));
         if (supported.length === 0) return;
-        setUploadingDroppedFilenames(supported.map((file) => file.name));
+        const supportedFiles = new Set(supported);
+        const supportedEntries = entries.filter((entry) =>
+            supportedFiles.has(entry.file),
+        );
+        const progressEntries = documentUploadProgressEntries(supportedEntries);
+        setCollectionUploadProgress({
+            parentFolderId: baseFolderId,
+            entries: progressEntries,
+        });
+
         try {
-            const uploaded = await Promise.all(supported.map((file) => operations.uploadDocument(file)));
+            const addResolvedFolders = (resolvedFolders: DocTableFolder[]) => {
+                setFolders((current) => {
+                    const next = [...current];
+                    const knownIds = new Set(current.map((folder) => folder.id));
+                    for (const folder of resolvedFolders) {
+                        if (knownIds.has(folder.id)) continue;
+                        knownIds.add(folder.id);
+                        next.push(folder);
+                    }
+                    return next;
+                });
+            };
+
+            const rootFolderNames = Array.from(
+                new Set(
+                    supportedEntries.flatMap((entry) => {
+                        const segments = documentUploadFolderSegments(entry);
+                        return segments.length > 0 ? [segments[0]] : [];
+                    }),
+                ),
+            );
+            const resolvedRoots = new Map<
+                string,
+                { folderId: string }
+            >();
+
+            for (const rootFolderName of rootFolderNames) {
+                const resolution = await resolveDocumentUploadRootFolder({
+                    rootFolderName,
+                    baseFolderId,
+                    resolveFolderPath: operations.resolveFolderPath,
+                    chooseConflict: requestFolderUploadConflictChoice,
+                    replaceFolder: async (folderId) => {
+                        await operations.deleteFolder(folderId);
+                        await operations.refreshCollection();
+                    },
+                });
+                if (!resolution) return;
+
+                addResolvedFolders(resolution.folders);
+                resolvedRoots.set(rootFolderName, {
+                    folderId: resolution.folder_id,
+                });
+                if (resolution.resolved_name !== rootFolderName) {
+                    setCollectionUploadProgress((current) =>
+                        current
+                            ? {
+                                  ...current,
+                                  entries: current.entries.map((entry) =>
+                                      entry.kind === "folder" &&
+                                      entry.name === rootFolderName
+                                          ? {
+                                                ...entry,
+                                                name: resolution.resolved_name,
+                                            }
+                                          : entry,
+                                  ),
+                              }
+                            : current,
+                    );
+                }
+            }
+
+            const folderPathPromises = new Map<string, Promise<string>>();
+            const resolveEntryFolder = async (entry: DocumentUploadEntry) => {
+                const segments = documentUploadFolderSegments(entry);
+                if (segments.length === 0) return baseFolderId;
+                const root = resolvedRoots.get(segments[0]);
+                if (!root) throw new Error("Folder root was not resolved");
+                const remainingSegments = segments.slice(1);
+                if (remainingSegments.length === 0) return root.folderId;
+                const key = JSON.stringify([root.folderId, remainingSegments]);
+                const existing = folderPathPromises.get(key);
+                if (existing) return existing;
+                const pending = operations
+                    .resolveFolderPath(
+                        remainingSegments,
+                        root.folderId,
+                        "reuse",
+                    )
+                    .then((nestedResolution) => {
+                        if (nestedResolution.conflict) {
+                            throw new Error("Nested folder path conflicted");
+                        }
+                        addResolvedFolders(nestedResolution.folders);
+                        return nestedResolution.folder_id;
+                    });
+                folderPathPromises.set(key, pending);
+                return pending;
+            };
+
+            const results = await Promise.allSettled(
+                supportedEntries.map(async (entry) => {
+                    const folderId = await resolveEntryFolder(entry);
+                    return operations.uploadDocument(entry.file, folderId);
+                }),
+            );
+            const uploaded = results.flatMap((result) =>
+                result.status === "fulfilled" ? [result.value] : [],
+            );
             handleDocsSelected(uploaded);
+            const failedCount = results.length - uploaded.length;
+            if (failedCount > 0) {
+                setCollectionActionWarning(
+                    `${failedCount} ${failedCount === 1 ? "document" : "documents"} could not be uploaded. Please try again.`,
+                );
+            }
         } catch (err) {
             console.error("Document drop upload failed", err);
+            setCollectionActionWarning(
+                apiErrorDetail(err) ??
+                    "This folder could not be uploaded. Please try again.",
+            );
         } finally {
-            setUploadingDroppedFilenames([]);
+            setCollectionUploadProgress(null);
+        }
+    }
+
+    function handleDropCollectionFiles(
+        files: File[],
+        baseFolderId?: string | null,
+    ) {
+        return handleCollectionUploadEntries(
+            documentUploadEntriesFromFiles(files),
+            baseFolderId,
+        );
+    }
+
+    async function handleDroppedCollectionDataTransfer(
+        dataTransfer: DataTransfer,
+        baseFolderId?: string | null,
+    ) {
+        try {
+            const entries =
+                await collectDroppedDocumentUploadEntries(dataTransfer);
+            await handleCollectionUploadEntries(entries, baseFolderId);
+        } catch (error) {
+            console.error("Folder drop traversal failed", error);
+            setCollectionActionWarning(
+                "This folder could not be read. Please try selecting it with Upload folder.",
+            );
         }
     }
 
@@ -1165,10 +1403,12 @@ export function DocTable({
             if (!hasFiles(event.dataTransfer)) return;
             event.preventDefault();
             event.stopPropagation();
+            const dataTransfer = event.dataTransfer;
             collectionDragDepthRef.current = 0;
             setIsDraggingCollectionFiles(false);
             setDragOverFileRoot(false);
-            void handleDropCollectionFiles(Array.from(event.dataTransfer?.files ?? []));
+            if (!dataTransfer) return;
+            void handleDroppedCollectionDataTransfer(dataTransfer);
         }
 
         window.addEventListener("dragenter", handleDragEnter);
@@ -1251,6 +1491,7 @@ export function DocTable({
     }
 
     function handleDocumentVersionDragOver(e: DragEvent<HTMLDivElement>, docId: string) {
+        if (dataTransferHasDirectory(e.dataTransfer)) return;
         if (!hasFilePayload(e.dataTransfer) && !hasDocumentPayload(e.dataTransfer)) {
             return;
         }
@@ -1269,6 +1510,7 @@ export function DocTable({
     }
 
     function handleDocumentVersionDrop(e: DragEvent<HTMLDivElement>, doc: Document) {
+        if (dataTransferHasDirectory(e.dataTransfer)) return;
         if (!hasFilePayload(e.dataTransfer) && !hasDocumentPayload(e.dataTransfer)) {
             return;
         }
@@ -1284,20 +1526,26 @@ export function DocTable({
             void handleDropDocumentVersions(doc, Array.from(e.dataTransfer.files));
             return;
         }
-        void handleDropExistingDocumentVersion(doc, e.dataTransfer.getData("application/mike-doc"));
+        void handleDropExistingDocumentVersion(
+            doc,
+            readDocumentDragPayload(e.dataTransfer)[0] ?? "",
+        );
     }
 
     async function handleDropOnFolder(targetFolderId: string | null, dt: DataTransfer) {
         if (!hasMovePayload(dt)) return;
-        const docId = dt.getData("application/mike-doc");
+        const docIds = readDocumentDragPayload(dt);
         const subFolderId = dt.getData("application/mike-folder");
-        if (docId) {
-            const doc = documents.find((d) => d.id === docId);
-            if (!doc || (doc.folder_id ?? null) === targetFolderId) return;
+        if (docIds.length > 0) {
+            const movingIds = docIds.filter((id) => {
+                const doc = documents.find((candidate) => candidate.id === id);
+                return doc && (doc.folder_id ?? null) !== targetFolderId;
+            });
+            if (movingIds.length === 0) return;
             const updatedAt = new Date().toISOString();
             setDocuments((prev) =>
                 prev.map((document) =>
-                    document.id === docId
+                    movingIds.includes(document.id)
                         ? {
                               ...document,
                               folder_id: targetFolderId,
@@ -1306,17 +1554,32 @@ export function DocTable({
                         : document,
                 ),
             );
-            const updated = await operations.moveDocument(
-                docId,
-                targetFolderId,
+            const results = await Promise.allSettled(
+                movingIds.map((documentId) =>
+                    operations.moveDocument(documentId, targetFolderId),
+                ),
+            );
+            const updatedById = new Map(
+                results.flatMap((result) =>
+                    result.status === "fulfilled"
+                        ? [[result.value.id, result.value] as const]
+                        : [],
+                ),
             );
             setDocuments((prev) =>
                 prev.map((document) =>
-                    document.id === docId
-                        ? { ...document, ...updated }
+                    updatedById.has(document.id)
+                        ? { ...document, ...updatedById.get(document.id)! }
                         : document,
                 ),
             );
+            const failedCount = results.length - updatedById.size;
+            if (failedCount > 0) {
+                await operations.refreshCollection();
+                setCollectionActionWarning(
+                    `${failedCount} ${failedCount === 1 ? "document" : "documents"} could not be moved. Please try again.`,
+                );
+            }
         } else if (subFolderId && subFolderId !== targetFolderId) {
             if (targetFolderId !== null && wouldCreateCycle(subFolderId, targetFolderId)) return;
             const folder = folders.find((f) => f.id === subFolderId);
@@ -1405,12 +1668,14 @@ export function DocTable({
         fileType,
         depth,
         statusLabel,
+        entryKind = "file",
     }: {
         key: string;
         filename: string;
         fileType: string | null;
         depth: number;
         statusLabel: string;
+        entryKind?: "file" | "folder";
     }) {
         return (
             <div key={key} className="group flex h-10 min-w-max items-center pr-3">
@@ -1420,14 +1685,28 @@ export function DocTable({
                 >
                     <div className="flex items-center">
                         <Loader2 className="mr-3 h-2.5 w-2.5 animate-spin text-gray-400 shrink-0" />
+                        {entryKind === "folder" && (
+                            <span className="mr-2 flex h-4 w-4 shrink-0 items-center justify-center">
+                                <ChevronRight className="h-4 w-4 text-gray-400" />
+                            </span>
+                        )}
                         <span className="mr-2 shrink-0">
-                            <DocIcon fileType={fileType ?? filename} muted />
+                            {entryKind === "folder" ? (
+                                <SubfolderSvgIcon className="h-4 w-4 opacity-50" />
+                            ) : (
+                                <DocIcon fileType={fileType ?? filename} muted />
+                            )}
                         </span>
                         <span className="text-xs text-gray-400 truncate">{filename}</span>
                     </div>
                 </div>
                 <div className="ml-auto w-20 shrink-0 text-xs text-gray-300 lowercase truncate">
-                    {fileType ?? (filename.includes(".") ? filename.split(".").pop() : "file")}
+                    {entryKind === "folder"
+                        ? "folder"
+                        : fileType ??
+                          (filename.includes(".")
+                              ? filename.split(".").pop()
+                              : "file")}
                 </div>
                 <div className="w-24 shrink-0 text-xs text-gray-300">{statusLabel}</div>
                 <div className="w-20 shrink-0 text-xs text-gray-300">—</div>
@@ -1438,14 +1717,21 @@ export function DocTable({
         );
     }
 
-    function renderUploadingDocumentRows(depth: number) {
-        return uploadingDroppedFilenames.map((filename) =>
+    function renderUploadingDocumentRows(
+        depth: number,
+        parentFolderId: string | null,
+    ) {
+        if (collectionUploadProgress?.parentFolderId !== parentFolderId) {
+            return null;
+        }
+        return collectionUploadProgress.entries.map((entry, index) =>
             renderDocumentActivityRow({
-                key: `uploading-doc-${filename}`,
-                filename,
+                key: `uploading-${entry.kind}-${entry.name}-${index}`,
+                filename: entry.name,
                 fileType: null,
                 depth,
                 statusLabel: "Uploading",
+                entryKind: entry.kind,
             }),
         );
     }
@@ -1484,6 +1770,86 @@ export function DocTable({
             for (const id of ancestorIds) next.delete(id);
             return next;
         });
+    }
+
+    function visibleDocumentIds(): string[] {
+        return Array.from(
+            tableRootRef.current?.querySelectorAll<HTMLElement>(
+                "[data-document-row][data-document-id]",
+            ) ?? [],
+            (row) => row.dataset.documentId,
+        ).filter((id): id is string => !!id);
+    }
+
+    function updateDocumentSelection(
+        doc: Document,
+        selected: boolean,
+        shiftKey: boolean,
+    ) {
+        const ids = shiftKey
+            ? selectedDocumentRange(
+                  visibleDocumentIds(),
+                  selectionAnchorIdRef.current,
+                  doc.id,
+              )
+            : [doc.id];
+        if (!selected) {
+            for (const id of ids) {
+                clearSelectedFolderAncestors(
+                    documents.find((candidate) => candidate.id === id)
+                        ?.folder_id,
+                );
+            }
+        }
+        setSelectionCameFromSelectAll(false);
+        setSelectedDocIds((current) => {
+            const next = new Set(current);
+            for (const id of ids) {
+                if (selected) next.add(id);
+                else next.delete(id);
+            }
+            return [...next];
+        });
+        selectionAnchorIdRef.current = doc.id;
+    }
+
+    function handleDocumentRowClick(
+        event: React.MouseEvent<HTMLDivElement>,
+        doc: Document,
+    ) {
+        if (event.shiftKey) {
+            event.preventDefault();
+            updateDocumentSelection(doc, true, true);
+            return;
+        }
+        selectionAnchorIdRef.current = doc.id;
+        setViewingDocVersion(null);
+        setViewingDoc(doc);
+    }
+
+    function handleDocumentDragStart(
+        event: DragEvent<HTMLDivElement>,
+        doc: Document,
+    ) {
+        if (renamingDocumentId === doc.id) {
+            event.preventDefault();
+            return;
+        }
+        const visibleIds = new Set(visibleDocumentIds());
+        const selectedVisibleIds = selectedDocIds.filter((id) =>
+            visibleIds.has(id),
+        );
+        const draggedIds = writeDocumentDragPayload(
+            event.dataTransfer,
+            doc.id,
+            selectedVisibleIds,
+        );
+        if (!selectedDocIds.includes(doc.id)) {
+            setSelectedFolderIds(new Set());
+            setSelectionCameFromSelectAll(false);
+            setSelectedDocIds(draggedIds);
+        }
+        selectionAnchorIdRef.current = doc.id;
     }
 
     useEffect(() => {
@@ -1533,8 +1899,19 @@ export function DocTable({
             effectiveSort.direction === "desc"
                 ? -1
                 : 1;
+        const uploadingFolderNames = new Set(
+            collectionUploadProgress?.parentFolderId === parentId
+                ? collectionUploadProgress.entries
+                      .filter((entry) => entry.kind === "folder")
+                      .map((entry) => entry.name)
+                : [],
+        );
         const childFolders = folders
-            .filter((f) => f.parent_folder_id === parentId)
+            .filter(
+                (folder) =>
+                    folder.parent_folder_id === parentId &&
+                    !uploadingFolderNames.has(folder.name),
+            )
             .sort((a, b) => a.name.localeCompare(b.name) * nameMultiplier);
         const allChildDocs = filteredDocs.filter(
             (d) => (d.folder_id ?? null) === parentId,
@@ -1602,7 +1979,7 @@ export function DocTable({
 
         return (
             <div className="flex flex-col">
-                {parentId === null && renderUploadingDocumentRows(depth)}
+                {renderUploadingDocumentRows(depth, parentId)}
                 {childDocs.map((doc) => {
                     const docName = doc.filename;
                     const isProcessing = doc.status === "pending" || doc.status === "processing";
@@ -1633,15 +2010,11 @@ export function DocTable({
                         >
                             <div
                                 data-document-row
+                                data-document-id={doc.id}
                                 draggable={renamingDocumentId !== doc.id}
-                                onDragStart={(e) => {
-                                    if (renamingDocumentId === doc.id) {
-                                        e.preventDefault();
-                                        return;
-                                    }
-                                    e.dataTransfer.setData("application/mike-doc", doc.id);
-                                    e.dataTransfer.effectAllowed = "copyMove";
-                                }}
+                                onDragStart={(event) =>
+                                    handleDocumentDragStart(event, doc)
+                                }
                                 onDragEnd={() => {
                                     setDragOverRoot(false);
                                     setDragOverFolderId(null);
@@ -1650,10 +2023,9 @@ export function DocTable({
                                 onDragOver={(e) => handleDocumentVersionDragOver(e, doc.id)}
                                 onDragLeave={handleDocumentVersionDragLeave}
                                 onDrop={(e) => handleDocumentVersionDrop(e, doc)}
-                                onClick={() => {
-                                    setViewingDocVersion(null);
-                                    setViewingDoc(doc);
-                                }}
+                                onClick={(event) =>
+                                    handleDocumentRowClick(event, doc)
+                                }
                                 onContextMenu={(e) => {
                                     e.preventDefault();
                                     e.stopPropagation();
@@ -1687,18 +2059,15 @@ export function DocTable({
                                                         <input
                                                             type="checkbox"
                                                             checked={selectedDocIds.includes(doc.id)}
-                                                            onChange={() => {
-                                                                if (selectedDocIds.includes(doc.id)) {
-                                                                    clearSelectedFolderAncestors(
-                                                                        doc.folder_id,
-                                                                    );
-                                                                }
-                                                                setSelectedDocIds((prev) =>
-                                                                    prev.includes(doc.id)
-                                                                        ? prev.filter((x) => x !== doc.id)
-                                                                        : [...prev, doc.id],
-                                                                );
-                                                            }}
+                                                            onChange={(event) =>
+                                                                updateDocumentSelection(
+                                                                    doc,
+                                                                    event.target.checked,
+                                                                    (
+                                                                        event.nativeEvent as MouseEvent
+                                                                    ).shiftKey,
+                                                                )
+                                                            }
                                                             onClick={(e) => e.stopPropagation()}
                                                             className="mr-3 h-2.5 w-2.5 shrink-0 rounded border-gray-200 cursor-pointer accent-black"
                                                         />
@@ -1905,9 +2274,19 @@ export function DocTable({
                                     e.stopPropagation();
                                 }}
                                 onDragOver={(e) => {
-                                    if (!hasMovePayload(e.dataTransfer)) return;
+                                    if (
+                                        !hasMovePayload(e.dataTransfer) &&
+                                        !hasFilePayload(e.dataTransfer)
+                                    ) {
+                                        return;
+                                    }
                                     e.preventDefault();
                                     e.stopPropagation();
+                                    e.dataTransfer.dropEffect = hasFilePayload(
+                                        e.dataTransfer,
+                                    )
+                                        ? "copy"
+                                        : "move";
                                     setDragOverFolderId(folder.id);
                                     setDragOverVersionDocId(null);
                                 }}
@@ -1916,12 +2295,24 @@ export function DocTable({
                                     setDragOverFolderId(null);
                                 }}
                                 onDrop={async (e) => {
-                                    if (!hasMovePayload(e.dataTransfer)) return;
+                                    if (
+                                        !hasMovePayload(e.dataTransfer) &&
+                                        !hasFilePayload(e.dataTransfer)
+                                    ) {
+                                        return;
+                                    }
                                     e.preventDefault();
                                     e.stopPropagation();
                                     setDragOverFolderId(null);
                                     setDragOverRoot(false);
                                     setDragOverVersionDocId(null);
+                                    if (hasFilePayload(e.dataTransfer)) {
+                                        await handleDroppedCollectionDataTransfer(
+                                            e.dataTransfer,
+                                            folder.id,
+                                        );
+                                        return;
+                                    }
                                     await handleDropOnFolder(folder.id, e.dataTransfer);
                                 }}
                                 onClick={() => openFolderView(folder.id)}
@@ -1976,15 +2367,6 @@ export function DocTable({
                                                     }
                                                     return [...next];
                                                 });
-                                                if (
-                                                    !allFolderDocumentsSelected &&
-                                                    !expandedFolderIds.has(folder.id)
-                                                ) {
-                                                    setExpandedFolderIds((current) =>
-                                                        new Set([...current, folder.id]),
-                                                    );
-                                                    void expandFolderChildren(folder.id);
-                                                }
                                             }}
                                             onClick={(event) =>
                                                 event.stopPropagation()
@@ -2286,6 +2668,9 @@ export function DocTable({
             return a.filename.localeCompare(b.filename) * multiplier;
         });
     }, [docs, effectiveSort, enableHeaderFilters, q, serverQueryActive, typeFilter]);
+    const hasVisibleCollectionUpload =
+        collectionUploadProgress?.parentFolderId === viewedFolderId &&
+        collectionUploadProgress.entries.length > 0;
     const viewedFolderIsEmpty =
         !!viewedFolder &&
         !loadingChildFolderIds.has(viewedFolder.id) &&
@@ -2294,7 +2679,7 @@ export function DocTable({
             (folder) => folder.parent_folder_id === viewedFolder.id,
         ) &&
         creatingFolderIn !== viewedFolder.id &&
-        uploadingDroppedFilenames.length === 0;
+        !hasVisibleCollectionUpload;
 
     const nameSortDirection = effectiveSort?.key === "name" ? effectiveSort.direction : null;
     const sizeSortDirection = effectiveSort?.key === "size" ? effectiveSort.direction : null;
@@ -2475,7 +2860,10 @@ export function DocTable({
     ) : undefined;
 
     return (
-        <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+        <div
+            ref={tableRootRef}
+            className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+        >
             <input
                 ref={versionUploadInputRef}
                 type="file"
@@ -2495,9 +2883,24 @@ export function DocTable({
                     void handleDropCollectionFiles(files);
                 }}
             />
+            <input
+                ref={directoryUploadInputRef}
+                type="file"
+                accept={SUPPORTED_DOCUMENT_ACCEPT}
+                multiple
+                className="hidden"
+                {...{ webkitdirectory: "", directory: "" }}
+                onChange={(event) => {
+                    const entries = documentUploadEntriesFromFiles(
+                        event.target.files ?? [],
+                    );
+                    event.target.value = "";
+                    void handleCollectionUploadEntries(entries);
+                }}
+            />
             <UploadOverlay
                 open={isDraggingCollectionFiles}
-                label="Drop files here to upload"
+                label="Drop files or folders here to upload"
                 warning={documentUploadWarning}
                 onWarningClose={() => setDocumentUploadWarning(null)}
             />
@@ -2510,6 +2913,35 @@ export function DocTable({
                 open={!!collectionActionWarning}
                 onClose={() => setCollectionActionWarning(null)}
                 message={collectionActionWarning}
+            />
+            <WarningPopup
+                open={!!folderUploadConflict}
+                onClose={() => finishFolderUploadConflict("cancel")}
+                title="Folder already exists"
+                message={
+                    folderUploadConflict
+                        ? `A folder named “${folderUploadConflict.folderName}” already exists. Replace it and permanently delete all of its contents, or save this upload as “${folderUploadConflict.suggestedName}”.${folderUploadConflict.canReplace ? "" : " Only the project owner can replace the existing folder."}`
+                        : undefined
+                }
+                secondaryAction={
+                    folderUploadConflict
+                        ? {
+                              label: "Save over it",
+                              onClick: () =>
+                                  finishFolderUploadConflict("replace"),
+                              disabled: !folderUploadConflict.canReplace,
+                          }
+                        : undefined
+                }
+                primaryAction={
+                    folderUploadConflict
+                        ? {
+                              label: `Save as ${folderUploadConflict.suggestedName}`,
+                              onClick: () =>
+                                  finishFolderUploadConflict("rename"),
+                          }
+                        : undefined
+                }
             />
             <ConfirmPopup
                 open={confirmDeleteAllOpen && selectedDocIds.length > 0}
@@ -2640,7 +3072,7 @@ export function DocTable({
                                     setDragOverFileRoot(false);
                                 }
                             }}
-                            onDrop={(e) => {
+                            onDrop={async (e) => {
                                 if (!hasFilePayload(e.dataTransfer)) return;
                                 e.preventDefault();
                                 e.stopPropagation();
@@ -2650,7 +3082,9 @@ export function DocTable({
                                 setDragOverRoot(false);
                                 setDragOverFolderId(null);
                                 setDragOverVersionDocId(null);
-                                void handleDropCollectionFiles(Array.from(e.dataTransfer.files));
+                                await handleDroppedCollectionDataTransfer(
+                                    e.dataTransfer,
+                                );
                             }}
                         >
                             {dragOverRoot && dragOverFolderId === null && (
@@ -2670,7 +3104,7 @@ export function DocTable({
                             ) : docs.length === 0 &&
                             (serverQueryActive || folders.length === 0) &&
                             creatingFolderIn === undefined &&
-                            uploadingDroppedFilenames.length === 0 ? (
+                            !hasVisibleCollectionUpload ? (
                                 serverQueryActive ? (
                                     <div className="flex-1 flex flex-col items-center justify-center py-24 text-center">
                                         <p className="text-sm text-gray-400">No matches found</p>
@@ -2684,7 +3118,7 @@ export function DocTable({
                                             <EmptyState
                                                 icon={<LibrarySkeuoIcon />}
                                                 title={emptyStateTitle}
-                                                description="Upload documents or drop them here"
+                                                description="Upload documents or drop files and folders here"
                                                 action={
                                                     <PillButton
                                                         tone="black"
@@ -2741,7 +3175,10 @@ export function DocTable({
                                     {/* Search: flat list; no search: folder tree */}
                                     {q ? (
                                         <>
-                                            {renderUploadingDocumentRows(0)}
+                                            {renderUploadingDocumentRows(
+                                                0,
+                                                viewedFolderId,
+                                            )}
                                             {filteredDocs.map((doc) => {
                                                 const docName = doc.filename;
                                                 const isProcessing =
@@ -2768,15 +3205,14 @@ export function DocTable({
                                                     <div key={doc.id}>
                                                         <div
                                                             data-document-row
+                                                            data-document-id={doc.id}
                                                             draggable={renamingDocumentId !== doc.id}
-                                                            onDragStart={(e) => {
-                                                                if (renamingDocumentId === doc.id) {
-                                                                    e.preventDefault();
-                                                                    return;
-                                                                }
-                                                                e.dataTransfer.setData("application/mike-doc", doc.id);
-                                                                e.dataTransfer.effectAllowed = "copyMove";
-                                                            }}
+                                                            onDragStart={(event) =>
+                                                                handleDocumentDragStart(
+                                                                    event,
+                                                                    doc,
+                                                                )
+                                                            }
                                                             onDragEnd={() => {
                                                                 setDragOverRoot(false);
                                                                 setDragOverFolderId(null);
@@ -2785,10 +3221,12 @@ export function DocTable({
                                                             onDragOver={(e) => handleDocumentVersionDragOver(e, doc.id)}
                                                             onDragLeave={handleDocumentVersionDragLeave}
                                                             onDrop={(e) => handleDocumentVersionDrop(e, doc)}
-                                                            onClick={() => {
-                                                                setViewingDocVersion(null);
-                                                                setViewingDoc(doc);
-                                                            }}
+                                                            onClick={(event) =>
+                                                                handleDocumentRowClick(
+                                                                    event,
+                                                                    doc,
+                                                                )
+                                                            }
                                                             onContextMenu={(e) => {
                                                                 e.preventDefault();
                                                                 e.stopPropagation();
@@ -2813,22 +3251,15 @@ export function DocTable({
                                                                         <input
                                                                             type="checkbox"
                                                                             checked={selectedDocIds.includes(doc.id)}
-                                                                            onChange={() => {
-                                                                                if (
-                                                                                    selectedDocIds.includes(doc.id)
-                                                                                ) {
-                                                                                    clearSelectedFolderAncestors(
-                                                                                        doc.folder_id,
-                                                                                    );
-                                                                                }
-                                                                                setSelectedDocIds((prev) =>
-                                                                                    prev.includes(doc.id)
-                                                                                        ? prev.filter(
-                                                                                              (x) => x !== doc.id,
-                                                                                          )
-                                                                                        : [...prev, doc.id],
-                                                                                );
-                                                                            }}
+                                                                            onChange={(event) =>
+                                                                                updateDocumentSelection(
+                                                                                    doc,
+                                                                                    event.target.checked,
+                                                                                    (
+                                                                                        event.nativeEvent as MouseEvent
+                                                                                    ).shiftKey,
+                                                                                )
+                                                                            }
                                                                             onClick={(e) => e.stopPropagation()}
                                                                             className="mr-3 h-2.5 w-2.5 shrink-0 rounded border-gray-200 cursor-pointer accent-black"
                                                                         />

--- a/frontend/src/app/components/documents/DocTable.tsx
+++ b/frontend/src/app/components/documents/DocTable.tsx
@@ -2920,24 +2920,18 @@ export function DocTable({
                 onClose={() => setCollectionActionWarning(null)}
                 message={collectionActionWarning}
             />
-            <WarningPopup
+            <ConfirmPopup
                 open={!!folderUploadConflict}
-                onClose={() => finishFolderUploadConflict("cancel")}
                 title="Folder already exists"
                 message={
                     folderUploadConflict
                         ? `A folder named “${folderUploadConflict.folderName}” already exists. This folder will be uploaded as “${folderUploadConflict.suggestedName}”.`
                         : undefined
                 }
-                primaryAction={
-                    folderUploadConflict
-                        ? {
-                              label: "Continue",
-                              onClick: () =>
-                                  finishFolderUploadConflict("rename"),
-                          }
-                        : undefined
-                }
+                confirmLabel="Continue"
+                cancelLabel="Cancel"
+                onCancel={() => finishFolderUploadConflict("cancel")}
+                onConfirm={() => finishFolderUploadConflict("rename")}
             />
             <ConfirmPopup
                 open={confirmDeleteAllOpen && selectedDocIds.length > 0}

--- a/frontend/src/app/components/documents/DocTable.tsx
+++ b/frontend/src/app/components/documents/DocTable.tsx
@@ -597,10 +597,9 @@ export function DocTable({
     const [folderUploadConflict, setFolderUploadConflict] = useState<{
         folderName: string;
         suggestedName: string;
-        canReplace: boolean;
     } | null>(null);
     const folderUploadConflictResolverRef = useRef<
-        ((choice: "replace" | "rename" | "cancel") => void) | null
+        ((choice: "rename" | "cancel") => void) | null
     >(null);
     const [deletingDocIds, setDeletingDocIds] = useState<Set<string>>(() => new Set());
     const [documentUploadWarning, setDocumentUploadWarning] = useState<string | null>(null);
@@ -1190,13 +1189,11 @@ export function DocTable({
     function requestFolderUploadConflictChoice(conflict: {
         folder_name: string;
         suggested_name: string;
-        can_replace: boolean;
-    }): Promise<"replace" | "rename" | "cancel"> {
+    }): Promise<"rename" | "cancel"> {
         folderUploadConflictResolverRef.current?.("cancel");
         setFolderUploadConflict({
             folderName: conflict.folder_name,
             suggestedName: conflict.suggested_name,
-            canReplace: conflict.can_replace,
         });
         return new Promise((resolve) => {
             folderUploadConflictResolverRef.current = resolve;
@@ -1204,7 +1201,7 @@ export function DocTable({
     }
 
     function finishFolderUploadConflict(
-        choice: "replace" | "rename" | "cancel",
+        choice: "rename" | "cancel",
     ) {
         const resolve = folderUploadConflictResolverRef.current;
         folderUploadConflictResolverRef.current = null;
@@ -1273,10 +1270,6 @@ export function DocTable({
                     baseFolderId,
                     resolveFolderPath: operations.resolveFolderPath,
                     chooseConflict: requestFolderUploadConflictChoice,
-                    replaceFolder: async (folderId) => {
-                        await operations.deleteFolder(folderId);
-                        await operations.refreshCollection();
-                    },
                 });
                 if (!resolution) return;
 
@@ -2933,23 +2926,13 @@ export function DocTable({
                 title="Folder already exists"
                 message={
                     folderUploadConflict
-                        ? `A folder named “${folderUploadConflict.folderName}” already exists. Replace it and permanently delete all of its contents, or save this upload as “${folderUploadConflict.suggestedName}”.${folderUploadConflict.canReplace ? "" : " Only the project owner can replace the existing folder."}`
-                        : undefined
-                }
-                secondaryAction={
-                    folderUploadConflict
-                        ? {
-                              label: "Save over it",
-                              onClick: () =>
-                                  finishFolderUploadConflict("replace"),
-                              disabled: !folderUploadConflict.canReplace,
-                          }
+                        ? `A folder named “${folderUploadConflict.folderName}” already exists. This folder will be uploaded as “${folderUploadConflict.suggestedName}”.`
                         : undefined
                 }
                 primaryAction={
                     folderUploadConflict
                         ? {
-                              label: `Save as ${folderUploadConflict.suggestedName}`,
+                              label: "Continue",
                               onClick: () =>
                                   finishFolderUploadConflict("rename"),
                           }

--- a/frontend/src/app/components/documents/DocTable.tsx
+++ b/frontend/src/app/components/documents/DocTable.tsx
@@ -1346,8 +1346,7 @@ export function DocTable({
         } catch (err) {
             console.error("Document drop upload failed", err);
             setCollectionActionWarning(
-                apiErrorDetail(err) ??
-                    "This folder could not be uploaded. Please try again.",
+                "This folder could not be uploaded. Please try again.",
             );
         } finally {
             setCollectionUploadProgress(null);
@@ -2784,6 +2783,7 @@ export function DocTable({
             setSelectedDocIds(ids);
             setSelectionCameFromSelectAll(true);
         } catch (error) {
+            console.error("Select all matching documents failed", error);
             setCollectionActionWarning(
                 userFacingApiError(
                     error,

--- a/frontend/src/app/components/documents/DocTable.tsx
+++ b/frontend/src/app/components/documents/DocTable.tsx
@@ -54,7 +54,7 @@ import {
     DOCUMENT_UPLOAD_CONCURRENCY,
     documentUploadEntriesFromFiles,
     documentUploadFolderSegments,
-    documentUploadProgressEntries,
+    resolvedDocumentUploadProgressEntries,
     MAX_DOCUMENTS_PER_DIRECTORY_UPLOAD,
     resolveDocumentUploadRootFolder,
     settleWithConcurrency,
@@ -1231,11 +1231,17 @@ export function DocTable({
             );
             return;
         }
-        const progressEntries = documentUploadProgressEntries(supportedEntries);
-        setCollectionUploadProgress({
-            parentFolderId: baseFolderId,
-            entries: progressEntries,
-        });
+        const resolvedRootFolderNames = new Map<string, string>();
+        const updateCollectionUploadProgress = () => {
+            setCollectionUploadProgress({
+                parentFolderId: baseFolderId,
+                entries: resolvedDocumentUploadProgressEntries(
+                    supportedEntries,
+                    resolvedRootFolderNames,
+                ),
+            });
+        };
+        updateCollectionUploadProgress();
 
         try {
             const addResolvedFolders = (resolvedFolders: DocTableFolder[]) => {
@@ -1273,28 +1279,15 @@ export function DocTable({
                 });
                 if (!resolution) return;
 
+                resolvedRootFolderNames.set(
+                    rootFolderName,
+                    resolution.resolved_name,
+                );
+                updateCollectionUploadProgress();
                 addResolvedFolders(resolution.folders);
                 resolvedRoots.set(rootFolderName, {
                     folderId: resolution.folder_id,
                 });
-                if (resolution.resolved_name !== rootFolderName) {
-                    setCollectionUploadProgress((current) =>
-                        current
-                            ? {
-                                  ...current,
-                                  entries: current.entries.map((entry) =>
-                                      entry.kind === "folder" &&
-                                      entry.name === rootFolderName
-                                          ? {
-                                                ...entry,
-                                                name: resolution.resolved_name,
-                                            }
-                                          : entry,
-                                  ),
-                              }
-                            : current,
-                    );
-                }
             }
 
             const folderPathPromises = new Map<string, Promise<string>>();

--- a/frontend/src/app/components/library/LibraryWorkspace.tsx
+++ b/frontend/src/app/components/library/LibraryWorkspace.tsx
@@ -13,7 +13,7 @@ import {
     useState,
 } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronLeft, Plus, Upload } from "lucide-react";
+import { ChevronLeft, FolderUp, Plus, Upload } from "lucide-react";
 import { DocTable } from "@/app/components/documents/DocTable";
 import type {
   DocTableFolderBreadcrumb,
@@ -37,6 +37,7 @@ import {
     moveLibraryFolder,
     renameLibraryDocument,
     renameLibraryFolder,
+  resolveLibraryFolderPath,
   searchLibraryDocuments,
     uploadLibraryDocument,
     type LibraryKind,
@@ -639,6 +640,9 @@ export function LibraryCollectionPage({
     const [createFolderAction, setCreateFolderAction] = useState<
         (() => void) | null
     >(null);
+    const [uploadFolderAction, setUploadFolderAction] = useState<
+        (() => void) | null
+    >(null);
     const [folderBackAction, setFolderBackAction] = useState<
         (() => void) | null
     >(null);
@@ -659,6 +663,12 @@ export function LibraryCollectionPage({
     const handleCreateFolderActionChange = useCallback(
         (action: (() => void) | null) => {
             setCreateFolderAction(() => action);
+        },
+        [],
+    );
+    const handleUploadFolderActionChange = useCallback(
+        (action: (() => void) | null) => {
+            setUploadFolderAction(() => action);
         },
         [],
     );
@@ -833,13 +843,25 @@ export function LibraryCollectionPage({
 
     const operations = useMemo(
         () => ({
-            uploadDocument: (file: File) => uploadLibraryDocument(kind, file),
+            uploadDocument: (file: File, folderId?: string | null) =>
+                uploadLibraryDocument(kind, file, folderId),
       refreshCollection: async () => {
         await loadLibrary(kind);
         setServerQueryRefreshVersion((current) => current + 1);
       },
             createFolder: (name: string, parentFolderId?: string | null) =>
                 createLibraryFolder(kind, name, parentFolderId),
+            resolveFolderPath: (
+                segments: string[],
+                baseFolderId: string | null,
+                conflictResolution?: "error" | "reuse" | "rename",
+            ) =>
+                resolveLibraryFolderPath(
+                    kind,
+                    segments,
+                    baseFolderId,
+                    conflictResolution,
+                ),
             renameFolder: (folderId: string, name: string) =>
                 renameLibraryFolder(kind, folderId, name),
       deleteFolder: (folderId: string) => deleteLibraryFolder(kind, folderId),
@@ -884,9 +906,7 @@ export function LibraryCollectionPage({
                         actions: [
                             {
                                 icon: <Upload className="h-3.5 w-3.5" />,
-                                label: (
-                  <span className="hidden sm:inline">{addCollectionLabel}</span>
-                                ),
+                                iconOnly: true,
                                 title: `Add ${addCollectionLabel}`,
                                 onClick: addDocumentsAction ?? undefined,
                                 disabled: !addDocumentsAction || loading,
@@ -914,6 +934,15 @@ export function LibraryCollectionPage({
                                 </TabPillButton>
                             )}
                             <TabPillButton
+                                onClick={uploadFolderAction ?? undefined}
+                                disabled={!uploadFolderAction || loading}
+                            >
+                                <FolderUp className="h-3.5 w-3.5" />
+                                <span className="hidden sm:inline">
+                                    Upload folder
+                                </span>
+                            </TabPillButton>
+                            <TabPillButton
                                 onClick={createFolderAction ?? undefined}
                                 disabled={!createFolderAction || loading}
                             >
@@ -934,6 +963,9 @@ export function LibraryCollectionPage({
                     operations={operations}
                     emptyStateTitle={title}
                     onAddDocumentsActionChange={handleAddDocumentsActionChange}
+                    onUploadFolderActionChange={
+                        handleUploadFolderActionChange
+                    }
           onCreateFolderActionChange={handleCreateFolderActionChange}
                     onFolderViewBackActionChange={handleFolderBackActionChange}
                     onFolderViewChange={handleFolderViewChange}

--- a/frontend/src/app/components/projects/ProjectAssistantTable.tsx
+++ b/frontend/src/app/components/projects/ProjectAssistantTable.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMemo, useState, type Dispatch, type SetStateAction } from "react";
-import { Plus } from "lucide-react";
 import {
     RowActionMenuItems,
     RowActions,
@@ -237,7 +236,6 @@ export function ProjectAssistantTable({
                                 onClick={onCreateChat}
                                 className="px-3"
                             >
-                                <Plus className="h-3.5 w-3.5" />
                                 Create
                             </PillButton>
                         }

--- a/frontend/src/app/components/projects/ProjectDocumentsView.tsx
+++ b/frontend/src/app/components/projects/ProjectDocumentsView.tsx
@@ -10,7 +10,7 @@ import {
     useState,
 } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronDown, ChevronLeft, Plus } from "lucide-react";
+import { ChevronDown, ChevronLeft, FolderUp, Plus } from "lucide-react";
 import {
     createProjectFolder,
     deleteProjectFolder,
@@ -19,6 +19,7 @@ import {
     moveSubfolderToFolder,
     renameProjectDocument,
     renameProjectFolder,
+    resolveProjectFolderPath,
     uploadProjectDocument,
 } from "@/app/lib/mikeApi";
 import type { Document } from "@/app/components/shared/types";
@@ -55,6 +56,9 @@ export function ProjectDocumentsView({ projectId, folderId = null }: Props) {
         setDocumentFolderBreadcrumbs,
     } = workspace;
     const [createFolderAction, setCreateFolderAction] = useState<
+        (() => void) | null
+    >(null);
+    const [uploadFolderAction, setUploadFolderAction] = useState<
         (() => void) | null
     >(null);
     const [folderBackAction, setFolderBackAction] = useState<
@@ -179,11 +183,22 @@ export function ProjectDocumentsView({ projectId, folderId = null }: Props) {
     }, [projectId, setFolders, setProject]);
     const operations = useMemo(
         () => ({
-            uploadDocument: (file: File) =>
-                uploadProjectDocument(projectId, file),
+            uploadDocument: (file: File, targetFolderId?: string | null) =>
+                uploadProjectDocument(projectId, file, targetFolderId),
             refreshCollection,
             createFolder: (name: string, parentFolderId?: string | null) =>
                 createProjectFolder(projectId, name, parentFolderId),
+            resolveFolderPath: (
+                segments: string[],
+                baseFolderId: string | null,
+                conflictResolution?: "error" | "reuse" | "rename",
+            ) =>
+                resolveProjectFolderPath(
+                    projectId,
+                    segments,
+                    baseFolderId,
+                    conflictResolution,
+                ),
             renameFolder: (folderId: string, name: string) =>
                 renameProjectFolder(projectId, folderId, name),
             deleteFolder: (folderId: string) =>
@@ -201,6 +216,12 @@ export function ProjectDocumentsView({ projectId, folderId = null }: Props) {
     const handleCreateFolderActionChange = useCallback(
         (action: (() => void) | null) => {
             setCreateFolderAction(() => action);
+        },
+        [],
+    );
+    const handleUploadFolderActionChange = useCallback(
+        (action: (() => void) | null) => {
+            setUploadFolderAction(() => action);
         },
         [],
     );
@@ -291,6 +312,13 @@ export function ProjectDocumentsView({ projectId, folderId = null }: Props) {
                 </div>
             )}
             <TabPillButton
+                onClick={uploadFolderAction ?? undefined}
+                disabled={!uploadFolderAction || projectLoading}
+            >
+                <FolderUp className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">Upload folder</span>
+            </TabPillButton>
+            <TabPillButton
                 onClick={createFolderAction ?? undefined}
                 disabled={!createFolderAction || projectLoading}
             >
@@ -325,6 +353,9 @@ export function ProjectDocumentsView({ projectId, folderId = null }: Props) {
                 emptyStateTitle="Documents"
                 onAddDocumentsActionChange={
                     workspace.setAddDocumentsHeaderAction
+                }
+                onUploadFolderActionChange={
+                    handleUploadFolderActionChange
                 }
                 onCreateFolderActionChange={handleCreateFolderActionChange}
                 onFolderViewBackActionChange={handleFolderBackActionChange}

--- a/frontend/src/app/components/projects/ProjectPageParts.tsx
+++ b/frontend/src/app/components/projects/ProjectPageParts.tsx
@@ -399,7 +399,7 @@ export function ProjectPageHeader({
                   onClick: onAddDocuments ?? undefined,
                   disabled: !onAddDocuments,
                   icon: <Upload className="h-4 w-4" />,
-                  label: <span className="hidden sm:inline">Documents</span>,
+                  iconOnly: true,
                   title: "Add documents",
               }
             : activeSection === "assistant"

--- a/frontend/src/app/components/projects/ProjectPageParts.tsx
+++ b/frontend/src/app/components/projects/ProjectPageParts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type CSSProperties, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import {
     CornerDownRight,
     Loader2,
@@ -19,7 +19,10 @@ import type { Project } from "@/app/components/shared/types";
 import type { DocumentVersion } from "@/app/lib/mikeApi";
 import { RowActions } from "@/app/components/shared/RowActions";
 import { HeaderActionsMenu } from "@/app/components/shared/HeaderActionsMenu";
-import { TABLE_PRIMARY_CELL_WIDTH_CLASS } from "@/app/components/shared/TablePrimitive";
+import {
+    TABLE_PRIMARY_CELL_WIDTH_CLASS,
+    tableTreeCellStyle,
+} from "@/app/components/shared/TablePrimitive";
 
 export type ProjectWorkspaceSection = "documents" | "assistant" | "reviews";
 
@@ -35,17 +38,7 @@ export const NAME_COL_W = TABLE_PRIMARY_CELL_WIDTH_CLASS;
 export const DOC_NAME_COL_W =
     "w-[292px] sm:w-[332px] md:w-[392px] lg:w-[452px] xl:w-[532px] 2xl:w-[592px] shrink-0";
 
-// Each nested row advances by the checkbox width (10px) plus the 12px gap,
-// placing its checkbox directly beneath its parent folder's chevron.
-const TREE_CONTROL_WIDTH_PX = 22;
-const TREE_NAME_PADDING_PX = 12;
-
-export function treeNameCellStyle(depth: number): CSSProperties | undefined {
-    if (depth <= 0) return undefined;
-    return {
-        paddingLeft: TREE_NAME_PADDING_PX + depth * TREE_CONTROL_WIDTH_PX,
-    };
-}
+export const treeNameCellStyle = tableTreeCellStyle;
 
 export function formatBytes(bytes: number): string {
     if (bytes < 1024) return `${bytes} B`;

--- a/frontend/src/app/components/projects/ProjectReviewsTable.tsx
+++ b/frontend/src/app/components/projects/ProjectReviewsTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Dispatch, SetStateAction } from "react";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import {
     RowActionMenuItems,
     RowActions,
@@ -262,7 +262,6 @@ export function ProjectReviewsTable({
                                     }
                                     className="px-3"
                                 >
-                                    <Plus className="h-3.5 w-3.5" />
                                     Create
                                 </PillButton>
                             }

--- a/frontend/src/app/components/projects/ProjectsOverview.tsx
+++ b/frontend/src/app/components/projects/ProjectsOverview.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ChevronDown, Plus } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import {
     getProjectFilterOptions,
     type ProjectFilterOptions,
@@ -591,7 +591,6 @@ export function ProjectsOverview() {
                                         onClick={() => setModalOpen(true)}
                                         className="px-3"
                                     >
-                                        <Plus className="h-3.5 w-3.5" />
                                         Create
                                     </PillButton>
                                 }

--- a/frontend/src/app/components/shared/FileDirectory.test.tsx
+++ b/frontend/src/app/components/shared/FileDirectory.test.tsx
@@ -117,18 +117,94 @@ describe("FileDirectory", () => {
         const nameHeader = screen.getByText("Name");
         expect(nameHeader.parentElement?.firstElementChild).toBe(nameHeader);
 
-        const folderRow = screen
-            .getByText("Closing documents")
-            .closest("button");
-        expect(folderRow).toHaveStyle({ paddingLeft: "8px" });
+        const folderRow = screen.getByRole("button", {
+            name: "Expand Closing documents",
+        });
+        expect(folderRow.parentElement).toHaveStyle({ paddingLeft: "8px" });
         fireEvent.click(folderRow!);
 
         expect(screen.getByText("Agreement.pdf")).toBeInTheDocument();
-        expect(screen.getByText("Agreement.pdf").closest("button")).toHaveStyle(
+        expect(screen.getByText("Agreement.pdf").closest("label")).toHaveStyle(
             {
                 paddingLeft: "30px",
             },
         );
+    });
+
+    it("renders folder selection and expansion as sibling controls", () => {
+        const onChange = vi.fn();
+        const folder = {
+            id: "folder-1",
+            name: "Closing documents",
+            parent_folder_id: null,
+            created_at: "2026-08-03T00:00:00.000Z",
+        } as Folder;
+        const document = {
+            id: "document-1",
+            filename: "Agreement.pdf",
+            file_type: "pdf",
+            folder_id: folder.id,
+        } as Document;
+
+        render(
+            <FileDirectory
+                documents={[document]}
+                folders={[folder]}
+                selectedDocuments={[]}
+                onChange={onChange}
+                showTabs={false}
+                loadedFolderIds={new Set([folder.id])}
+            />,
+        );
+
+        const checkbox = screen.getByRole("checkbox", {
+            name: "Select all files in Closing documents",
+        });
+        const expandButton = screen.getByRole("button", {
+            name: "Expand Closing documents",
+        });
+
+        expect(checkbox).toHaveAttribute("type", "checkbox");
+        expect(checkbox.parentElement).toBe(expandButton.parentElement);
+        expect(expandButton).not.toContainElement(checkbox);
+
+        checkbox.focus();
+        expect(checkbox).toHaveFocus();
+        fireEvent.click(checkbox);
+        expect(onChange).toHaveBeenCalledWith([document]);
+        expect(screen.queryByText("Agreement.pdf")).not.toBeInTheDocument();
+
+        fireEvent.click(expandButton);
+        expect(screen.getByText("Agreement.pdf")).toBeInTheDocument();
+        const documentCheckbox = screen.getByRole("checkbox", {
+            name: "Select Agreement.pdf",
+        });
+        expect(documentCheckbox).toHaveAttribute("type", "checkbox");
+        expect(documentCheckbox.closest("label")).toContainElement(
+            screen.getByText("Agreement.pdf"),
+        );
+    });
+
+    it("renders project selection outside the project row button", () => {
+        render(
+            <FileDirectory
+                selectedDocuments={[]}
+                onChange={vi.fn()}
+                showTabs
+                initialTab="projects"
+            />,
+        );
+
+        const checkbox = screen.getByRole("checkbox", {
+            name: "Expand Acquisition and load all files before selecting it",
+        });
+        const expandButton = screen.getByRole("button", {
+            name: "Expand Acquisition",
+        });
+
+        expect(checkbox).toBeDisabled();
+        expect(checkbox.parentElement).toBe(expandButton.parentElement);
+        expect(expandButton).not.toContainElement(checkbox);
     });
 
     it("renders folders inside projects on the Projects tab", () => {
@@ -191,11 +267,12 @@ describe("FileDirectory", () => {
             />,
         );
 
-        const row = screen
-            .getByText("Existing agreement.pdf")
-            .closest("button");
-        expect(row).toBeDisabled();
-        fireEvent.click(row!);
+        const checkbox = screen.getByRole("checkbox", {
+            name: "Select Existing agreement.pdf",
+        });
+        expect(checkbox).toBeChecked();
+        expect(checkbox).toBeDisabled();
+        fireEvent.click(screen.getByText("Existing agreement.pdf"));
         expect(onChange).not.toHaveBeenCalled();
     });
 

--- a/frontend/src/app/components/shared/FileDirectory.tsx
+++ b/frontend/src/app/components/shared/FileDirectory.tsx
@@ -12,7 +12,6 @@ import { Loader2 } from "lucide-react";
 import type { Document, LibraryFolder, Project } from "./types";
 import { FileTypeIcon } from "./FileTypeIcon";
 import { ProjectSvgIcon, SubfolderSvgIcon } from "./FolderSvgIcon";
-import { CheckSquare } from "@/app/components/ui/check-square";
 import { SearchBar } from "@/app/components/ui/search-bar";
 import { TabPillButton } from "@/app/components/ui/tab-pill-button";
 import { SkeletonLine } from "./TablePrimitive";
@@ -35,6 +34,10 @@ type DirectoryFolder = Pick<
 
 const DIRECTORY_GRID_CLASS =
     "grid grid-cols-[14px_14px_minmax(0,1fr)_48px_84px_64px] items-center gap-2";
+const DIRECTORY_ROW_ACTION_CLASS =
+    "col-span-5 grid min-w-0 grid-cols-[14px_minmax(0,1fr)_48px_84px_64px] items-center gap-2 text-left";
+const DIRECTORY_CHECKBOX_CLASS =
+    "h-2.5 w-2.5 shrink-0 justify-self-center cursor-pointer rounded border-gray-200 accent-black disabled:cursor-not-allowed";
 
 const DIRECTORY_TABS: { value: DirectoryTab; label: string }[] = [
     { value: "files", label: "Files" },
@@ -54,6 +57,41 @@ const EMPTY_LEVEL_STATE: Record<
   Record<string, boolean>
 > = { files: {}, templates: {} };
 const DIRECTORY_SEARCH_PAGE_SIZE = 40;
+
+function DirectorySelectionCheckbox({
+  checked,
+  disabled,
+  indeterminate,
+  label,
+  onChange,
+}: {
+  checked: boolean;
+  disabled: boolean;
+  indeterminate: boolean;
+  label: string;
+  onChange: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="checkbox"
+      checked={checked}
+      disabled={disabled}
+      onChange={onChange}
+      aria-checked={indeterminate ? "mixed" : checked}
+      aria-label={label}
+      className={DIRECTORY_CHECKBOX_CLASS}
+    />
+  );
+}
 
 function mergeDirectoryRows<T extends { id: string }>(current: T[], next: T[]) {
   const rows = new Map(current.map((row) => [row.id, row]));
@@ -584,17 +622,22 @@ export function FileDirectory({
         const selected = checkedIds.has(doc.id);
         const disabled = disabledDocumentIds?.has(doc.id) ?? false;
         return (
-            <button
-                type="button"
+            <label
                 key={doc.id}
-                onClick={() => toggle(doc)}
-                disabled={disabled}
                 style={{ paddingLeft: indentedRowPadding(depth) }}
-                className={`w-full rounded-md ${DIRECTORY_GRID_CLASS} py-2 pr-2 text-xs transition-all text-left disabled:cursor-not-allowed disabled:opacity-50 ${
+                className={`w-full rounded-md ${DIRECTORY_GRID_CLASS} py-2 pr-2 text-left text-xs transition-all ${
+                    disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"
+                } ${
           selected ? APP_SURFACE_ACTIVE_CLASS : APP_SURFACE_HOVER_CLASS
                 }`}
             >
-                <CheckSquare state={selected ? "checked" : "unchecked"} />
+                <DirectorySelectionCheckbox
+                    checked={selected}
+                    indeterminate={false}
+                    disabled={disabled}
+                    label={`Select ${doc.filename}`}
+                    onChange={() => toggle(doc)}
+                />
                 <DocFileIcon fileType={doc.file_type} />
                 <span
           className={`min-w-0 truncate ${selected ? "text-gray-900" : "text-gray-700"}`}
@@ -606,7 +649,7 @@ export function FileDirectory({
                     created={formatDate(doc.created_at)}
                     size={formatBytes(doc.size_bytes)}
                 />
-            </button>
+            </label>
         );
     }
 
@@ -639,41 +682,37 @@ export function FileDirectory({
             const isExpanded = !!q || expandedLibraryFolders.has(folder.id);
             return (
                 <div key={folder.id}>
-                    <button
-                        type="button"
-            onClick={() =>
-              toggleLibraryFolder(folder.id, libraryTab, projectId)
-            }
+                    <div
                         style={{ paddingLeft: indentedRowPadding(depth) }}
-                        className={`w-full rounded-md ${DIRECTORY_GRID_CLASS} py-2 pr-2 text-xs transition-all text-left ${APP_SURFACE_HOVER_CLASS}`}
+                        className={`w-full rounded-md ${DIRECTORY_GRID_CLASS} py-2 pr-2 text-xs transition-all ${APP_SURFACE_HOVER_CLASS}`}
                     >
-                        <CheckSquare
-                            role="checkbox"
-                            aria-checked={someSelected ? "mixed" : allSelected}
-              aria-disabled={!folderSelectionReady}
-              aria-label={
-                folderSelectionReady
-                  ? `Select all files in ${folder.name}`
-                  : `Expand ${folder.name} and load all files before selecting it`
-              }
-                            onClick={(e) => {
-                                e.stopPropagation();
-                if (folderSelectionReady) {
-                                toggleDocuments(docsInFolder);
-                }
-                            }}
-                            state={
-                                allSelected
-                                    ? "checked"
-                                    : someSelected
-                                      ? "indeterminate"
-                                      : "unchecked"
-                            }
-                            muted={
+                        <DirectorySelectionCheckbox
+                            checked={allSelected}
+                            indeterminate={someSelected}
+                            disabled={
                                 !folderSelectionReady ||
                                 docsInFolder.length === 0
                             }
+                            label={
+                                folderSelectionReady
+                                    ? `Select all files in ${folder.name}`
+                                    : `Expand ${folder.name} and load all files before selecting it`
+                            }
+                            onChange={() => toggleDocuments(docsInFolder)}
                         />
+                        <button
+                            type="button"
+                            aria-expanded={isExpanded}
+                            aria-label={`${isExpanded ? "Collapse" : "Expand"} ${folder.name}`}
+                            onClick={() =>
+                                toggleLibraryFolder(
+                                    folder.id,
+                                    libraryTab,
+                                    projectId,
+                                )
+                            }
+                            className={DIRECTORY_ROW_ACTION_CLASS}
+                        >
             {(libraryTab && loadingFolderIds[libraryTab].has(folder.id)) ||
             (projectId &&
               loadingProjectLevels.has(`${projectId}:${folder.id}`)) ||
@@ -696,7 +735,8 @@ export function FileDirectory({
                             {docsInFolder.length}{" "}
                             {docsInFolder.length === 1 ? "file" : "files"}
                         </span>
-                    </button>
+                        </button>
+                    </div>
                     {isExpanded && (
                         <div>
                             {renderFolderRows(
@@ -1070,42 +1110,38 @@ export function FileDirectory({
                   !allProjectDocsSelected;
                             return (
                                 <div key={project.id}>
-                                    <button
-                                        type="button"
-                      onClick={() => toggleFolder(project.id)}
+                                    <div
                                         className={`w-full rounded-md ${DIRECTORY_GRID_CLASS} px-2 py-2 text-xs transition-all text-left ${APP_SURFACE_HOVER_CLASS}`}
                                     >
-                                        <CheckSquare
-                                            role="checkbox"
-                                            aria-checked={
+                                        <DirectorySelectionCheckbox
+                                            checked={allProjectDocsSelected}
+                                            indeterminate={
                                                 someProjectDocsSelected
-                                                    ? "mixed"
-                                                    : allProjectDocsSelected
                                             }
-                        aria-label={
-                          projectSelectionReady
-                            ? `Select all files in ${project.name}`
-                            : `Expand ${project.name} and load all files before selecting it`
-                        }
-                        aria-disabled={!projectSelectionReady}
-                                            onClick={(e) => {
-                                                e.stopPropagation();
-                          if (projectSelectionReady) {
-                                                toggleDocuments(docs);
-                          }
-                                            }}
-                                            state={
-                                                allProjectDocsSelected
-                                                    ? "checked"
-                                                    : someProjectDocsSelected
-                                                      ? "indeterminate"
-                                                      : "unchecked"
-                                            }
-                                            muted={
+                                            disabled={
                                                 !projectSelectionReady ||
                                                 docs.length === 0
                                             }
+                                            label={
+                                                projectSelectionReady
+                                                    ? `Select all files in ${project.name}`
+                                                    : `Expand ${project.name} and load all files before selecting it`
+                                            }
+                                            onChange={() =>
+                                                toggleDocuments(docs)
+                                            }
                                         />
+                                        <button
+                                            type="button"
+                                            aria-expanded={isExpanded}
+                                            aria-label={`${isExpanded ? "Collapse" : "Expand"} ${project.name}`}
+                                            onClick={() =>
+                                                toggleFolder(project.id)
+                                            }
+                                            className={
+                                                DIRECTORY_ROW_ACTION_CLASS
+                                            }
+                                        >
                                         <ProjectSvgIcon
                                             open={isExpanded}
                                             className="h-3.5 w-3.5 shrink-0"
@@ -1125,7 +1161,8 @@ export function FileDirectory({
                                         <span className="truncate text-right text-gray-400">
                         {docs.length} {docs.length === 1 ? "file" : "files"}
                                         </span>
-                                    </button>
+                                        </button>
+                                    </div>
                                     {isExpanded && (
                                         <div>
                         {loadingProjectLevels.has(`${project.id}:root`) ? (

--- a/frontend/src/app/components/shared/TablePrimitive.test.tsx
+++ b/frontend/src/app/components/shared/TablePrimitive.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+    TablePrimaryCell,
+    tableTreeCellStyle,
+} from "./TablePrimitive";
+
+describe("table tree indentation", () => {
+    it("centers each child checkbox beneath its parent chevron", () => {
+        expect(tableTreeCellStyle(1)).toEqual({ paddingLeft: 37 });
+        expect(tableTreeCellStyle(2)).toEqual({ paddingLeft: 62 });
+    });
+
+    it("applies tree indentation to primary cells", () => {
+        render(
+            <TablePrimaryCell
+                label="Nested workflow"
+                selected={false}
+                onSelectionChange={vi.fn()}
+                style={tableTreeCellStyle(1)}
+            />,
+        );
+
+        expect(
+            screen.getByRole("checkbox", {
+                name: "Select Nested workflow",
+            }).parentElement?.parentElement,
+        ).toHaveStyle({ paddingLeft: "37px" });
+    });
+});

--- a/frontend/src/app/components/shared/TablePrimitive.tsx
+++ b/frontend/src/app/components/shared/TablePrimitive.tsx
@@ -4,6 +4,7 @@ import {
     useEffect,
     useRef,
     useState,
+    type CSSProperties,
     type HTMLAttributes,
     type ComponentType,
     type MouseEvent as ReactMouseEvent,
@@ -44,6 +45,22 @@ export const TABLE_PRIMARY_CELL_WIDTH_CLASS =
     "w-[248px] sm:w-[292px] md:w-[332px] shrink-0";
 export const TABLE_CHECKBOX_CLASS =
     "mr-3 h-2.5 w-2.5 shrink-0 rounded border-gray-200 cursor-pointer accent-black";
+
+// A child checkbox is centered beneath its parent folder's 16px chevron.
+// Root padding is 12px; advancing one level crosses the 10px checkbox, its
+// 12px margin, and half the 6px width difference between both controls.
+const TABLE_TREE_ROOT_PADDING_PX = 12;
+const TABLE_TREE_DEPTH_INDENT_PX = 25;
+
+export function tableTreeCellStyle(
+    depth: number,
+): CSSProperties | undefined {
+    if (depth <= 0) return undefined;
+    return {
+        paddingLeft:
+            TABLE_TREE_ROOT_PADDING_PX + depth * TABLE_TREE_DEPTH_INDENT_PX,
+    };
+}
 
 type DivProps = HTMLAttributes<HTMLDivElement>;
 
@@ -329,6 +346,7 @@ export function TableRow({
 export function TableStickyCell({
     children,
     className,
+    style,
     widthClassName = TABLE_PRIMARY_CELL_WIDTH_CLASS,
     bgClassName = TABLE_STICKY_CELL_BG,
     header = false,
@@ -341,6 +359,7 @@ export function TableStickyCell({
 }) {
     return (
         <div
+            style={style}
             className={cn(
                 "sticky left-0 z-[60] flex pl-3 pr-2 text-left",
                 widthClassName,
@@ -360,6 +379,7 @@ export function TableStickyCell({
 export function TablePrimaryCell({
     children,
     className,
+    style,
     widthClassName = TABLE_PRIMARY_CELL_WIDTH_CLASS,
     bgClassName,
     selected,
@@ -412,6 +432,7 @@ export function TablePrimaryCell({
 
     return (
         <TableStickyCell
+            style={style}
             widthClassName={widthClassName}
             bgClassName={selected ? APP_SURFACE_ACTIVE_CLASS : bgClassName}
             className={className}

--- a/frontend/src/app/components/tabular/TabularReviewView.tsx
+++ b/frontend/src/app/components/tabular/TabularReviewView.tsx
@@ -823,11 +823,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                     disabled: loading || savingColumnsConfig,
                                     title: "Add documents",
                                     icon: <Upload className="h-4 w-4" />,
-                                    label: (
-                                        <span className="hidden sm:inline">
-                                            Documents
-                                        </span>
-                                    ),
+                                    iconOnly: true,
                                 },
                             ],
                         },

--- a/frontend/src/app/components/workflows/WorkflowList.tsx
+++ b/frontend/src/app/components/workflows/WorkflowList.tsx
@@ -871,7 +871,7 @@ function WorkflowTable({
                 onClick={onCreate}
                 className="px-3"
               >
-                <Plus className="h-3.5 w-3.5" /> Create
+                Create
               </PillButton>
             }
           />

--- a/frontend/src/app/components/workflows/WorkflowList.tsx
+++ b/frontend/src/app/components/workflows/WorkflowList.tsx
@@ -40,6 +40,7 @@ import {
   SkeletonDot,
   SkeletonLine,
   TABLE_CHECKBOX_CLASS,
+  tableTreeCellStyle,
   TableBody,
   TableCell,
   TableEmptyState,
@@ -1083,7 +1084,7 @@ function AddonTable({
         onClick={() => onOpen(addon)}
       >
         <TablePrimaryCell
-          className={nested ? "pl-12" : undefined}
+          style={nested ? tableTreeCellStyle(1) : undefined}
           label={addon.title}
           selected={selectedIds.includes(addon.id)}
           onSelectionChange={() => toggleOne(addon.id)}

--- a/frontend/src/app/lib/docTableSelection.test.ts
+++ b/frontend/src/app/lib/docTableSelection.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    MULTI_DOCUMENT_DRAG_TYPE,
+    readDocumentDragPayload,
+    selectedDocumentRange,
+    SINGLE_DOCUMENT_DRAG_TYPE,
+    writeDocumentDragPayload,
+} from "./docTableSelection";
+
+describe("DocTable range selection", () => {
+    it("selects every visible row between the anchor and target", () => {
+        expect(
+            selectedDocumentRange(["a", "b", "c", "d"], "b", "d"),
+        ).toEqual(["b", "c", "d"]);
+        expect(
+            selectedDocumentRange(["a", "b", "c", "d"], "d", "b"),
+        ).toEqual(["b", "c", "d"]);
+    });
+
+    it("falls back to the clicked row when the anchor is not visible", () => {
+        expect(selectedDocumentRange(["a", "b"], "missing", "b")).toEqual([
+            "b",
+        ]);
+    });
+});
+
+describe("DocTable document drag payload", () => {
+    it("writes every selected row when dragging an existing selection", () => {
+        const values = new Map<string, string>();
+        const dataTransfer = {
+            setData: vi.fn((type: string, value: string) =>
+                values.set(type, value),
+            ),
+            getData: (type: string) => values.get(type) ?? "",
+            effectAllowed: "none" as DataTransfer["effectAllowed"],
+        };
+
+        expect(
+            writeDocumentDragPayload(dataTransfer, "b", ["a", "b", "c"]),
+        ).toEqual(["a", "b", "c"]);
+        expect(readDocumentDragPayload(dataTransfer)).toEqual([
+            "a",
+            "b",
+            "c",
+        ]);
+        expect(values.has(SINGLE_DOCUMENT_DRAG_TYPE)).toBe(false);
+        expect(values.has(MULTI_DOCUMENT_DRAG_TYPE)).toBe(true);
+        expect(dataTransfer.effectAllowed).toBe("copyMove");
+    });
+
+    it("keeps the legacy single-row payload for version drops", () => {
+        const values = new Map<string, string>();
+        const dataTransfer = {
+            setData: (type: string, value: string) => values.set(type, value),
+            getData: (type: string) => values.get(type) ?? "",
+            effectAllowed: "none" as DataTransfer["effectAllowed"],
+        };
+
+        writeDocumentDragPayload(dataTransfer, "b", ["a"]);
+
+        expect(values.get(SINGLE_DOCUMENT_DRAG_TYPE)).toBe("b");
+        expect(readDocumentDragPayload(dataTransfer)).toEqual(["b"]);
+    });
+});

--- a/frontend/src/app/lib/docTableSelection.test.ts
+++ b/frontend/src/app/lib/docTableSelection.test.ts
@@ -21,6 +21,10 @@ describe("DocTable range selection", () => {
         expect(selectedDocumentRange(["a", "b"], "missing", "b")).toEqual([
             "b",
         ]);
+        expect(selectedDocumentRange(["a", "b"], null, "b")).toEqual(["b"]);
+        expect(selectedDocumentRange(["a", "b"], "a", "missing")).toEqual([
+            "missing",
+        ]);
     });
 });
 
@@ -60,5 +64,33 @@ describe("DocTable document drag payload", () => {
 
         expect(values.get(SINGLE_DOCUMENT_DRAG_TYPE)).toBe("b");
         expect(readDocumentDragPayload(dataTransfer)).toEqual(["b"]);
+    });
+
+    it("deduplicates and filters malformed multi-row payloads", () => {
+        const dataTransfer = {
+            getData: (type: string) =>
+                type === MULTI_DOCUMENT_DRAG_TYPE
+                    ? JSON.stringify(["a", "", "a", 7, "b"])
+                    : "legacy",
+        };
+
+        expect(readDocumentDragPayload(dataTransfer)).toEqual(["a", "b"]);
+    });
+
+    it("falls back to the legacy payload when multi-row data is invalid", () => {
+        expect(
+            readDocumentDragPayload({
+                getData: (type: string) =>
+                    type === MULTI_DOCUMENT_DRAG_TYPE ? "{invalid" : "legacy",
+            }),
+        ).toEqual(["legacy"]);
+        expect(
+            readDocumentDragPayload({
+                getData: (type: string) =>
+                    type === MULTI_DOCUMENT_DRAG_TYPE
+                        ? JSON.stringify({ id: "a" })
+                        : "",
+            }),
+        ).toEqual([]);
     });
 });

--- a/frontend/src/app/lib/docTableSelection.ts
+++ b/frontend/src/app/lib/docTableSelection.ts
@@ -1,0 +1,56 @@
+export const MULTI_DOCUMENT_DRAG_TYPE = "application/mike-docs";
+export const SINGLE_DOCUMENT_DRAG_TYPE = "application/mike-doc";
+
+export function selectedDocumentRange(
+    visibleDocumentIds: readonly string[],
+    anchorId: string | null,
+    targetId: string,
+): string[] {
+    const anchorIndex = anchorId ? visibleDocumentIds.indexOf(anchorId) : -1;
+    const targetIndex = visibleDocumentIds.indexOf(targetId);
+    if (anchorIndex < 0 || targetIndex < 0) return [targetId];
+    const start = Math.min(anchorIndex, targetIndex);
+    const end = Math.max(anchorIndex, targetIndex);
+    return visibleDocumentIds.slice(start, end + 1);
+}
+
+export function writeDocumentDragPayload(
+    dataTransfer: Pick<DataTransfer, "setData" | "effectAllowed">,
+    draggedDocumentId: string,
+    selectedDocumentIds: readonly string[],
+): string[] {
+    const ids = selectedDocumentIds.includes(draggedDocumentId)
+        ? [...selectedDocumentIds]
+        : [draggedDocumentId];
+    dataTransfer.setData(MULTI_DOCUMENT_DRAG_TYPE, JSON.stringify(ids));
+    if (ids.length === 1) {
+        dataTransfer.setData(SINGLE_DOCUMENT_DRAG_TYPE, ids[0]);
+    }
+    dataTransfer.effectAllowed = "copyMove";
+    return ids;
+}
+
+export function readDocumentDragPayload(
+    dataTransfer: Pick<DataTransfer, "getData">,
+): string[] {
+    const encoded = dataTransfer.getData(MULTI_DOCUMENT_DRAG_TYPE);
+    if (encoded) {
+        try {
+            const parsed = JSON.parse(encoded) as unknown;
+            if (Array.isArray(parsed)) {
+                return Array.from(
+                    new Set(
+                        parsed.filter(
+                            (id): id is string =>
+                                typeof id === "string" && id.length > 0,
+                        ),
+                    ),
+                );
+            }
+        } catch {
+            // Fall through to the legacy single-document payload.
+        }
+    }
+    const single = dataTransfer.getData(SINGLE_DOCUMENT_DRAG_TYPE);
+    return single ? [single] : [];
+}

--- a/frontend/src/app/lib/documentDirectoryUpload.test.ts
+++ b/frontend/src/app/lib/documentDirectoryUpload.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
     collectDroppedDocumentUploadEntries,
+    dataTransferHasDirectory,
     DOCUMENT_UPLOAD_CONCURRENCY,
     documentUploadEntriesFromFiles,
     documentUploadFolderSegments,
@@ -21,6 +22,22 @@ function folderFile(name: string, relativePath: string) {
 }
 
 describe("document directory upload paths", () => {
+    it("returns immediately when there is no concurrent work", async () => {
+        const worker = vi.fn(async (value: number) => value);
+
+        await expect(settleWithConcurrency([], 0, worker)).resolves.toEqual([]);
+        expect(worker).not.toHaveBeenCalled();
+    });
+
+    it("clamps non-positive concurrency to one worker", async () => {
+        await expect(
+            settleWithConcurrency([1, 2], 0, async (value) => value * 2),
+        ).resolves.toEqual([
+            { status: "fulfilled", value: 2 },
+            { status: "fulfilled", value: 4 },
+        ]);
+    });
+
     it("keeps directory upload concurrency bounded and preserves result order", async () => {
         let active = 0;
         let maxActive = 0;
@@ -84,6 +101,9 @@ describe("document directory upload paths", () => {
 
         expect(documentUploadPathSegments(entry)).toEqual(["memo.docx"]);
         expect(documentUploadFolderSegments(entry)).toEqual([]);
+        expect(
+            documentUploadPathSegments({ file, relativePath: "" }),
+        ).toEqual(["memo.docx"]);
     });
 
     it("summarizes a selected directory as one top-level folder row", () => {
@@ -111,6 +131,11 @@ describe("document directory upload paths", () => {
             { kind: "folder", name: "Matter" },
             { kind: "file", name: "memo.docx" },
         ]);
+        expect(
+            documentUploadProgressEntries([
+                { file: new File(["memo"], "memo.docx"), relativePath: "." },
+            ]),
+        ).toEqual([{ kind: "file", name: "memo.docx" }]);
     });
 
     it("does not show an unresolved folder as an uploading row", () => {
@@ -196,6 +221,41 @@ describe("document directory upload paths", () => {
         ]);
     });
 
+    it("detects directory entries in a drag payload", () => {
+        const directoryItem = {
+            webkitGetAsEntry: () => ({ isDirectory: true }),
+        };
+        const fileItem = {
+            webkitGetAsEntry: () => ({ isDirectory: false }),
+        };
+
+        expect(
+            dataTransferHasDirectory({
+                items: [fileItem, directoryItem],
+            } as unknown as DataTransfer),
+        ).toBe(true);
+        expect(
+            dataTransferHasDirectory({
+                items: [{}, fileItem],
+            } as unknown as DataTransfer),
+        ).toBe(false);
+    });
+
+    it("falls back to the FileList when directory entry APIs are unavailable", async () => {
+        const file = new File(["memo"], "memo.docx");
+        const dataTransfer = {
+            items: [
+                { kind: "string" },
+                { kind: "file", webkitGetAsEntry: () => null },
+            ],
+            files: [file],
+        } as unknown as DataTransfer;
+
+        await expect(
+            collectDroppedDocumentUploadEntries(dataTransfer),
+        ).resolves.toEqual([{ file, relativePath: "memo.docx" }]);
+    });
+
     it("confirms before creating a suffixed folder", async () => {
         const resolveFolderPath = vi
             .fn()
@@ -232,6 +292,26 @@ describe("document directory upload paths", () => {
             "rename",
         );
         expect(result?.resolved_name).toBe("NDAs (2)");
+    });
+
+    it("returns a conflict-free root folder without prompting", async () => {
+        const resolution = {
+            conflict: false as const,
+            folder_id: "folder-1",
+            resolved_name: "NDAs",
+            folders: [],
+        };
+        const chooseConflict = vi.fn();
+
+        await expect(
+            resolveDocumentUploadRootFolder({
+                rootFolderName: "NDAs",
+                baseFolderId: "parent-1",
+                resolveFolderPath: vi.fn().mockResolvedValue(resolution),
+                chooseConflict,
+            }),
+        ).resolves.toEqual(resolution);
+        expect(chooseConflict).not.toHaveBeenCalled();
     });
 
     it("does not create a suffixed folder when the alert is dismissed", async () => {

--- a/frontend/src/app/lib/documentDirectoryUpload.test.ts
+++ b/frontend/src/app/lib/documentDirectoryUpload.test.ts
@@ -7,6 +7,7 @@ import {
     documentUploadPathSegments,
     documentUploadProgressEntries,
     MAX_DOCUMENTS_PER_DIRECTORY_UPLOAD,
+    resolvedDocumentUploadProgressEntries,
     resolveDocumentUploadRootFolder,
     settleWithConcurrency,
 } from "./documentDirectoryUpload";
@@ -110,6 +111,30 @@ describe("document directory upload paths", () => {
             { kind: "folder", name: "Matter" },
             { kind: "file", name: "memo.docx" },
         ]);
+    });
+
+    it("does not show an unresolved folder as an uploading row", () => {
+        const entries = documentUploadEntriesFromFiles([
+            folderFile("agreement.pdf", "NDAs/agreement.pdf"),
+            new File(["memo"], "memo.docx"),
+        ]);
+
+        expect(
+            resolvedDocumentUploadProgressEntries(entries, new Map()),
+        ).toEqual([{ kind: "file", name: "memo.docx" }]);
+    });
+
+    it("shows the backend-resolved folder name once uploading can begin", () => {
+        const entries = documentUploadEntriesFromFiles([
+            folderFile("agreement.pdf", "NDAs/agreement.pdf"),
+        ]);
+
+        expect(
+            resolvedDocumentUploadProgressEntries(
+                entries,
+                new Map([["NDAs", "NDAs (2)"]]),
+            ),
+        ).toEqual([{ kind: "folder", name: "NDAs (2)" }]);
     });
 
     it("normalizes separators and excludes traversal segments", () => {

--- a/frontend/src/app/lib/documentDirectoryUpload.test.ts
+++ b/frontend/src/app/lib/documentDirectoryUpload.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    collectDroppedDocumentUploadEntries,
+    documentUploadEntriesFromFiles,
+    documentUploadFolderSegments,
+    documentUploadPathSegments,
+    documentUploadProgressEntries,
+    resolveDocumentUploadRootFolder,
+} from "./documentDirectoryUpload";
+
+function folderFile(name: string, relativePath: string) {
+    const file = new File([name], name);
+    Object.defineProperty(file, "webkitRelativePath", {
+        value: relativePath,
+    });
+    return file;
+}
+
+describe("document directory upload paths", () => {
+    it("preserves the selected root folder and nested subfolders", () => {
+        const file = folderFile(
+            "agreement.pdf",
+            "Matter/Contracts/Executed/agreement.pdf",
+        );
+        const [entry] = documentUploadEntriesFromFiles([file]);
+
+        expect(entry.relativePath).toBe(
+            "Matter/Contracts/Executed/agreement.pdf",
+        );
+        expect(documentUploadFolderSegments(entry)).toEqual([
+            "Matter",
+            "Contracts",
+            "Executed",
+        ]);
+    });
+
+    it("uploads ordinary files directly into the target folder", () => {
+        const file = new File(["memo"], "memo.docx");
+        const [entry] = documentUploadEntriesFromFiles([file]);
+
+        expect(documentUploadPathSegments(entry)).toEqual(["memo.docx"]);
+        expect(documentUploadFolderSegments(entry)).toEqual([]);
+    });
+
+    it("summarizes a selected directory as one top-level folder row", () => {
+        const entries = documentUploadEntriesFromFiles([
+            folderFile("agreement.pdf", "Matter/Contracts/agreement.pdf"),
+            folderFile("memo.docx", "Matter/Advice/memo.docx"),
+        ]);
+
+        expect(documentUploadProgressEntries(entries)).toEqual([
+            { kind: "folder", name: "Matter" },
+        ]);
+    });
+
+    it("keeps direct files as file rows alongside dropped folders", () => {
+        const entries = [
+            ...documentUploadEntriesFromFiles([
+                folderFile("agreement.pdf", "Matter/agreement.pdf"),
+            ]),
+            ...documentUploadEntriesFromFiles([
+                new File(["memo"], "memo.docx"),
+            ]),
+        ];
+
+        expect(documentUploadProgressEntries(entries)).toEqual([
+            { kind: "folder", name: "Matter" },
+            { kind: "file", name: "memo.docx" },
+        ]);
+    });
+
+    it("normalizes separators and excludes traversal segments", () => {
+        const file = new File(["memo"], "memo.docx");
+        expect(
+            documentUploadPathSegments({
+                file,
+                relativePath: "Matter\\.\\..\\Advice\\memo.docx",
+            }),
+        ).toEqual(["Matter", "Advice", "memo.docx"]);
+    });
+
+    it("recursively traverses dropped folders and all directory batches", async () => {
+        const agreement = new File(["agreement"], "agreement.pdf");
+        const advice = new File(["advice"], "advice.docx");
+        const fileEntry = (file: File) => ({
+            isFile: true,
+            isDirectory: false,
+            name: file.name,
+            file: (resolve: (value: File) => void) => resolve(file),
+        });
+        const directoryEntry = (
+            name: string,
+            batches: unknown[][],
+        ) => ({
+            isFile: false,
+            isDirectory: true,
+            name,
+            createReader: () => {
+                let index = 0;
+                return {
+                    readEntries: (resolve: (entries: unknown[]) => void) =>
+                        resolve(batches[index++] ?? []),
+                };
+            },
+        });
+        const nested = directoryEntry("Advice", [[fileEntry(advice)], []]);
+        const root = directoryEntry("Matter", [
+            [fileEntry(agreement)],
+            [nested],
+            [],
+        ]);
+        const dataTransfer = {
+            items: [
+                {
+                    kind: "file",
+                    webkitGetAsEntry: () => root,
+                },
+            ],
+            files: [],
+        } as unknown as DataTransfer;
+
+        const entries = await collectDroppedDocumentUploadEntries(
+            dataTransfer,
+        );
+        expect(entries.map((entry) => entry.relativePath)).toEqual([
+            "Matter/agreement.pdf",
+            "Matter/Advice/advice.docx",
+        ]);
+    });
+
+    it("deletes an existing folder before resolving a replacement", async () => {
+        const calls: string[] = [];
+        const resolveFolderPath = vi
+            .fn()
+            .mockImplementationOnce(async () => ({
+                conflict: true as const,
+                folder_name: "NDAs",
+                existing_folder_id: "old-folder",
+                suggested_name: "NDAs (2)",
+                can_replace: true,
+            }))
+            .mockImplementationOnce(async () => {
+                calls.push("resolve-new-folder");
+                return {
+                    conflict: false as const,
+                    folder_id: "new-folder",
+                    resolved_name: "NDAs",
+                    folders: [],
+                };
+            });
+        const replaceFolder = vi.fn(async () => {
+            calls.push("delete-old-folder");
+        });
+
+        const result = await resolveDocumentUploadRootFolder({
+            rootFolderName: "NDAs",
+            baseFolderId: null,
+            resolveFolderPath,
+            chooseConflict: async () => "replace",
+            replaceFolder,
+        });
+
+        expect(calls).toEqual(["delete-old-folder", "resolve-new-folder"]);
+        expect(replaceFolder).toHaveBeenCalledWith("old-folder");
+        expect(result).toMatchObject({
+            conflict: false,
+            folder_id: "new-folder",
+            resolved_name: "NDAs",
+        });
+    });
+
+    it("creates a suffixed folder without deleting the existing one", async () => {
+        const resolveFolderPath = vi
+            .fn()
+            .mockResolvedValueOnce({
+                conflict: true as const,
+                folder_name: "NDAs",
+                existing_folder_id: "old-folder",
+                suggested_name: "NDAs (2)",
+                can_replace: true,
+            })
+            .mockResolvedValueOnce({
+                conflict: false as const,
+                folder_id: "new-folder",
+                resolved_name: "NDAs (2)",
+                folders: [],
+            });
+        const replaceFolder = vi.fn(async () => {});
+
+        const result = await resolveDocumentUploadRootFolder({
+            rootFolderName: "NDAs",
+            baseFolderId: null,
+            resolveFolderPath,
+            chooseConflict: async () => "rename",
+            replaceFolder,
+        });
+
+        expect(replaceFolder).not.toHaveBeenCalled();
+        expect(resolveFolderPath).toHaveBeenLastCalledWith(
+            ["NDAs"],
+            null,
+            "rename",
+        );
+        expect(result?.resolved_name).toBe("NDAs (2)");
+    });
+});

--- a/frontend/src/app/lib/documentDirectoryUpload.test.ts
+++ b/frontend/src/app/lib/documentDirectoryUpload.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import {
     collectDroppedDocumentUploadEntries,
+    DOCUMENT_UPLOAD_CONCURRENCY,
     documentUploadEntriesFromFiles,
     documentUploadFolderSegments,
     documentUploadPathSegments,
     documentUploadProgressEntries,
+    MAX_DOCUMENTS_PER_DIRECTORY_UPLOAD,
     resolveDocumentUploadRootFolder,
+    settleWithConcurrency,
 } from "./documentDirectoryUpload";
 
 function folderFile(name: string, relativePath: string) {
@@ -17,6 +20,46 @@ function folderFile(name: string, relativePath: string) {
 }
 
 describe("document directory upload paths", () => {
+    it("keeps directory upload concurrency bounded and preserves result order", async () => {
+        let active = 0;
+        let maxActive = 0;
+        let releaseFirstWave = () => {};
+        const firstWave = new Promise<void>((resolve) => {
+            releaseFirstWave = resolve;
+        });
+
+        const pending = settleWithConcurrency(
+            [0, 1, 2, 3],
+            DOCUMENT_UPLOAD_CONCURRENCY,
+            async (value) => {
+                active += 1;
+                maxActive = Math.max(maxActive, active);
+                if (value < DOCUMENT_UPLOAD_CONCURRENCY) await firstWave;
+                active -= 1;
+                if (value === 2) throw new Error("upload failed");
+                return value * 2;
+            },
+        );
+
+        await vi.waitFor(() =>
+            expect(active).toBe(DOCUMENT_UPLOAD_CONCURRENCY),
+        );
+        expect(maxActive).toBe(DOCUMENT_UPLOAD_CONCURRENCY);
+        releaseFirstWave();
+
+        await expect(pending).resolves.toEqual([
+            { status: "fulfilled", value: 0 },
+            { status: "fulfilled", value: 2 },
+            { status: "rejected", reason: expect.any(Error) },
+            { status: "fulfilled", value: 6 },
+        ]);
+        expect(maxActive).toBe(DOCUMENT_UPLOAD_CONCURRENCY);
+    });
+
+    it("caps a directory upload at the backend hourly request limit", () => {
+        expect(MAX_DOCUMENTS_PER_DIRECTORY_UPLOAD).toBe(50);
+    });
+
     it("preserves the selected root folder and nested subfolders", () => {
         const file = folderFile(
             "agreement.pdf",

--- a/frontend/src/app/lib/documentDirectoryUpload.test.ts
+++ b/frontend/src/app/lib/documentDirectoryUpload.test.ts
@@ -171,48 +171,7 @@ describe("document directory upload paths", () => {
         ]);
     });
 
-    it("deletes an existing folder before resolving a replacement", async () => {
-        const calls: string[] = [];
-        const resolveFolderPath = vi
-            .fn()
-            .mockImplementationOnce(async () => ({
-                conflict: true as const,
-                folder_name: "NDAs",
-                existing_folder_id: "old-folder",
-                suggested_name: "NDAs (2)",
-                can_replace: true,
-            }))
-            .mockImplementationOnce(async () => {
-                calls.push("resolve-new-folder");
-                return {
-                    conflict: false as const,
-                    folder_id: "new-folder",
-                    resolved_name: "NDAs",
-                    folders: [],
-                };
-            });
-        const replaceFolder = vi.fn(async () => {
-            calls.push("delete-old-folder");
-        });
-
-        const result = await resolveDocumentUploadRootFolder({
-            rootFolderName: "NDAs",
-            baseFolderId: null,
-            resolveFolderPath,
-            chooseConflict: async () => "replace",
-            replaceFolder,
-        });
-
-        expect(calls).toEqual(["delete-old-folder", "resolve-new-folder"]);
-        expect(replaceFolder).toHaveBeenCalledWith("old-folder");
-        expect(result).toMatchObject({
-            conflict: false,
-            folder_id: "new-folder",
-            resolved_name: "NDAs",
-        });
-    });
-
-    it("creates a suffixed folder without deleting the existing one", async () => {
+    it("confirms before creating a suffixed folder", async () => {
         const resolveFolderPath = vi
             .fn()
             .mockResolvedValueOnce({
@@ -220,7 +179,6 @@ describe("document directory upload paths", () => {
                 folder_name: "NDAs",
                 existing_folder_id: "old-folder",
                 suggested_name: "NDAs (2)",
-                can_replace: true,
             })
             .mockResolvedValueOnce({
                 conflict: false as const,
@@ -228,22 +186,45 @@ describe("document directory upload paths", () => {
                 resolved_name: "NDAs (2)",
                 folders: [],
             });
-        const replaceFolder = vi.fn(async () => {});
+        const chooseConflict = vi.fn(async () => "rename" as const);
 
         const result = await resolveDocumentUploadRootFolder({
             rootFolderName: "NDAs",
             baseFolderId: null,
             resolveFolderPath,
-            chooseConflict: async () => "rename",
-            replaceFolder,
+            chooseConflict,
         });
 
-        expect(replaceFolder).not.toHaveBeenCalled();
+        expect(chooseConflict).toHaveBeenCalledWith({
+            conflict: true,
+            folder_name: "NDAs",
+            existing_folder_id: "old-folder",
+            suggested_name: "NDAs (2)",
+        });
         expect(resolveFolderPath).toHaveBeenLastCalledWith(
             ["NDAs"],
             null,
             "rename",
         );
         expect(result?.resolved_name).toBe("NDAs (2)");
+    });
+
+    it("does not create a suffixed folder when the alert is dismissed", async () => {
+        const resolveFolderPath = vi.fn().mockResolvedValue({
+            conflict: true as const,
+            folder_name: "NDAs",
+            existing_folder_id: "old-folder",
+            suggested_name: "NDAs (2)",
+        });
+
+        const result = await resolveDocumentUploadRootFolder({
+            rootFolderName: "NDAs",
+            baseFolderId: null,
+            resolveFolderPath,
+            chooseConflict: async () => "cancel",
+        });
+
+        expect(result).toBeNull();
+        expect(resolveFolderPath).toHaveBeenCalledTimes(1);
     });
 });

--- a/frontend/src/app/lib/documentDirectoryUpload.ts
+++ b/frontend/src/app/lib/documentDirectoryUpload.ts
@@ -1,0 +1,223 @@
+export type DocumentUploadEntry = {
+    file: File;
+    relativePath: string;
+};
+
+export type DocumentUploadProgressEntry = {
+    kind: "file" | "folder";
+    name: string;
+};
+
+export type DocumentUploadFolderPathResolution<TFolder> =
+    | {
+          conflict: true;
+          folder_name: string;
+          existing_folder_id: string;
+          suggested_name: string;
+          can_replace: boolean;
+      }
+    | {
+          conflict: false;
+          folder_id: string;
+          resolved_name: string;
+          folders: TFolder[];
+      };
+
+export async function resolveDocumentUploadRootFolder<TFolder>({
+    rootFolderName,
+    baseFolderId,
+    resolveFolderPath,
+    chooseConflict,
+    replaceFolder,
+}: {
+    rootFolderName: string;
+    baseFolderId: string | null;
+    resolveFolderPath: (
+        segments: string[],
+        baseFolderId: string | null,
+        conflictResolution?: "error" | "reuse" | "rename",
+    ) => Promise<DocumentUploadFolderPathResolution<TFolder>>;
+    chooseConflict: (
+        conflict: Extract<
+            DocumentUploadFolderPathResolution<TFolder>,
+            { conflict: true }
+        >,
+    ) => Promise<"replace" | "rename" | "cancel">;
+    replaceFolder: (folderId: string) => Promise<void>;
+}): Promise<
+    | Extract<
+          DocumentUploadFolderPathResolution<TFolder>,
+          { conflict: false }
+      >
+    | null
+> {
+    let resolution = await resolveFolderPath(
+        [rootFolderName],
+        baseFolderId,
+    );
+    while (resolution.conflict) {
+        const choice = await chooseConflict(resolution);
+        if (choice === "cancel") return null;
+        if (choice === "replace") {
+            await replaceFolder(resolution.existing_folder_id);
+            resolution = await resolveFolderPath(
+                [rootFolderName],
+                baseFolderId,
+            );
+        } else {
+            resolution = await resolveFolderPath(
+                [rootFolderName],
+                baseFolderId,
+                "rename",
+            );
+        }
+    }
+    return resolution;
+}
+
+type DroppedFileEntry = {
+    isFile: true;
+    isDirectory: false;
+    name: string;
+    file: (
+        success: (file: File) => void,
+        error?: (error: DOMException) => void,
+    ) => void;
+};
+
+type DroppedDirectoryReader = {
+    readEntries: (
+        success: (entries: DroppedEntry[]) => void,
+        error?: (error: DOMException) => void,
+    ) => void;
+};
+
+type DroppedDirectoryEntry = {
+    isFile: false;
+    isDirectory: true;
+    name: string;
+    createReader: () => DroppedDirectoryReader;
+};
+
+type DroppedEntry = DroppedFileEntry | DroppedDirectoryEntry;
+
+type DirectoryDataTransferItem = {
+    webkitGetAsEntry?: () => DroppedEntry | null;
+};
+
+export function documentUploadEntriesFromFiles(
+    files: Iterable<File>,
+): DocumentUploadEntry[] {
+    return Array.from(files, (file) => ({
+        file,
+        relativePath: file.webkitRelativePath || file.name,
+    }));
+}
+
+export function documentUploadPathSegments(
+    entry: Pick<DocumentUploadEntry, "relativePath" | "file">,
+): string[] {
+    const path = entry.relativePath || entry.file.name;
+    return path
+        .replace(/\\/g, "/")
+        .split("/")
+        .map((segment) => segment.trim())
+        .filter(
+            (segment) =>
+                segment.length > 0 && segment !== "." && segment !== "..",
+        );
+}
+
+export function documentUploadFolderSegments(
+    entry: Pick<DocumentUploadEntry, "relativePath" | "file">,
+): string[] {
+    return documentUploadPathSegments(entry).slice(0, -1);
+}
+
+export function documentUploadProgressEntries(
+    entries: readonly DocumentUploadEntry[],
+): DocumentUploadProgressEntry[] {
+    const progressEntries: DocumentUploadProgressEntry[] = [];
+    const folderNames = new Set<string>();
+
+    for (const entry of entries) {
+        const segments = documentUploadPathSegments(entry);
+        if (segments.length > 1) {
+            const folderName = segments[0];
+            if (!folderNames.has(folderName)) {
+                folderNames.add(folderName);
+                progressEntries.push({ kind: "folder", name: folderName });
+            }
+            continue;
+        }
+        progressEntries.push({
+            kind: "file",
+            name: segments[0] ?? entry.file.name,
+        });
+    }
+
+    return progressEntries;
+}
+
+export function dataTransferHasDirectory(dataTransfer: DataTransfer): boolean {
+    return Array.from(dataTransfer.items).some((item) => {
+        const entry = (item as unknown as DirectoryDataTransferItem)
+            .webkitGetAsEntry?.();
+        return entry?.isDirectory === true;
+    });
+}
+
+function readFile(entry: DroppedFileEntry): Promise<File> {
+    return new Promise((resolve, reject) => entry.file(resolve, reject));
+}
+
+async function readDirectoryEntries(
+    entry: DroppedDirectoryEntry,
+): Promise<DroppedEntry[]> {
+    const reader = entry.createReader();
+    const result: DroppedEntry[] = [];
+    while (true) {
+        const batch = await new Promise<DroppedEntry[]>((resolve, reject) =>
+            reader.readEntries(resolve, reject),
+        );
+        if (batch.length === 0) return result;
+        result.push(...batch);
+    }
+}
+
+async function walkDroppedEntry(
+    entry: DroppedEntry,
+    parentPath: string,
+): Promise<DocumentUploadEntry[]> {
+    const relativePath = parentPath
+        ? `${parentPath}/${entry.name}`
+        : entry.name;
+    if (entry.isFile) {
+        const file = await readFile(entry);
+        return [{ file, relativePath }];
+    }
+
+    const children = await readDirectoryEntries(entry);
+    return (
+        await Promise.all(
+            children.map((child) => walkDroppedEntry(child, relativePath)),
+        )
+    ).flat();
+}
+
+export async function collectDroppedDocumentUploadEntries(
+    dataTransfer: DataTransfer,
+): Promise<DocumentUploadEntry[]> {
+    const entries = Array.from(dataTransfer.items)
+        .filter((item) => item.kind === "file")
+        .map((item) =>
+            (item as unknown as DirectoryDataTransferItem)
+                .webkitGetAsEntry?.(),
+        )
+        .filter((entry): entry is DroppedEntry => !!entry);
+
+    if (entries.length === 0) {
+        return documentUploadEntriesFromFiles(dataTransfer.files);
+    }
+    return (await Promise.all(entries.map((entry) => walkDroppedEntry(entry, "")))).flat();
+}

--- a/frontend/src/app/lib/documentDirectoryUpload.ts
+++ b/frontend/src/app/lib/documentDirectoryUpload.ts
@@ -17,7 +17,6 @@ export type DocumentUploadFolderPathResolution<TFolder> =
           folder_name: string;
           existing_folder_id: string;
           suggested_name: string;
-          can_replace: boolean;
       }
     | {
           conflict: false;
@@ -63,7 +62,6 @@ export async function resolveDocumentUploadRootFolder<TFolder>({
     baseFolderId,
     resolveFolderPath,
     chooseConflict,
-    replaceFolder,
 }: {
     rootFolderName: string;
     baseFolderId: string | null;
@@ -77,8 +75,7 @@ export async function resolveDocumentUploadRootFolder<TFolder>({
             DocumentUploadFolderPathResolution<TFolder>,
             { conflict: true }
         >,
-    ) => Promise<"replace" | "rename" | "cancel">;
-    replaceFolder: (folderId: string) => Promise<void>;
+    ) => Promise<"rename" | "cancel">;
 }): Promise<
     | Extract<
           DocumentUploadFolderPathResolution<TFolder>,
@@ -93,19 +90,11 @@ export async function resolveDocumentUploadRootFolder<TFolder>({
     while (resolution.conflict) {
         const choice = await chooseConflict(resolution);
         if (choice === "cancel") return null;
-        if (choice === "replace") {
-            await replaceFolder(resolution.existing_folder_id);
-            resolution = await resolveFolderPath(
-                [rootFolderName],
-                baseFolderId,
-            );
-        } else {
-            resolution = await resolveFolderPath(
-                [rootFolderName],
-                baseFolderId,
-                "rename",
-            );
-        }
+        resolution = await resolveFolderPath(
+            [rootFolderName],
+            baseFolderId,
+            "rename",
+        );
     }
     return resolution;
 }

--- a/frontend/src/app/lib/documentDirectoryUpload.ts
+++ b/frontend/src/app/lib/documentDirectoryUpload.ts
@@ -3,6 +3,9 @@ export type DocumentUploadEntry = {
     relativePath: string;
 };
 
+export const MAX_DOCUMENTS_PER_DIRECTORY_UPLOAD = 50;
+export const DOCUMENT_UPLOAD_CONCURRENCY = 2;
+
 export type DocumentUploadProgressEntry = {
     kind: "file" | "folder";
     name: string;
@@ -22,6 +25,38 @@ export type DocumentUploadFolderPathResolution<TFolder> =
           resolved_name: string;
           folders: TFolder[];
       };
+
+export async function settleWithConcurrency<TItem, TResult>(
+    items: readonly TItem[],
+    concurrency: number,
+    worker: (item: TItem, index: number) => Promise<TResult>,
+): Promise<PromiseSettledResult<TResult>[]> {
+    if (items.length === 0) return [];
+    const results = new Array<PromiseSettledResult<TResult>>(items.length);
+    const workerCount = Math.min(
+        items.length,
+        Math.max(1, Math.floor(concurrency)),
+    );
+    let nextIndex = 0;
+
+    const runWorker = async () => {
+        while (nextIndex < items.length) {
+            const index = nextIndex;
+            nextIndex += 1;
+            try {
+                results[index] = {
+                    status: "fulfilled",
+                    value: await worker(items[index], index),
+                };
+            } catch (reason) {
+                results[index] = { status: "rejected", reason };
+            }
+        }
+    };
+
+    await Promise.all(Array.from({ length: workerCount }, runWorker));
+    return results;
+}
 
 export async function resolveDocumentUploadRootFolder<TFolder>({
     rootFolderName,

--- a/frontend/src/app/lib/documentDirectoryUpload.ts
+++ b/frontend/src/app/lib/documentDirectoryUpload.ts
@@ -183,6 +183,19 @@ export function documentUploadProgressEntries(
     return progressEntries;
 }
 
+export function resolvedDocumentUploadProgressEntries(
+    entries: readonly DocumentUploadEntry[],
+    resolvedRootFolderNames: ReadonlyMap<string, string>,
+): DocumentUploadProgressEntry[] {
+    return documentUploadProgressEntries(entries).flatMap((entry) => {
+        if (entry.kind === "file") return [entry];
+        const resolvedName = resolvedRootFolderNames.get(entry.name);
+        return resolvedName
+            ? [{ ...entry, name: resolvedName }]
+            : [];
+    });
+}
+
 export function dataTransferHasDirectory(dataTransfer: DataTransfer): boolean {
     return Array.from(dataTransfer.items).some((item) => {
         const entry = (item as unknown as DirectoryDataTransferItem)

--- a/frontend/src/app/lib/mikeApi.test.ts
+++ b/frontend/src/app/lib/mikeApi.test.ts
@@ -113,6 +113,8 @@ import {
     renameProjectFolder,
     renameTabularChat,
     replaceDocumentVersionFile,
+    resolveLibraryFolderPath,
+    resolveProjectFolderPath,
     resolveDocumentEdit,
     saveApiKey,
     bulkDeleteLibraryDocuments,
@@ -1601,6 +1603,20 @@ describe("multipart upload endpoints", () => {
         expect(init.headers).toEqual({ Authorization: "Bearer token-123" });
     });
 
+    it("includes the destination folder in project and library uploads", async () => {
+        fetchMock.mockImplementation(() =>
+            Promise.resolve(jsonResponse({ id: "d1" })),
+        );
+
+        await uploadProjectDocument("p1", file, "project-folder");
+        let body = lastFetchCall().init.body as FormData;
+        expect(body.get("folder_id")).toBe("project-folder");
+
+        await uploadLibraryDocument("files", file, "library-folder");
+        body = lastFetchCall().init.body as FormData;
+        expect(body.get("folder_id")).toBe("library-folder");
+    });
+
     it("multipart upload failures use the sanitized API error contract", async () => {
         fetchMock.mockImplementation(() =>
             Promise.resolve(new Response("file too large", { status: 413 })),
@@ -1776,6 +1792,46 @@ describe("query and payload defaults", () => {
         expect(JSON.parse(lastFetchCall().init.body as string)).toEqual({
             name: "Precedents",
             parent_folder_id: "parent-1",
+        });
+    });
+
+    it("resolves project and library upload paths with conflict choices", async () => {
+        fetchMock.mockImplementation(() =>
+            Promise.resolve(
+                jsonResponse({
+                    conflict: false,
+                    folder_id: "f1",
+                    resolved_name: "NDAs (2)",
+                    folders: [],
+                }),
+            ),
+        );
+
+        await resolveProjectFolderPath("p1", ["NDAs"], null, "rename");
+        let call = lastFetchCall();
+        expect(call.url).toBe(
+            "http://localhost:3001/projects/p1/folder-paths/resolve",
+        );
+        expect(JSON.parse(call.init.body as string)).toEqual({
+            segments: ["NDAs"],
+            base_folder_id: null,
+            conflict_resolution: "rename",
+        });
+
+        await resolveLibraryFolderPath(
+            "templates",
+            ["Executed", "2026"],
+            "parent-1",
+            "reuse",
+        );
+        call = lastFetchCall();
+        expect(call.url).toBe(
+            "http://localhost:3001/library/templates/folder-paths/resolve",
+        );
+        expect(JSON.parse(call.init.body as string)).toEqual({
+            segments: ["Executed", "2026"],
+            base_folder_id: "parent-1",
+            conflict_resolution: "reuse",
         });
     });
 

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -774,7 +774,6 @@ export type FolderPathResolution<TFolder> =
           folder_name: string;
           existing_folder_id: string;
           suggested_name: string;
-          can_replace: boolean;
       }
     | {
           conflict: false;

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -766,6 +766,43 @@ export async function getProjectPeople(
 // Folders
 // ---------------------------------------------------------------------------
 
+export type FolderConflictResolution = "error" | "reuse" | "rename";
+
+export type FolderPathResolution<TFolder> =
+    | {
+          conflict: true;
+          folder_name: string;
+          existing_folder_id: string;
+          suggested_name: string;
+          can_replace: boolean;
+      }
+    | {
+          conflict: false;
+          folder_id: string;
+          resolved_name: string;
+          folders: TFolder[];
+      };
+
+export async function resolveProjectFolderPath(
+    projectId: string,
+    segments: string[],
+    baseFolderId: string | null,
+    conflictResolution: FolderConflictResolution = "error",
+): Promise<FolderPathResolution<Folder>> {
+    return apiRequest<FolderPathResolution<Folder>>(
+        `/projects/${projectId}/folder-paths/resolve`,
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                segments,
+                base_folder_id: baseFolderId,
+                conflict_resolution: conflictResolution,
+            }),
+        },
+    );
+}
+
 export async function createProjectFolder(
     projectId: string,
     name: string,
@@ -983,10 +1020,12 @@ export async function bulkDeleteLibraryDocuments(
 export async function uploadLibraryDocument(
     kind: LibraryKind,
     file: File,
+    folderId?: string | null,
 ): Promise<Document> {
     const authHeaders = await getAuthHeader();
     const form = new FormData();
     form.append("file", file);
+    if (folderId) form.append("folder_id", folderId);
     const response = await fetch(`${API_BASE}/library/${kind}/documents`, {
         method: "POST",
         headers: { ...authHeaders },
@@ -1010,6 +1049,26 @@ export async function createLibraryFolder(
             parent_folder_id: parentFolderId ?? null,
         }),
     });
+}
+
+export async function resolveLibraryFolderPath(
+    kind: LibraryKind,
+    segments: string[],
+    baseFolderId: string | null,
+    conflictResolution: FolderConflictResolution = "error",
+): Promise<FolderPathResolution<LibraryFolder>> {
+    return apiRequest<FolderPathResolution<LibraryFolder>>(
+        `/library/${kind}/folder-paths/resolve`,
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                segments,
+                base_folder_id: baseFolderId,
+                conflict_resolution: conflictResolution,
+            }),
+        },
+    );
 }
 
 export async function renameLibraryFolder(
@@ -1201,10 +1260,12 @@ export async function deleteDocumentVersion(
 export async function uploadProjectDocument(
     projectId: string,
     file: File,
+    folderId?: string | null,
 ): Promise<Document> {
     const authHeaders = await getAuthHeader();
     const form = new FormData();
     form.append("file", file);
+    if (folderId) form.append("folder_id", folderId);
     const response = await fetch(
         `${API_BASE}/projects/${projectId}/documents`,
         {


### PR DESCRIPTION
## Summary

- support uploading local folders while preserving their nested folder structure in projects, files, and templates
- resolve folder-name conflicts against the complete database hierarchy and confirm creation of an available suffixed folder such as NDAs (2)
- serialize database folder-path creation, cap a directory batch at 50 supported files, and upload with bounded concurrency
- add Shift+click range selection and drag-and-drop for multiple document rows
- show one top-level loading row per uploaded folder without changing an existing conflicting folder while confirmation is pending
- replace FileDirectory pseudo-checkboxes nested inside buttons with accessible sibling checkbox controls
- align nested document and workflow-pack checkboxes with their parent chevrons
- sanitize folder-upload failures shown to users

Fixes #358.

## Database migration

Apply backend/migrations/20260822_01_resolve_folder_upload_paths.sql before deploying the new folder-path resolver routes.

## Testing

- Backend: 713 tests passed (24 skipped)
- Backend TypeScript build passed
- Frontend: 502 tests passed
- Frontend TypeScript check passed
- Frontend ESLint passed with no errors (36 existing warnings)