### PR TITLE
fix(chat): surface empty upstream model completions instead of silence

### DIFF
--- a/backend/src/__tests__/integration/chat.routes.test.ts
+++ b/backend/src/__tests__/integration/chat.routes.test.ts
@@ -341,6 +341,28 @@ describe("POST /chat — streaming endpoint", () => {
         );
     });
 
+    it("surfaces an empty upstream completion as a visible retry error", async () => {
+        // Some providers end the stream cleanly but produce no content.
+        // Silence reads as a hung composer, so the route emits an explicit,
+        // safe-to-display error event before closing the stream.
+        runLLMStream.mockResolvedValue({
+            fullText: "",
+            events: [],
+            citations: [],
+        });
+
+        const res = await request(app)
+            .post("/chat")
+            .set("Authorization", "Bearer test")
+            .send(VALID_BODY);
+
+        expect(res.status).toBe(200);
+        expect(res.text).toContain('"type":"error"');
+        expect(res.text).toContain("empty response");
+        expect(res.text).toContain('"safe_to_display":true');
+        expect(res.text).toContain("[DONE]");
+    });
+
     it("stores cloud Word chats only in the document-scoped Word tables", async () => {
         const chatLib = await import("../../lib/chat");
         const res = await request(app)

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -638,6 +638,26 @@ chatRouter.post("/", requireAuth, async (req, res) => {
             eventCount: events?.length ?? 0,
         });
 
+        // Upstream providers occasionally end the stream cleanly but empty
+        // (observed via OpenRouter). Silence reads as a hung composer, so
+        // surface it — unless tools produced visible artifacts, which carry
+        // their own completion signal.
+        if (
+            !fullText?.trim() &&
+            (!events || events.every((event) => !("error" in event)))
+        ) {
+            write(
+                `data: ${JSON.stringify({
+                    type: "error",
+                    message:
+                        "The model returned an empty response. Try again, or pick a different model.",
+                    safe_to_display: true,
+                })}\n\n`,
+            );
+            write("data: [DONE]\n\n");
+            return;
+        }
+
         const persistedEvents = stripTransientAssistantEvents(events);
         if (askInputsResponse) {
             await appendAssistantEventsToLastAssistantMessage(


### PR DESCRIPTION
## Summary

When an upstream provider ends a chat stream cleanly but produces **zero content** (observed intermittently via OpenRouter), the client currently renders nothing — the composer just sits there looking hung. This PR emits an explicit, safe-to-display error event instead:

> *The model returned an empty response. Try again, or pick a different model.*

## What changed

- `routes/chat.ts`: after `runLLMStream` resolves, if `fullText` is empty/whitespace and no events were produced, emit the retry-guidance error event followed by `[DONE]`.
- Turns that produced tool artifacts (documents, ask-inputs flows, etc.) keep their existing completion path — the guard only fires when nothing visible was generated.

## Why

An empty 200-complete stream is indistinguishable from a hang to the user, and the underlying trigger is provider-side (retrying or switching models works). Surfacing it turns a dead-end into actionable guidance.

## Testing performed

- New integration test in `chat.routes.test.ts`: empty `runLLMStream` result → SSE contains the `error` event with `safe_to_display: true` and terminates with `[DONE]`.
- Full backend suite on Node 22: 726 passed / 25 skipped.