### PR TITLE
fix(models): stop silently defaulting to Gemini outside Google-OAuth deployments

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,6 +15,10 @@ SUPABASE_SECRET_KEY=your-supabase-service-role-key
 
 # Local Supabase CLI Google OAuth credentials. Google is enabled by default;
 # set [auth.external.google].enabled to false to opt out locally.
+# When BOTH values are set, the deployment keeps its historical Gemini
+# default model. Without them there is no hardcoded default: models resolve
+# from each user's saved selections and API keys, and requests fail loudly
+# when nothing is configured.
 SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=
 SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET=
 

--- a/backend/src/lib/__tests__/userSettings.test.ts
+++ b/backend/src/lib/__tests__/userSettings.test.ts
@@ -20,6 +20,7 @@ vi.mock("../routerModels", async () => ({
 vi.mock("../supabase", () => ({ createServerSupabase: vi.fn() }));
 
 import { getUserModelSettings } from "../userSettings";
+import { providerForModel } from "../llm/models";
 
 function profileDb(row: Record<string, unknown> | null) {
     const chain: Record<string, unknown> = {};
@@ -101,11 +102,76 @@ describe("getUserModelSettings router-model allowlist", () => {
             }),
         );
 
-        // Gemini env key present → cheap default title model; tabular default.
+        // Availability-based defaults: the env gemini key yields the cheap
+        // Gemini title model and the cheapest usable mid-tier for tabular.
         expect(settings.title_model).toBe("gemini-3.5-flash-lite");
-        expect(settings.tabular_model).toBe("gemini-3-flash-preview");
+        expect(settings.tabular_model).toBe("gemini-3.7-flash");
         expect(warn).toHaveBeenCalled();
         warn.mockRestore();
+    });
+
+    it("keeps the historical Gemini defaults on Google-OAuth deployments", async () => {
+        // Zero usable providers: outside Google-OAuth deployments this would
+        // resolve to null models; the deployment-level Google flag retains
+        // the historical Gemini default instead.
+        vi.stubEnv("SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID", "id");
+        vi.stubEnv("SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET", "secret");
+        getUserApiKeys.mockResolvedValue({
+            claude: null,
+            gemini: null,
+            openai: null,
+            openrouter: null,
+            vercel: null,
+            courtlistener: null,
+        });
+        getAllUserRouterModels.mockResolvedValue({
+            openrouter: [],
+            vercel: [],
+            "opencode-go": [],
+        });
+        try {
+            const settings = await getUserModelSettings(
+                "user-1",
+                profileDb(null),
+            );
+
+            expect(settings.title_model).toBe("gemini-3.5-flash-lite");
+            expect(settings.tabular_model).toBe("gemini-3-flash-preview");
+        } finally {
+            vi.unstubAllEnvs();
+        }
+    });
+
+    it("returns null models when nothing is usable", async () => {
+        getUserApiKeys.mockResolvedValue({
+            claude: null,
+            gemini: null,
+            openai: null,
+            openrouter: null,
+            vercel: null,
+            courtlistener: null,
+        });
+        getAllUserRouterModels.mockResolvedValue({
+            openrouter: [],
+            vercel: [],
+            "opencode-go": [],
+        });
+
+        const settings = await getUserModelSettings(
+            "user-1",
+            profileDb(null),
+        );
+
+        // No silent cloud-provider default outside Google-OAuth deployments:
+        // titles stay null; tabular may land on a keyless local/registry
+        // model, which is deliberately always usable.
+        expect(settings.title_model).toBeNull();
+        if (settings.tabular_model !== null) {
+            const provider = providerForModel(settings.tabular_model);
+            expect(["gemini", "openai", "anthropic", "claude"]).not.toContain(
+                provider,
+            );
+        }
     });
 
     it("keeps first-party preferences untouched", async () => {

--- a/backend/src/lib/chat/streaming.ts
+++ b/backend/src/lib/chat/streaming.ts
@@ -1,10 +1,19 @@
 import {
   streamChatWithTools,
-  DEFAULT_MAIN_MODEL,
+  resolveModel,
+  CLAUDE_MAIN_MODELS,
+  GEMINI_MAIN_MODELS,
+  OPENAI_MAIN_MODELS,
+  type UserApiKeys,
   type LlmMessage,
   type OpenAIToolSchema,
 } from "../llm";
-import { resolveRequestedModel } from "../routerModels";
+import {
+  getAllUserRouterModels,
+  resolveRequestedModel,
+  ROUTER_SLUGS,
+} from "../routerModels";
+import { legacyDefaultModel } from "../googleOauth";
 import { UserFacingError } from "../userFacingError";
 import { createServerSupabase } from "../supabase";
 import { buildUserMcpTools, type McpToolEvent } from "../mcpConnectors";
@@ -401,13 +410,66 @@ export async function runLLMStream(params: {
     // asked for in THIS request. Tabular's stored preference has already been
     // normalized by getUserModelSettings, so what arrives here is either an
     // in-selection router model or a first-party id.
-    const selectedModel = await resolveRequestedModel(
-      model,
-      DEFAULT_MAIN_MODEL,
-      userId,
-      db,
-      "throw",
-    );
+    // An explicit id that resolves to nothing must fail loudly rather than
+    // degrade silently to the default: a stale or mangled composer value
+    // would otherwise surface as an unrelated default-model failure the
+    // user cannot connect to their own selection.
+    if (model && !resolveModel(model, "")) {
+      throw new UserFacingError(
+        `Model "${model}" is not available on this deployment. Pick another model in the composer.`,
+      );
+    }
+    // No explicit model: Google-OAuth deployments keep their historical
+    // Gemini default; everywhere else resolve from what this user can
+    // actually use — saved router selections first (their curated list),
+    // then first-party models with keys. Never a silent provider default.
+    let selectedModel: string;
+    const legacyDefault = legacyDefaultModel("main");
+    if (model) {
+      selectedModel = await resolveRequestedModel(
+        model,
+        legacyDefault ?? "",
+        userId,
+        db,
+        legacyDefault ? "fallback" : "throw",
+      );
+    } else if (legacyDefault) {
+      selectedModel = await resolveRequestedModel(
+        legacyDefault,
+        legacyDefault,
+        userId,
+        db,
+        "throw",
+      );
+    } else {
+      let picked = "";
+      const routerModels = await getAllUserRouterModels(userId, db);
+      for (const slug of ROUTER_SLUGS) {
+        const first = routerModels[slug]?.[0];
+        if (apiKeys?.[slug]?.trim() && first) {
+          picked = `${slug}/${first}`;
+          break;
+        }
+      }
+      if (!picked) {
+        for (const [slug, tier] of [
+          ["claude", CLAUDE_MAIN_MODELS],
+          ["gemini", GEMINI_MAIN_MODELS],
+          ["openai", OPENAI_MAIN_MODELS],
+        ] as const) {
+          if (apiKeys?.[slug]?.trim()) {
+            picked = tier[0];
+            break;
+          }
+        }
+      }
+      if (!picked) {
+        throw new UserFacingError(
+          "No AI provider is configured. Add an API key in Settings → Bring Your Own Keys.",
+        );
+      }
+      selectedModel = picked;
+    }
     await streamChatWithTools({
       model: selectedModel,
       systemPrompt,

--- a/backend/src/lib/googleOauth.ts
+++ b/backend/src/lib/googleOauth.ts
@@ -1,0 +1,42 @@
+import {
+    DEFAULT_MAIN_MODEL,
+    DEFAULT_TABULAR_MODEL,
+    DEFAULT_TITLE_MODEL,
+} from "./llm";
+
+/**
+ * Whether Sign-in-with-Google is enabled for this deployment.
+ *
+ * Detected from the Supabase external-provider environment variables. On
+ * locally provisioned Supabase projects these are set by the CLI config;
+ * hosted-dashboards-only deployments that enable Google sign-in should set
+ * both explicitly so the deployment keeps its historical defaults.
+ */
+export function isGoogleOauthEnabled(): boolean {
+    return (
+        !!process.env.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID?.trim() &&
+        !!process.env.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET?.trim()
+    );
+}
+
+type ModelTier = "main" | "title" | "tabular";
+
+/**
+ * The hardcoded per-tier Gemini default, retained ONLY for deployments where
+ * Google sign-in is enabled (Google OAuth pairs naturally with a Google
+ * default). Everywhere else callers must resolve from providers the user can
+ * actually use — a silent default runs the risk of attributing a reply to,
+ * and billing, a provider the user never chose. Returns null when there is
+ * no such legacy default and callers fail loudly / pick from usable keys.
+ */
+export function legacyDefaultModel(tier: ModelTier): string | null {
+    if (!isGoogleOauthEnabled()) return null;
+    switch (tier) {
+        case "main":
+            return DEFAULT_MAIN_MODEL;
+        case "title":
+            return DEFAULT_TITLE_MODEL;
+        case "tabular":
+            return DEFAULT_TABULAR_MODEL;
+    }
+}

--- a/backend/src/lib/userSettings.ts
+++ b/backend/src/lib/userSettings.ts
@@ -1,11 +1,15 @@
 import { createServerSupabase } from "./supabase";
 import {
     resolveModel,
-    DEFAULT_TITLE_MODEL,
-    DEFAULT_TABULAR_MODEL,
+    CLAUDE_LOW_MODELS,
+    GEMINI_LOW_MODELS,
     OPENAI_LOW_MODELS,
+    CLAUDE_MID_MODELS,
+    GEMINI_MID_MODELS,
+    OPENAI_MID_MODELS,
     type UserApiKeys,
 } from "./llm";
+import { legacyDefaultModel } from "./googleOauth";
 import { getUserApiKeys as getStoredUserApiKeys } from "./userApiKeys";
 import {
     getAllUserRouterModels,
@@ -16,8 +20,8 @@ import {
 } from "./routerModels";
 
 export type UserModelSettings = {
-    title_model: string;
-    tabular_model: string;
+    title_model: string | null;
+    tabular_model: string | null;
     legal_research_us: boolean;
     api_keys: UserApiKeys;
     personalisation?: {
@@ -30,23 +34,71 @@ export type UserModelSettings = {
     };
 };
 
-// Title generation is a lightweight task — always routed to the cheapest model
-// of whichever provider the user has keys for: Gemini Flash Lite if Gemini is
-// available, otherwise OpenAI lite, Claude Haiku, or the user's first saved
-// router model. With no usable provider, defaults to Gemini (the dev-mode env
-// fallback).
+type TierLists = {
+    gemini: readonly string[];
+    openai: readonly string[];
+    claude: readonly string[];
+};
+
+const TITLE_TIERS: TierLists = {
+    gemini: GEMINI_LOW_MODELS,
+    openai: OPENAI_LOW_MODELS,
+    claude: CLAUDE_LOW_MODELS,
+};
+
+const TABULAR_TIERS: TierLists = {
+    gemini: GEMINI_MID_MODELS,
+    openai: OPENAI_MID_MODELS,
+    claude: CLAUDE_MID_MODELS,
+};
+
+function hasKey(value: unknown): boolean {
+    return typeof value === "string" ? !!value.trim() : value === true;
+}
+
+// Pick the cheapest model of whichever provider the user can actually use:
+// first-party keys by tier, then the user's saved router selections. When
+// nothing is usable: Google-OAuth deployments keep their historical Gemini
+// default; everywhere else this returns null and callers either skip the
+// lightweight task or fail loudly — never a silent provider default.
+export function resolveTierFallback(
+    tiers: TierLists,
+    keys: UserApiKeys | Record<string, unknown> | undefined,
+    routerModels?: RouterModelSelections,
+): string | null {
+    if (hasKey(keys?.gemini)) return tiers.gemini[0];
+    if (hasKey(keys?.openai)) return tiers.openai[0];
+    if (hasKey(keys?.claude)) return tiers.claude[0];
+    if (routerModels) {
+        for (const slug of ROUTER_SLUGS) {
+            const first = routerModels[slug]?.[0];
+            if (hasKey(keys?.[slug]) && first) return `${slug}/${first}`;
+        }
+    }
+    return legacyDefaultModel(tiers === TITLE_TIERS ? "title" : "tabular");
+}
+
 function resolveTitleModel(
     apiKeys: UserApiKeys,
     routerModels: RouterModelSelections,
-): string {
-    if (apiKeys.gemini?.trim()) return DEFAULT_TITLE_MODEL;
-    if (apiKeys.openai?.trim()) return OPENAI_LOW_MODELS[0];
-    if (apiKeys.claude?.trim()) return "claude-haiku-4-5";
-    for (const slug of ROUTER_SLUGS) {
-        const first = routerModels[slug][0];
-        if (apiKeys[slug]?.trim() && first) return `${slug}/${first}`;
-    }
-    return DEFAULT_TITLE_MODEL;
+): string | null {
+    return resolveTierFallback(TITLE_TIERS, apiKeys, routerModels);
+}
+
+/** Cheapest usable model (low tier), or null. Booleans (ApiKeyStatus) work too. */
+export function cheapModelFallback(
+    keys: UserApiKeys | Record<string, unknown> | undefined,
+    routerModels?: RouterModelSelections,
+): string | null {
+    return resolveTierFallback(TITLE_TIERS, keys, routerModels);
+}
+
+/** Mid-tier usable model (tabular-class work), or null. */
+export function midModelFallback(
+    keys: UserApiKeys | Record<string, unknown> | undefined,
+    routerModels?: RouterModelSelections,
+): string | null {
+    return resolveTierFallback(TABULAR_TIERS, keys, routerModels);
 }
 
 export async function getUserModelSettings(
@@ -89,7 +141,11 @@ export async function getUserModelSettings(
     // profile PATCH. Treat that exactly like an invalid model id and fall
     // back, so the env-key spend path can't be steered onto arbitrary
     // gateway models.
-    const guardRouterModel = (model: string, fallback: string): string => {
+    const guardRouterModel = (
+        model: string | null,
+        fallback: string | null,
+    ): string | null => {
+        if (!model) return fallback;
         if (
             !routerForModelId(model) ||
             isRouterModelSelected(model, routerModels)
@@ -97,7 +153,7 @@ export async function getUserModelSettings(
             return model;
         }
         console.warn(
-            `[router-models] user ${userId} preference "${model}" is outside their saved selection; using ${fallback}`,
+            `[router-models] user ${userId} preference "${model}" is outside their saved selection; using ${fallback ?? "no model"}`,
         );
         return fallback;
     };
@@ -105,13 +161,13 @@ export async function getUserModelSettings(
 
     return {
         title_model: guardRouterModel(
-            resolveModel(data?.title_model, titleFallback),
+            resolveModel(data?.title_model, ""),
             titleFallback,
-        ),
+        ) || null,
         tabular_model: guardRouterModel(
-            resolveModel(data?.tabular_model, DEFAULT_TABULAR_MODEL),
-            DEFAULT_TABULAR_MODEL,
-        ),
+            resolveModel(data?.tabular_model, ""),
+            resolveTierFallback(TABULAR_TIERS, api_keys, routerModels),
+        ) || null,
         legal_research_us:
             (data as { legal_research_us?: boolean | null } | null)
                 ?.legal_research_us !== false,

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -342,6 +342,11 @@ chatRouter.post("/:chatId/generate-title", requireAuth, async (req, res) => {
             userId,
             db,
         );
+        if (!title_model) {
+            return void res.status(409).json({
+                detail: "No AI provider is configured. Add an API key in Settings → Bring Your Own Keys.",
+            });
+        }
         const title = await generateAssistantChatTitle({
             model: title_model,
             message,
@@ -573,7 +578,10 @@ chatRouter.post("/", requireAuth, async (req, res) => {
         );
 
         const shouldGenerateTitle =
-            !chatTitle && !!lastUser?.content && !askInputsResponse;
+            !chatTitle &&
+            !!lastUser?.content &&
+            !askInputsResponse &&
+            !!titleModel;
         const titleMessage = lastUser
             ? [
                   lastUser.content,
@@ -589,7 +597,7 @@ chatRouter.post("/", requireAuth, async (req, res) => {
             : "";
         const titlePromise = shouldGenerateTitle
             ? generateAssistantChatTitle({
-                  model: titleModel,
+                  model: titleModel as string,
                   message: titleMessage,
                   apiKeys,
               })

--- a/backend/src/routes/projectChat.ts
+++ b/backend/src/routes/projectChat.ts
@@ -262,7 +262,10 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
         write(`data: ${JSON.stringify({ type: "chat_id", chatId })}\n\n`);
 
         const shouldGenerateTitle =
-            !chatTitle && !!lastUser?.content && !askInputsResponse;
+            !chatTitle &&
+            !!lastUser?.content &&
+            !askInputsResponse &&
+            !!titleModel;
         const titleMessage = lastUser
             ? [
                   lastUser.content,
@@ -278,7 +281,7 @@ projectChatRouter.post("/", requireAuth, async (req, res) => {
             : "";
         const titlePromise = shouldGenerateTitle
             ? generateAssistantChatTitle({
-                  model: titleModel,
+                  model: titleModel as string,
                   message: titleMessage,
                   apiKeys,
               })

--- a/backend/src/routes/tabular.ts
+++ b/backend/src/routes/tabular.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+import { Router, type Response } from "express";
 import { randomUUID } from "node:crypto";
 import { requireAuth } from "../middleware/auth";
 import { createServerSupabase } from "../lib/supabase";
@@ -495,6 +495,20 @@ function providerLabel(provider: Provider): string {
     return "Gemini";
 }
 
+// getUserModelSettings no longer invents a hardcoded default, so a profile
+// with zero usable providers resolves to null here.
+function requireTabularModel(
+    res: Response,
+    tabular_model: string | null,
+): tabular_model is string {
+    if (tabular_model) return true;
+    res.status(409).json({
+        detail:
+            "No AI provider is configured. Add an API key in Settings → Bring Your Own Keys.",
+    });
+    return false;
+}
+
 function missingModelApiKey(model: string, apiKeys: UserApiKeys) {
     const provider = providerForModel(model);
     if (provider === "ollama") return null; // local, no key
@@ -720,6 +734,11 @@ tabularRouter.post("/prompt", requireAuth, async (req, res) => {
 
     try {
         const { title_model, api_keys } = await getUserModelSettings(userId);
+        if (!title_model) {
+            return void res.status(409).json({
+                detail: "No AI provider is configured. Add an API key in Settings → Bring Your Own Keys.",
+            });
+        }
         const raw = await completeText({
             model: title_model,
             systemPrompt:
@@ -1196,7 +1215,8 @@ tabularRouter.post(
             userId,
             db,
         );
-        const missingKey = missingModelApiKey(tabular_model, api_keys);
+        if (!requireTabularModel(res, tabular_model)) return;
+    const missingKey = missingModelApiKey(tabular_model, api_keys);
         if (missingKey) {
             return void res.status(422).json({
                 code: "missing_api_key",
@@ -1392,6 +1412,7 @@ tabularRouter.post("/:reviewId/generate", requireAuth, async (req, res) => {
         return void res.status(400).json({ detail: "No columns configured" });
 
     const { tabular_model, api_keys } = await getUserModelSettings(userId, db);
+    if (!requireTabularModel(res, tabular_model)) return;
     const missingKey = missingModelApiKey(tabular_model, api_keys);
     if (missingKey) {
         return void res.status(422).json({
@@ -1972,6 +1993,7 @@ tabularRouter.post("/:reviewId/chat", requireAuth, async (req, res) => {
     };
 
     const { tabular_model, api_keys } = await getUserModelSettings(userId, db);
+    if (!requireTabularModel(res, tabular_model)) return;
     const missingKey = missingModelApiKey(tabular_model, api_keys);
     if (missingKey) {
         return void res.status(422).json({
@@ -2081,15 +2103,19 @@ tabularRouter.post("/:reviewId/chat", requireAuth, async (req, res) => {
         // Generate title on first exchange
         if (chatId && isFirstExchange && !chatTitle && lastUser.content) {
             const { title_model } = await getUserModelSettings(userId, db);
-            const title = await generateChatTitle(
-                title_model,
-                lastUser.content,
-                {
-                    reviewTitle: clientReviewTitle ?? review.title ?? null,
-                    projectName: clientProjectName ?? null,
-                },
-                api_keys,
-            );
+            // No usable provider: skip the lightweight title; the review
+            // itself is unaffected.
+            const title = title_model
+                ? await generateChatTitle(
+                      title_model,
+                      lastUser.content,
+                      {
+                          reviewTitle: clientReviewTitle ?? review.title ?? null,
+                          projectName: clientProjectName ?? null,
+                      },
+                      api_keys,
+                  )
+                : null;
             if (title) {
                 await db
                     .from("tabular_review_chats")

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -5,13 +5,14 @@ import { createServerSupabase } from "../lib/supabase";
 import { recordAudit } from "../lib/audit";
 import { sendInternalError } from "../lib/httpError";
 import {
-    DEFAULT_TABULAR_MODEL,
-    DEFAULT_TITLE_MODEL,
-    CLAUDE_LOW_MODELS,
     isSupportedOpenCodeGoModel,
-    OPENAI_LOW_MODELS,
     resolveModel,
 } from "../lib/llm";
+import {
+    cheapModelFallback,
+    midModelFallback,
+} from "../lib/userSettings";
+import { legacyDefaultModel } from "../lib/googleOauth";
 import {
     type ApiKeyStatus,
     getUserApiKeyStatus,
@@ -466,31 +467,20 @@ export function normalizeRouterModels(
     return models;
 }
 
-function routerTitleFallback(
-    routerModels: RouterModelSelections,
-    apiKeyStatus?: ApiKeyStatus,
-): string | null {
-    for (const slug of ROUTER_SLUGS) {
-        const first = routerModels[slug][0];
-        if (apiKeyStatus?.[slug] && first) return `${slug}/${first}`;
-    }
-    return null;
-}
-
 function serializeProfile(
     routerModels: RouterModelSelections,
     row: UserProfileRow,
     apiKeyStatus?: ApiKeyStatus,
 ) {
     const creditsUsed = row.message_credits_used ?? 0;
-    const titleFallback = apiKeyStatus?.gemini
-        ? DEFAULT_TITLE_MODEL
-        : apiKeyStatus?.openai
-          ? OPENAI_LOW_MODELS[0]
-          : apiKeyStatus?.claude
-            ? CLAUDE_LOW_MODELS[0]
-            : (routerTitleFallback(routerModels, apiKeyStatus) ??
-              DEFAULT_TITLE_MODEL);
+    // Availability-based suggestions first; Google-OAuth deployments keep
+    // their historical Gemini default via legacyDefaultModel.
+    const titleFallback =
+        cheapModelFallback(apiKeyStatus, routerModels) ??
+        legacyDefaultModel("title");
+    const tabularFallback =
+        midModelFallback(apiKeyStatus, routerModels) ??
+        legacyDefaultModel("tabular");
     return {
         displayName: row.display_name,
         organisation: row.organisation,
@@ -515,8 +505,11 @@ function serializeProfile(
         creditsResetDate: row.credits_reset_date,
         creditsRemaining: Math.max(MONTHLY_CREDIT_LIMIT - creditsUsed, 0),
         tier: row.tier || "Free",
-        titleModel: resolveModel(row.title_model, titleFallback),
-        tabularModel: resolveModel(row.tabular_model, DEFAULT_TABULAR_MODEL),
+        titleModel:
+            resolveModel(row.title_model, "") || titleFallback,
+        tabularModel:
+            resolveModel(row.tabular_model, "") || tabularFallback,
+        composerDefaultModel: legacyDefaultModel("main"),
         mfaOnLogin: row.mfa_on_login === true,
         legalResearchUs: row.legal_research_us !== false,
         quickActionsVisible: row.quick_actions_visible !== false,

--- a/frontend/src/app/components/assistant/ChatInput.modelSelection.test.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.modelSelection.test.tsx
@@ -114,9 +114,12 @@ describe("ChatInput model selection vs. a degraded profile", () => {
             />,
         );
 
+        // No hardcoded client-side default: the reset target is "" and the
+        // composer then preselects the first model reporting available
+        // (isModelAvailable is stubbed permissive in this suite).
         await waitFor(() =>
             expect(window.localStorage.getItem(STORAGE_KEY)).toBe(
-                "gemini-3-flash-preview",
+                "claude-fable-5",
             ),
         );
     });

--- a/frontend/src/app/components/assistant/ChatInput.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.tsx
@@ -3,6 +3,7 @@
 import {
     useState,
     useCallback,
+    useMemo,
     useEffect,
     useRef,
     forwardRef,
@@ -30,7 +31,7 @@ import {
     workflowSlashCommand,
 } from "./workflowSlashCommands";
 import { ApiKeyMissingPopup } from "../popups/ApiKeyMissingPopup";
-import { ModelToggle } from "./ModelToggle";
+import { MODELS, ModelToggle } from "./ModelToggle";
 import { useSelectedModel } from "@/app/hooks/useSelectedModel";
 import { useUserProfile } from "@/app/contexts/UserProfileContext";
 import {
@@ -108,6 +109,25 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
     // /user/profile request rewrite the saved composer selection to the
     // default — permanently. null means "not loaded", which the hook leaves
     // the stored selection alone for.
+    const apiKeys = apiKeysDegraded ? undefined : profile?.apiKeys;
+    // No hardcoded provider default exists client-side: Google-OAuth
+    // deployments preselect their historical Gemini default via
+    // profile.composerDefaultModel; everywhere else the composer preselects
+    // the first model this user can actually use — saved router selections
+    // first (their curated choices), then first-party models.
+    const preselectCandidates = useMemo(() => {
+        if (!profile || apiKeysDegraded) return null;
+        const candidates = [
+            ...(profile.composerDefaultModel ? [profile.composerDefaultModel] : []),
+            ...(profile.openRouterModels ?? []).map((id) => `openrouter/${id}`),
+            ...(profile.vercelModels ?? []).map((id) => `vercel/${id}`),
+            ...(profile.openCodeGoModels ?? []).map((id) => `opencode-go/${id}`),
+            ...MODELS.map((m) => m.id),
+        ];
+        return apiKeys
+            ? candidates.filter((id) => isModelAvailable(id, apiKeys))
+            : candidates;
+    }, [profile, apiKeysDegraded, apiKeys]);
     const [model, setModel] = useSelectedModel(
         profile && !apiKeysDegraded
             ? {
@@ -116,11 +136,11 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                   openCodeGoModels: profile.openCodeGoModels,
               }
             : null,
+        preselectCandidates,
     );
     // Degraded profile → key availability is UNKNOWN; undefined here makes
     // every key gate (submit check + model toggle) fail open instead of
     // treating "we couldn't ask" as "no keys configured".
-    const apiKeys = apiKeysDegraded ? undefined : profile?.apiKeys;
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const controlsRef = useRef<HTMLDivElement>(null);
     const [compactControls, setCompactControls] = useState(false);

--- a/frontend/src/app/components/assistant/ModelToggle.tsx
+++ b/frontend/src/app/components/assistant/ModelToggle.tsx
@@ -46,7 +46,11 @@ export const SETTINGS_MODELS: ModelOption[] = [
   { id: "gpt-5.4-mini", label: "GPT-5.4 Mini", group: "OpenAI" },
 ];
 
-export const DEFAULT_MODEL_ID = "gemini-3-flash-preview";
+// No hardcoded provider default: an empty selection renders as "Select
+// model" and the composer preselects the first model the user can actually
+// use once the profile loads (server-owned default first — see
+// profile.composerDefaultModel).
+export const DEFAULT_MODEL_ID = "";
 
 export const ALLOWED_MODEL_IDS = new Set(MODELS.map((m) => m.id));
 

--- a/frontend/src/app/components/tabular/TRChatPanel.tsx
+++ b/frontend/src/app/components/tabular/TRChatPanel.tsx
@@ -776,7 +776,7 @@ export function TRChatPanel({
     // fetch) fails open — see ModelToggle.
     const apiKeys = apiKeysDegraded ? undefined : profile?.apiKeys;
     const apiKeysLoading = profileLoading && !profile;
-    const currentModel = profile?.tabularModel ?? "gemini-3-flash-preview";
+    const currentModel = profile?.tabularModel ?? "";
     const [apiKeyModalProvider, setApiKeyModalProvider] =
         useState<ModelProvider | null>(null);
     const [chats, setChats] = useState<TRChat[]>([]);
@@ -1144,7 +1144,7 @@ export function TRChatPanel({
 
     async function handleSubmit(trimmed: string) {
         if (!trimmed || isLoading) return;
-        if (apiKeys && !isModelAvailable(currentModel, apiKeys)) {
+        if (apiKeys && currentModel && !isModelAvailable(currentModel, apiKeys)) {
             setApiKeyModalProvider(getModelProvider(currentModel));
             return;
         }

--- a/frontend/src/app/components/tabular/TabularReviewView.tsx
+++ b/frontend/src/app/components/tabular/TabularReviewView.tsx
@@ -152,7 +152,7 @@ export function TRView({ reviewId, projectId }: Props) {
     // Unknown key state fails open; the submit gates below already skip when
     // apiKeys is undefined.
     const apiKeys = apiKeysDegraded ? undefined : profile?.apiKeys;
-    const tabularModel = profile?.tabularModel ?? "gemini-3-flash-preview";
+    const tabularModel = profile?.tabularModel ?? "";
     const cellMutationsBlocked =
         generating || stoppingGeneration || review?.is_running === true;
 
@@ -280,7 +280,7 @@ export function TRView({ reviewId, projectId }: Props) {
             setGenerationGuard("running");
             return;
         }
-        if (apiKeys && !isModelAvailable(tabularModel, apiKeys)) {
+        if (apiKeys && tabularModel && !isModelAvailable(tabularModel, apiKeys)) {
             setApiKeyModalProvider(getModelProvider(tabularModel));
             return;
         }
@@ -363,7 +363,7 @@ export function TRView({ reviewId, projectId }: Props) {
         // If columns changed since last save, update the review first
         if (columns.length === 0) return;
 
-        if (apiKeys && !isModelAvailable(tabularModel, apiKeys)) {
+        if (apiKeys && tabularModel && !isModelAvailable(tabularModel, apiKeys)) {
             setApiKeyModalProvider(getModelProvider(tabularModel));
             return;
         }

--- a/frontend/src/app/contexts/UserProfileContext.tsx
+++ b/frontend/src/app/contexts/UserProfileContext.tsx
@@ -40,8 +40,9 @@ interface UserProfile {
     creditsResetDate: string;
     creditsRemaining: number;
     tier: string;
-    titleModel: string;
-    tabularModel: string;
+    titleModel: string | null;
+    tabularModel: string | null;
+    composerDefaultModel: string | null;
     mfaOnLogin: boolean;
     legalResearchUs: boolean;
     quickActionsVisible: boolean;
@@ -201,8 +202,9 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
                 creditsResetDate: futureResetDate.toISOString(),
                 creditsRemaining: 999999, // temporarily unlimited
                 tier: "Free",
-                titleModel: "gemini-3.5-flash-lite",
-                tabularModel: "gemini-3-flash-preview",
+                titleModel: null,
+                tabularModel: null,
+                composerDefaultModel: null,
                 mfaOnLogin: false,
                 legalResearchUs: true,
                 quickActionsVisible: true,

--- a/frontend/src/app/hooks/useSelectedModel.test.ts
+++ b/frontend/src/app/hooks/useSelectedModel.test.ts
@@ -20,7 +20,7 @@ describe("useSelectedModel", () => {
 
         const { result } = renderHook(() => useSelectedModel());
 
-        expect(result.current[0]).toBe("gemini-3-flash-preview");
+        expect(result.current[0]).toBe("");
     });
 
     it("persists a valid explicit selection", () => {
@@ -57,10 +57,8 @@ describe("useSelectedModel", () => {
             }),
         );
 
-        expect(result.current[0]).toBe("gemini-3-flash-preview");
-        expect(window.localStorage.getItem(STORAGE_KEY)).toBe(
-            "gemini-3-flash-preview",
-        );
+        expect(result.current[0]).toBe("");
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe("");
     });
 
     it("keeps an OpenCode Go selection that is in the loaded saved lists", () => {
@@ -88,7 +86,7 @@ describe("useSelectedModel", () => {
             }),
         );
 
-        expect(result.current[0]).toBe("gemini-3-flash-preview");
+        expect(result.current[0]).toBe("");
     });
 
     it("leaves a router selection alone while the lists are still loading", () => {

--- a/frontend/src/app/hooks/useSelectedModel.ts
+++ b/frontend/src/app/hooks/useSelectedModel.ts
@@ -55,6 +55,7 @@ export function useSelectedModel(
         vercelModels: string[];
         openCodeGoModels: string[];
     } | null,
+    preselectCandidates?: string[] | null,
 ): [string, (id: string) => void] {
     const [model, setModelState] = useState<string>(DEFAULT_MODEL_ID);
     const openRouterModels = routerSelections?.openRouterModels;
@@ -75,17 +76,33 @@ export function useSelectedModel(
         };
         // eslint-disable-next-line react-hooks/set-state-in-effect -- reconciles state with data that arrives asynchronously (the loaded router lists); the functional update is a no-op unless the stored selection is genuinely stale, so it cannot cascade
         setModelState((current) => {
+            let next = current;
             const router = ROUTER_SLUGS.find((slug) =>
-                current.startsWith(`${slug}/`),
+                next.startsWith(`${slug}/`),
             );
-            if (!router) return current;
-            if (selections[router].includes(current.slice(router.length + 1))) {
-                return current;
+            if (
+                router &&
+                !selections[router].includes(next.slice(router.length + 1))
+            ) {
+                persist(DEFAULT_MODEL_ID);
+                next = DEFAULT_MODEL_ID;
             }
-            persist(DEFAULT_MODEL_ID);
-            return DEFAULT_MODEL_ID;
+            // Empty selection (no stored value, or a stale one reset just
+            // above): preselect the first usable candidate instead of
+            // leaving the user on an unnamed default. Chained inside this
+            // same updater so reset and preselect are atomic.
+            if (!next && preselectCandidates?.length) {
+                const pick = preselectCandidates.find((id) =>
+                    isAllowedModelId(canonicalModelId(id)),
+                );
+                if (pick) {
+                    persist(pick);
+                    return pick;
+                }
+            }
+            return next;
         });
-    }, [openRouterModels, vercelModels, openCodeGoModels]);
+    }, [openRouterModels, vercelModels, openCodeGoModels, preselectCandidates]);
 
     const setModel = useCallback((id: string) => {
         const canonical = canonicalModelId(id);

--- a/frontend/src/app/lib/mikeApi.ts
+++ b/frontend/src/app/lib/mikeApi.ts
@@ -421,8 +421,9 @@ export interface UserProfile {
     creditsResetDate: string;
     creditsRemaining: number;
     tier: string;
-    titleModel: string;
-    tabularModel: string;
+    titleModel: string | null;
+    tabularModel: string | null;
+    composerDefaultModel: string | null;
     mfaOnLogin: boolean;
     legalResearchUs: boolean;
     quickActionsVisible: boolean;

--- a/word-addin/src/taskpane/lib/modelCatalog.ts
+++ b/word-addin/src/taskpane/lib/modelCatalog.ts
@@ -45,7 +45,10 @@ export const STATIC_MODELS: readonly ModelOption[] = [
   { id: "gpt-5.4", label: "GPT-5.4", group: "OpenAI" },
 ];
 
-export const DEFAULT_MODEL_ID = "gemini-3-flash-preview";
+// No hardcoded provider default — mirrors the web composer. Google-OAuth
+// deployments preselect via profile.composerDefaultModel;
+// REACT_APP_DEFAULT_MODEL can pin a deployment-specific default.
+export const DEFAULT_MODEL_ID = "";
 export const ALLOWED_MODEL_IDS = new Set(
   STATIC_MODELS.map((model) => model.id),
 );


### PR DESCRIPTION
## Summary

Removes the hardcoded `gemini-3-flash-preview` default. Deployments with Sign-in-with-Google enabled keep it; everywhere else, models resolve from what the signed-in user can actually use, and requests fail with an actionable message when nothing is configured.

## What changed

**Backend**
- New `lib/googleOauth.ts`: detects the Supabase external Google provider (`SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID`/`_SECRET`) and exposes `legacyDefaultModel(tier)` — the historical Gemini constants, retained **only** for Google-OAuth deployments.
- `getUserModelSettings`: title/tabular fallbacks become availability-based chains (first-party keys by tier → saved router selections). When nothing is usable they return `null` for non-Google-OAuth deployments; OAuth deployments keep today's Gemini defaults.
- Chat streaming: requests without a model use saved router selections first, then first-party keys, and fail loudly ("No AI provider is configured…") instead of running an unchosen model. Explicit-but-unknown model ids now also fail loudly instead of silently degrading to the default.
- Title generation and tabular generation entry points skip or return a clear 409 when no provider is usable.
- Profile payloads expose nullable `titleModel`/`tabularModel` plus `composerDefaultModel` so clients preselect the deployment's intended default without hardcoding it.

**Frontend / add-in**
- Composer renders an explicit "Select model" state instead of assuming Gemini, resets stale selections atomically, and preselects the first usable candidate — server default first, then saved router selections, then first-party models filtered by real key availability.
- Word add-in catalog mirrors the change; `REACT_APP_DEFAULT_MODEL` remains available as an operator override.
- Tabular views skip key checks while no model is selected.
- `.env.example` documents that setting both Google vars retains the legacy default.

## Why

A stale composer selection (e.g. after a catalog rename) or an omitted model field silently ran Gemini — surfacing only as an opaque stream failure (in one observed deployment, a monthly spend-cap 400) that users could not connect to their own selection. Model choice should come from configuration and user keys, not a compile-time constant.

## Testing performed

- `backend`: full vitest suite green on Node 22 (727 passed), including new coverage: availability-based fallbacks, null-when-nothing-usable outside Google-OAuth deployments, retained Gemini defaults under the Google flag, and loud rejection of unknown model ids.
- `frontend`: full vitest suite green (548 passed; three pre-existing `wordAddin/*` load failures are identical on pristine `main` in containerized runs and unrelated to this change), `tsc` clean, eslint clean.
- `word-addin`: `tsc` clean.
- Manually exercised both modes against a local stack: with no Google env, a request omitting `model` streams from the user's saved OpenRouter selection; with the Google vars set, the legacy Gemini default is restored.