### PR TITLE
Improve workflow commands and document review UX

### DIFF
--- a/e2e/workflows-settings.spec.ts
+++ b/e2e/workflows-settings.spec.ts
@@ -111,7 +111,7 @@ test.describe("Workflows", () => {
         const defaultWorkflow = page.getByText("Proofread", { exact: true });
         await expect(defaultWorkflow).toBeVisible({ timeout: 10_000 });
         await defaultWorkflow.click();
-        await page.getByRole("button", { name: "View Page" }).click();
+        await page.getByRole("button", { name: "Edit", exact: true }).click();
 
         await expect(page).toHaveURL(/\/workflows\/assistant\/.+/, {
             timeout: 10_000,

--- a/frontend/src/app/components/assistant/ChatInput.slashCommands.test.tsx
+++ b/frontend/src/app/components/assistant/ChatInput.slashCommands.test.tsx
@@ -210,7 +210,7 @@ describe("ChatInput workflow slash commands", () => {
         expect(input).toHaveValue("Document Quick Action prompt");
     });
 
-    it("treats slash as ordinary input when no workflows define commands", async () => {
+    it("treats slash as ordinary input when workflow titles cannot form commands", async () => {
         let resolveWorkflows!: (workflows: Workflow[]) => void;
         vi.mocked(listWorkflows).mockReturnValue(
             new Promise((resolve) => {
@@ -223,6 +223,7 @@ describe("ChatInput workflow slash commands", () => {
                 metadata: {
                     ...workflow.metadata,
                     name: null,
+                    title: "---",
                 },
             } as Workflow,
         ];

--- a/frontend/src/app/components/assistant/QuickActionsModal.test.tsx
+++ b/frontend/src/app/components/assistant/QuickActionsModal.test.tsx
@@ -46,7 +46,7 @@ describe("QuickActionsModal", () => {
         ).toHaveClass("liquid-glass-modal-row-hover");
         expect(
             document.querySelector('[data-slot="quick-actions-list"]'),
-        ).toHaveClass("overflow-x-hidden", "px-1");
+        ).toHaveClass("overflow-x-hidden", "px-1", "pt-1");
 
         fireEvent.click(
             screen.getByRole("button", { name: /Proofread agreement/ }),

--- a/frontend/src/app/components/assistant/QuickActionsModal.tsx
+++ b/frontend/src/app/components/assistant/QuickActionsModal.tsx
@@ -194,7 +194,7 @@ export function QuickActionsModal({
           </div>
           <div
             data-slot="quick-actions-list"
-            className="mt-2 min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-1"
+            className="mt-2 min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-1 pt-1"
           >
             {error && (
               <p className="px-3 py-2 text-xs text-red-600" role="alert">

--- a/frontend/src/app/components/assistant/workflowSlashCommands.test.ts
+++ b/frontend/src/app/components/assistant/workflowSlashCommands.test.ts
@@ -10,14 +10,63 @@ import {
 const workflow = {
     id: "workflow-1",
     metadata: {
-        name: "contract-intake",
+        name: "ignored-machine-name",
         title: "Contract Intake",
     },
 } as Workflow;
 
 describe("workflow slash commands", () => {
-    it("derives the command from the workflow name", () => {
+    it("derives the command from the workflow title", () => {
         expect(workflowSlashCommand(workflow)).toBe("/contract-intake");
+    });
+
+    it("strips punctuation and replaces whitespace with hyphens", () => {
+        const titledWorkflow = {
+            ...workflow,
+            metadata: {
+                ...workflow.metadata,
+                title: "  Contract & Intake   2026!  ",
+            },
+        } as Workflow;
+
+        expect(workflowSlashCommand(titledWorkflow)).toBe(
+            "/contract-intake-2026",
+        );
+    });
+
+    it("preserves and normalizes hyphens in the workflow title", () => {
+        const titledWorkflow = {
+            ...workflow,
+            metadata: {
+                ...workflow.metadata,
+                title: "Pre-Merger - Review",
+            },
+        } as Workflow;
+
+        expect(workflowSlashCommand(titledWorkflow)).toBe(
+            "/pre-merger-review",
+        );
+    });
+
+    it("supports alphabetical and numeric characters outside ASCII", () => {
+        const titledWorkflow = {
+            ...workflow,
+            metadata: {
+                ...workflow.metadata,
+                title: "Révision 合同 2",
+            },
+        } as Workflow;
+
+        expect(workflowSlashCommand(titledWorkflow)).toBe("/révision-合同-2");
+    });
+
+    it("does not create a command when the title has no letters or numbers", () => {
+        const titledWorkflow = {
+            ...workflow,
+            metadata: { ...workflow.metadata, title: " --- !!! " },
+        } as Workflow;
+
+        expect(workflowSlashCommand(titledWorkflow)).toBeNull();
     });
 
     it("recognizes a slash command without arguments", () => {

--- a/frontend/src/app/components/assistant/workflowSlashCommands.ts
+++ b/frontend/src/app/components/assistant/workflowSlashCommands.ts
@@ -1,10 +1,8 @@
 import type { Workflow } from "../shared/types";
-
-const WORKFLOW_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+import { workflowSlashCommandFromTitle } from "@/shared/ui/WorkflowSlashCommandUI";
 
 export function workflowSlashCommand(workflow: Workflow): string | null {
-    const name = workflow.metadata.name;
-    return name && WORKFLOW_NAME_PATTERN.test(name) ? `/${name}` : null;
+    return workflowSlashCommandFromTitle(workflow.metadata.title);
 }
 
 export function slashCommandQuery(value: string): string | null {

--- a/frontend/src/app/components/modals/ModalSegmentedToggle.tsx
+++ b/frontend/src/app/components/modals/ModalSegmentedToggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { LucideIcon } from "lucide-react";
+import type { ComponentType } from "react";
 import { cn } from "@/app/lib/utils";
 import {
     LIQUID_GLASS_HOVER_CLASS,
@@ -11,7 +11,7 @@ import {
 export interface SegmentedToggleOption<T extends string> {
     value: T;
     label: string;
-    icon?: LucideIcon;
+    icon?: ComponentType<{ className?: string }>;
 }
 
 interface ModalSegmentedToggleProps<T extends string> {

--- a/frontend/src/app/components/modals/ModalSelect.test.tsx
+++ b/frontend/src/app/components/modals/ModalSelect.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ModalSelect } from "./ModalSelect";
+
+describe("ModalSelect", () => {
+    it("portals its open menu above modal content and footers", () => {
+        const { container } = render(
+            <div data-testid="modal-content" className="overflow-y-auto">
+                <ModalSelect
+                    id="language"
+                    value="English"
+                    options={["English", "French"]}
+                    onChange={vi.fn()}
+                    open
+                />
+            </div>,
+        );
+
+        const menu = screen.getByRole("menu");
+        expect(menu).toHaveClass("z-[250]");
+        expect(container).not.toContainElement(menu);
+        expect(container.querySelector("button")).toHaveClass("text-sm");
+        expect(screen.getByRole("menuitem", { name: "French" })).toHaveClass(
+            "text-xs",
+        );
+    });
+
+    it("finds an option from keyboard input", async () => {
+        render(
+            <ModalSelect
+                id="country"
+                value="Australia"
+                options={["Australia", "Singapore", "United Kingdom"]}
+                onChange={vi.fn()}
+                open
+            />,
+        );
+
+        const menu = screen.getByRole("menu");
+        menu.focus();
+        fireEvent.keyDown(menu, { key: "s" });
+
+        await waitFor(() =>
+            expect(
+                screen.getByRole("menuitem", { name: "Singapore" }),
+            ).toHaveFocus(),
+        );
+    });
+});

--- a/frontend/src/app/components/modals/ModalSelect.tsx
+++ b/frontend/src/app/components/modals/ModalSelect.tsx
@@ -4,7 +4,12 @@ import { useState } from "react";
 import { ChevronDown, type LucideIcon } from "lucide-react";
 import { cn } from "@/app/lib/utils";
 import {
-    LIQUID_GLASS_FLOAT_CLASS,
+    Dropdown,
+    DropdownContent,
+    DropdownItem,
+    DropdownTrigger,
+} from "@/shared/ui/DropdownUI";
+import {
     LIQUID_GLASS_HOVER_CLASS,
     LIQUID_GLASS_SELECTED_CLASS,
     LIQUID_GLASS_SUBTLE_CLASS,
@@ -69,63 +74,64 @@ export function ModalSelect({
     }
 
     return (
-        <div className="relative">
-            <button
-                id={id}
-                type="button"
-                onClick={() => setOpen(!isOpen)}
-                disabled={disabled}
-                className={cn(
-                    `flex h-10 w-full items-center justify-between rounded-xl px-3 text-sm text-gray-700 ${LIQUID_GLASS_SUBTLE_CLASS} ${LIQUID_GLASS_HOVER_CLASS} backdrop-blur-xl transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-60`,
-                    isOpen && LIQUID_GLASS_SELECTED_CLASS,
-                    className,
-                )}
-                aria-haspopup="listbox"
-                aria-expanded={isOpen}
-            >
-                <span className="flex min-w-0 items-center gap-2">
-                    {selected?.icon && (
-                        <selected.icon
-                            className={cn(
-                                "h-3.5 w-3.5 shrink-0",
-                                selected.iconClassName,
-                            )}
-                        />
+        <Dropdown open={isOpen} onOpenChange={setOpen}>
+            <DropdownTrigger asChild>
+                <button
+                    id={id}
+                    type="button"
+                    disabled={disabled}
+                    className={cn(
+                        `flex h-10 w-full items-center justify-between rounded-xl px-3 text-sm text-gray-700 ${LIQUID_GLASS_SUBTLE_CLASS} ${LIQUID_GLASS_HOVER_CLASS} backdrop-blur-xl transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-60`,
+                        isOpen && LIQUID_GLASS_SELECTED_CLASS,
+                        className,
                     )}
-                    <span
-                        className={cn(
-                            "truncate",
-                            !selected && !hasValue && "text-gray-400",
+                >
+                    <span className="flex min-w-0 items-center gap-2">
+                        {selected?.icon && (
+                            <selected.icon
+                                className={cn(
+                                    "h-3.5 w-3.5 shrink-0",
+                                    selected.iconClassName,
+                                )}
+                            />
                         )}
-                    >
-                        {selected?.label ?? (hasValue ? value : placeholder)}
+                        <span
+                            className={cn(
+                                "truncate",
+                                !selected && !hasValue && "text-gray-400",
+                            )}
+                        >
+                            {selected?.label ??
+                                (hasValue ? value : placeholder)}
+                        </span>
                     </span>
-                </span>
-                <ChevronDown
-                    className={cn(
-                        "ml-2 h-3.5 w-3.5 shrink-0 text-gray-400 transition-transform",
-                        isOpen && "rotate-180",
-                    )}
-                />
-            </button>
+                    <ChevronDown
+                        className={cn(
+                            "ml-2 h-3.5 w-3.5 shrink-0 text-gray-400 transition-transform",
+                            isOpen && "rotate-180",
+                        )}
+                    />
+                </button>
+            </DropdownTrigger>
             {isOpen && !disabled && (
-                <div
-                    role="listbox"
-                    aria-labelledby={id}
+                <DropdownContent
+                    align="start"
+                    sideOffset={4}
+                    collisionPadding={12}
+                    onEscapeKeyDown={(event) => event.stopPropagation()}
                     className={cn(
-                        `absolute left-0 top-full z-30 mt-1 max-h-56 w-full overflow-y-auto rounded-2xl p-1 ${LIQUID_GLASS_FLOAT_CLASS} backdrop-blur-2xl`,
+                        "max-h-56 w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto rounded-2xl p-1",
                         menuClassName,
                     )}
                 >
                     {normalizedOptions.map((option) => (
-                        <button
+                        <DropdownItem
                             key={option.value}
-                            type="button"
-                            role="option"
-                            aria-selected={option.value === value}
-                            onClick={() => handleSelect(option.value)}
+                            textValue={option.label}
+                            selected={option.value === value}
+                            onSelect={() => handleSelect(option.value)}
                             className={cn(
-                                "theme-dropdown-item flex w-full items-center rounded-md px-3 py-2 text-left text-sm transition-all",
+                                "theme-dropdown-item flex w-full items-center rounded-md px-3 py-2 text-left text-xs transition-all",
                                 option.value === value
                                     ? "theme-dropdown-selected text-gray-900"
                                     : "text-gray-700",
@@ -144,10 +150,10 @@ export function ModalSelect({
                                     {option.label}
                                 </span>
                             </span>
-                        </button>
+                        </DropdownItem>
                     ))}
-                </div>
+                </DropdownContent>
             )}
-        </div>
+        </Dropdown>
     );
 }

--- a/frontend/src/app/components/shared/FileDirectory.test.tsx
+++ b/frontend/src/app/components/shared/FileDirectory.test.tsx
@@ -276,6 +276,21 @@ describe("FileDirectory", () => {
         expect(onChange).not.toHaveBeenCalled();
     });
 
+    it("shows upload activity with a checkbox spinner and muted file icon", () => {
+        render(
+            <FileDirectory
+                selectedDocuments={[]}
+                onChange={vi.fn()}
+                showTabs={false}
+                uploadingFilenames={["Uploading contract.docx"]}
+            />,
+        );
+
+        const row = screen.getByText("Uploading contract.docx").closest("div");
+        expect(row?.children[0]).toHaveClass("animate-spin");
+        expect(row?.children[1]).toHaveClass("grayscale", "opacity-35");
+    });
+
     it("loads the next page when the directory is scrolled to the bottom", () => {
         const onLoadMore = vi.fn();
         const document = {

--- a/frontend/src/app/components/shared/FileDirectory.tsx
+++ b/frontend/src/app/components/shared/FileDirectory.tsx
@@ -863,8 +863,12 @@ export function FileDirectory({
                                 key={i}
                                 className={`${DIRECTORY_GRID_CLASS} rounded-md px-2 py-2`}
                             >
-                                <div className="h-2.5 w-2.5 shrink-0 justify-self-center rounded bg-gray-100 animate-pulse" />
-                                <div className="h-3.5 w-3.5 rounded bg-gray-100 animate-pulse shrink-0" />
+                                <Loader2 className="h-2.5 w-2.5 shrink-0 justify-self-center animate-spin text-gray-400" />
+                                <FileTypeIcon
+                                    fileType={null}
+                                    muted
+                                    className="h-3.5 w-3.5"
+                                />
                                 <div
                                     className="h-3 rounded bg-gray-100 animate-pulse"
                                     style={{ width: `${w}%` }}
@@ -951,8 +955,12 @@ export function FileDirectory({
                                     key={`uploading-${filename}`}
                                     className={`w-full ${DIRECTORY_GRID_CLASS} py-2 pl-2 pr-2 text-xs text-left`}
                                 >
-                                    <span className="shrink-0 h-3.5 w-3.5 rounded border border-gray-300" />
-                                    <Loader2 className="h-3.5 w-3.5 animate-spin text-gray-400 shrink-0" />
+                                    <Loader2 className="h-2.5 w-2.5 shrink-0 justify-self-center animate-spin text-gray-400" />
+                                    <FileTypeIcon
+                                        fileType={filename}
+                                        muted
+                                        className="h-3.5 w-3.5"
+                                    />
                                     <span className="flex-1 truncate text-gray-400">
                                         {filename}
                                     </span>

--- a/frontend/src/app/components/shared/views/PdfView.test.ts
+++ b/frontend/src/app/components/shared/views/PdfView.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getObservedPanelWidth } from "./PdfView";
+
+describe("getObservedPanelWidth", () => {
+    it("uses the stable border-box width when a scrollbar changes the content box", () => {
+        const entry = {
+            borderBoxSize: [{ inlineSize: 800, blockSize: 600 }],
+            contentRect: { width: 785 },
+        } as unknown as ResizeObserverEntry;
+
+        expect(getObservedPanelWidth(entry)).toBe(800);
+    });
+
+    it("falls back to the content-box width for older ResizeObserver implementations", () => {
+        const entry = {
+            contentRect: { width: 785 },
+        } as unknown as ResizeObserverEntry;
+
+        expect(getObservedPanelWidth(entry)).toBe(785);
+    });
+});

--- a/frontend/src/app/components/shared/views/PdfView.tsx
+++ b/frontend/src/app/components/shared/views/PdfView.tsx
@@ -39,6 +39,22 @@ type RenderedPage = {
     textDivs: HTMLElement[];
 };
 
+/**
+ * ResizeObserver's content box shrinks when an overflow scrollbar appears.
+ * The border box does not, so it is the stable measurement for deciding when
+ * the viewer's containing panel has actually been resized.
+ */
+export function getObservedPanelWidth(entry: ResizeObserverEntry): number {
+    const borderBoxSize = entry.borderBoxSize as
+        | readonly ResizeObserverSize[]
+        | ResizeObserverSize
+        | undefined;
+    const borderBox = Array.isArray(borderBoxSize)
+        ? borderBoxSize[0]
+        : borderBoxSize;
+    return Math.round(borderBox?.inlineSize ?? entry.contentRect.width);
+}
+
 export function PdfView({
     doc,
     quotes,
@@ -53,6 +69,7 @@ export function PdfView({
         null,
     );
     const renderedPagesRef = useRef<RenderedPage[]>([]);
+    const renderGenerationRef = useRef(0);
     const quoteListRef = useRef<QuoteEntry[]>([]);
     const zoomRef = useRef(1.0);
     const currentPageRef = useRef(1);
@@ -84,7 +101,11 @@ export function PdfView({
         const el = scrollContainerRef.current;
         if (!el) return;
         const ro = new ResizeObserver((entries) => {
-            setContainerWidth(entries[0]?.contentRect.width ?? 0);
+            const entry = entries[0];
+            const nextWidth = entry ? getObservedPanelWidth(entry) : 0;
+            setContainerWidth((currentWidth) =>
+                currentWidth === nextWidth ? currentWidth : nextWidth,
+            );
         });
         ro.observe(el);
         return () => ro.disconnect();
@@ -212,10 +233,17 @@ export function PdfView({
             list: QuoteEntry[],
             scrollToPage?: number,
         ) => {
-            if (!containerRef.current) return;
-            containerRef.current.innerHTML = "";
+            const container = containerRef.current;
+            if (!container) return;
+            const renderGeneration = ++renderGenerationRef.current;
+            const isStale = () =>
+                renderGenerationRef.current !== renderGeneration ||
+                containerRef.current !== container;
+
+            container.innerHTML = "";
             renderedPagesRef.current = [];
             const lib = await getPdfJs();
+            if (isStale()) return;
             lib.TextLayer.cleanup();
 
             setNumPages(doc.numPages);
@@ -232,8 +260,9 @@ export function PdfView({
                     scrollContainerRef.current.style.opacity = "1";
             };
 
-            const panelW = containerRef.current.clientWidth;
+            const panelW = container.clientWidth;
             const firstPage = await doc.getPage(1);
+            if (isStale()) return;
             const naturalWidth = firstPage.getViewport({ scale: 1 }).width;
             const baseScale = Math.max(
                 0.5,
@@ -243,6 +272,7 @@ export function PdfView({
 
             for (let pageNum = 1; pageNum <= doc.numPages; pageNum++) {
                 const page = await doc.getPage(pageNum);
+                if (isStale()) return;
                 const viewport = page.getViewport({ scale });
 
                 const wrapper = document.createElement("div");
@@ -256,7 +286,7 @@ export function PdfView({
                 canvas.height = viewport.height;
                 canvas.style.display = "block";
                 wrapper.appendChild(canvas);
-                containerRef.current?.appendChild(wrapper);
+                container.appendChild(wrapper);
 
                 const ctx = canvas.getContext("2d");
                 if (!ctx) continue;
@@ -264,7 +294,9 @@ export function PdfView({
                 const task = page.render({ canvasContext: ctx, viewport });
                 try {
                     await task.promise;
+                    if (isStale()) return;
                 } catch (e: unknown) {
+                    if (isStale()) return;
                     if (
                         (e as { name?: string })?.name !==
                         "RenderingCancelledException"
@@ -290,6 +322,7 @@ export function PdfView({
                     viewport,
                 });
                 await textLayer.render();
+                if (isStale()) return;
                 const textDivs = textLayer.textDivs;
 
                 renderedPagesRef.current.push({
@@ -300,6 +333,8 @@ export function PdfView({
                     textDivs,
                 });
             }
+
+            if (isStale()) return;
 
             // Apply highlights across all entries, then scroll to the first hit.
             let targetPage: number | null = null;
@@ -443,6 +478,7 @@ export function PdfView({
     // Clean up PDF.js static font-measurement canvases on unmount
     useEffect(() => {
         return () => {
+            renderGenerationRef.current += 1;
             getPdfJs().then((lib) => lib.TextLayer.cleanup());
         };
     }, []);
@@ -476,6 +512,7 @@ export function PdfView({
         })();
         return () => {
             cancelled = true;
+            renderGenerationRef.current += 1;
         };
     }, [result, renderPDF]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -535,7 +572,7 @@ export function PdfView({
         >
             <div
                 ref={scrollContainerRef}
-                className="flex-1 overflow-auto px-3 pt-5 pb-3"
+                className="flex-1 overflow-auto px-3 pt-5 pb-3 [scrollbar-gutter:stable]"
             >
                 {loading && (
                     <div className="flex h-full items-center justify-center">

--- a/frontend/src/app/components/tabular/TRFirstColumnCell.tsx
+++ b/frontend/src/app/components/tabular/TRFirstColumnCell.tsx
@@ -15,6 +15,7 @@ interface Props {
     closeSignal: number;
     className: string;
     onToggleSelection: () => void;
+    onDocumentOpen: (document: Document) => void;
 }
 
 export function TRFirstColumnCell({
@@ -24,6 +25,7 @@ export function TRFirstColumnCell({
     closeSignal,
     className,
     onToggleSelection,
+    onDocumentOpen,
 }: Props) {
     const [expanded, setExpanded] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
@@ -48,6 +50,10 @@ export function TRFirstColumnCell({
             document.removeEventListener("mousedown", handleClickOutside);
     }, [expanded]);
 
+    const rowDocument =
+        sourceDocuments.find((document) => document.id === row.document_id) ??
+        sourceDocuments[0];
+
     return (
         <div ref={containerRef} className={`${className} relative`}>
             <input
@@ -70,7 +76,15 @@ export function TRFirstColumnCell({
                     </span>
                 </button>
             ) : (
-                <>
+                <button
+                    type="button"
+                    onClick={() => {
+                        if (rowDocument) onDocumentOpen(rowDocument);
+                    }}
+                    disabled={!rowDocument}
+                    aria-label={`Open ${row.label}`}
+                    className="flex min-w-0 flex-1 items-center rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 disabled:cursor-default"
+                >
                     <FileTypeIcon
                         fileType={row.label}
                         className="mr-2 h-3.5 w-3.5"
@@ -78,7 +92,7 @@ export function TRFirstColumnCell({
                     <span className="line-clamp-1" title={row.label}>
                         {row.label}
                     </span>
-                </>
+                </button>
             )}
 
             {row.row_type === "folder" && expanded && (
@@ -92,9 +106,15 @@ export function TRFirstColumnCell({
                         </div>
                         <div className="max-h-64 overflow-y-auto">
                             {sourceDocuments.map((document) => (
-                                <div
+                                <button
                                     key={document.id}
-                                    className="flex min-h-7 items-center py-1"
+                                    type="button"
+                                    onClick={() => {
+                                        setExpanded(false);
+                                        onDocumentOpen(document);
+                                    }}
+                                    className="flex min-h-7 w-full items-center rounded-md py-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
+                                    aria-label={`Open ${document.filename}`}
                                 >
                                     <CornerDownRight
                                         className="mr-2 h-3.5 w-3.5 shrink-0 text-gray-400"
@@ -113,7 +133,7 @@ export function TRFirstColumnCell({
                                     >
                                         {document.filename}
                                     </span>
-                                </div>
+                                </button>
                             ))}
                         </div>
                     </div>

--- a/frontend/src/app/components/tabular/TRSidePanel.test.tsx
+++ b/frontend/src/app/components/tabular/TRSidePanel.test.tsx
@@ -21,6 +21,62 @@ vi.mock("../shared/views/SpreadsheetView", () => ({
 }));
 
 describe("TRSidePanel", () => {
+    it("shows only document metadata for a document-name click", () => {
+        const document = {
+            id: "doc-1",
+            filename: "Agreement.pdf",
+            file_type: "pdf",
+            active_version_number: 3,
+        } as Document;
+        const row = {
+            id: "row-1",
+            label: document.filename,
+            row_type: "document",
+            document_id: document.id,
+            source_document_ids: [document.id],
+        } as TabularReviewRow;
+        const column = {
+            index: 0,
+            name: "Clause",
+            prompt: "Extract the clause",
+        } as ColumnConfig;
+        const cell = {
+            id: "cell-1",
+            row_id: row.id,
+            column_index: column.index,
+            status: "done",
+            content: {
+                summary: "A result that should stay hidden",
+                flag: "green",
+                reasoning: "Hidden reasoning",
+            },
+        } as TabularCell;
+
+        render(
+            <TRSidePanel
+                cell={cell}
+                row={row}
+                rows={[row]}
+                document={document}
+                documents={[document]}
+                column={column}
+                columns={[column]}
+                displayDocument
+                documentOnly
+                onClose={vi.fn()}
+                onNavigate={vi.fn()}
+                onRegenerate={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText("PDF doc-1")).toBeInTheDocument();
+        expect(screen.getByText("Version")).toBeInTheDocument();
+        expect(screen.getByText("V3")).toBeInTheDocument();
+        expect(screen.queryByText("Column")).not.toBeInTheDocument();
+        expect(screen.queryByText("Results")).not.toBeInTheDocument();
+        expect(screen.queryByTitle("Regenerate")).not.toBeInTheDocument();
+    });
+
     it("opens the source document encoded in a grouped-row citation", () => {
         const documents = [
             {

--- a/frontend/src/app/components/tabular/TRSidePanel.tsx
+++ b/frontend/src/app/components/tabular/TRSidePanel.tsx
@@ -67,6 +67,8 @@ interface Props {
     onRegenerate?: () => Promise<void>;
     /** If true, open the document panel immediately */
     displayDocument?: boolean;
+    /** Show document metadata instead of analysis details. */
+    documentOnly?: boolean;
     /** Quote to highlight when opening document panel */
     citationQuote?: string;
     /** Page to scroll to when opening document panel */
@@ -118,6 +120,7 @@ export function TRSidePanel({
     onNavigate,
     onRegenerate,
     displayDocument = false,
+    documentOnly = false,
     citationQuote,
     citationPage,
     citationSheet,
@@ -158,6 +161,8 @@ export function TRSidePanel({
                 document.id === activeDocumentId &&
                 row.source_document_ids.includes(document.id),
         ) ?? initialDocument;
+    const activeVersionNumber =
+        doc?.active_version_number ?? doc?.latest_version_number ?? 1;
     const [documentPaneOpen, setDocumentPaneOpen] = useState(
         displayDocument && !!doc,
     );
@@ -439,7 +444,7 @@ export function TRSidePanel({
                             <PanelLeft className="h-4 w-4" />
                         </button>
                     )}
-                    {onRegenerate && (
+                    {!documentOnly && onRegenerate && (
                         <button
                             type="button"
                             onClick={async () => {
@@ -469,217 +474,264 @@ export function TRSidePanel({
                 {/* Analysis panel */}
                 <div className="flex-1 overflow-y-auto">
                     <div className="pb-2 px-5">
-                        {/* Document field */}
-                        <div className="mb-4">
-                            <div className="mb-3 text-xs font-medium text-gray-900">
-                                {row.row_type === "folder"
-                                    ? "Folder"
-                                    : "Document"}
-                            </div>
-                            {row.row_type === "folder" ? (
-                                <div>
-                                    <button
-                                        type="button"
-                                        onClick={() =>
-                                            setFolderExpanded(
-                                                (expanded) => !expanded,
-                                            )
-                                        }
-                                        className={cn(
-                                            "flex min-h-6 w-full items-center gap-1.5 rounded-md px-1 text-left text-gray-800 transition-colors",
-                                            LIQUID_GLASS_HOVER_CLASS,
-                                            LIQUID_GLASS_PRESSED_CLASS,
-                                        )}
-                                        aria-expanded={folderExpanded}
-                                    >
-                                        <SubfolderSvgIcon
-                                            open={folderExpanded}
+                        {documentOnly ? (
+                            <>
+                                <div className="mb-4">
+                                    <div className="mb-3 text-xs font-medium text-gray-900">
+                                        Document
+                                    </div>
+                                    <div className="flex min-h-6 items-center gap-1.5">
+                                        <FileTypeIcon
+                                            fileType={
+                                                doc?.file_type ?? doc?.filename
+                                            }
                                             className="h-3 w-3 shrink-0"
                                         />
-                                        <span
-                                            className="min-w-0 flex-1 truncate text-xs leading-6"
-                                            title={row.label}
+                                        <div
+                                            className="min-w-0 flex-1 truncate text-xs leading-6 text-gray-800"
+                                            title={doc?.filename}
                                         >
-                                            {row.label}
-                                        </span>
-                                        <ChevronDown
-                                            className={cn(
-                                                "h-3 w-3 shrink-0 text-gray-500 transition-transform",
-                                                folderExpanded && "rotate-180",
+                                            {doc?.filename ?? row.label}
+                                        </div>
+                                    </div>
+                                </div>
+                                <div>
+                                    <div className="mb-3 text-xs font-medium text-gray-900">
+                                        Version
+                                    </div>
+                                    <div className="min-h-6 text-xs leading-6 text-gray-800">
+                                        V{activeVersionNumber}
+                                    </div>
+                                </div>
+                            </>
+                        ) : (
+                            <>
+                                {/* Document field */}
+                                <div className="mb-4">
+                                    <div className="mb-3 text-xs font-medium text-gray-900">
+                                        {row.row_type === "folder"
+                                            ? "Folder"
+                                            : "Document"}
+                                    </div>
+                                    {row.row_type === "folder" ? (
+                                        <div>
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    setFolderExpanded(
+                                                        (expanded) => !expanded,
+                                                    )
+                                                }
+                                                className={cn(
+                                                    "flex min-h-6 w-full items-center gap-1.5 rounded-md px-1 text-left text-gray-800 transition-colors",
+                                                    LIQUID_GLASS_HOVER_CLASS,
+                                                    LIQUID_GLASS_PRESSED_CLASS,
+                                                )}
+                                                aria-expanded={folderExpanded}
+                                            >
+                                                <SubfolderSvgIcon
+                                                    open={folderExpanded}
+                                                    className="h-3 w-3 shrink-0"
+                                                />
+                                                <span
+                                                    className="min-w-0 flex-1 truncate text-xs leading-6"
+                                                    title={row.label}
+                                                >
+                                                    {row.label}
+                                                </span>
+                                                <ChevronDown
+                                                    className={cn(
+                                                        "h-3 w-3 shrink-0 text-gray-500 transition-transform",
+                                                        folderExpanded &&
+                                                            "rotate-180",
+                                                    )}
+                                                />
+                                            </button>
+                                            {folderExpanded && (
+                                                <div className="mt-1">
+                                                    {sourceDocuments.map(
+                                                        (sourceDocument) => (
+                                                            <button
+                                                                key={
+                                                                    sourceDocument.id
+                                                                }
+                                                                type="button"
+                                                                onClick={() =>
+                                                                    handleSourceDocumentOpen(
+                                                                        sourceDocument,
+                                                                    )
+                                                                }
+                                                                className={cn(
+                                                                    "flex min-h-6 w-full items-center gap-1.5 rounded-md py-1 pl-5 pr-1 text-left text-xs text-gray-800 transition-colors",
+                                                                    LIQUID_GLASS_HOVER_CLASS,
+                                                                    LIQUID_GLASS_PRESSED_CLASS,
+                                                                )}
+                                                                title={
+                                                                    sourceDocument.filename
+                                                                }
+                                                            >
+                                                                <FileTypeIcon
+                                                                    fileType={
+                                                                        sourceDocument.file_type ??
+                                                                        sourceDocument.filename
+                                                                    }
+                                                                    className="h-3 w-3 shrink-0"
+                                                                />
+                                                                <span className="min-w-0 flex-1 truncate">
+                                                                    {
+                                                                        sourceDocument.filename
+                                                                    }
+                                                                </span>
+                                                            </button>
+                                                        ),
+                                                    )}
+                                                </div>
                                             )}
-                                        />
-                                    </button>
-                                    {folderExpanded && (
-                                        <div className="mt-1">
-                                            {sourceDocuments.map(
-                                                (sourceDocument) => (
-                                                    <button
-                                                        key={sourceDocument.id}
-                                                        type="button"
-                                                        onClick={() =>
-                                                            handleSourceDocumentOpen(
-                                                                sourceDocument,
-                                                            )
-                                                        }
-                                                        className={cn(
-                                                            "flex min-h-6 w-full items-center gap-1.5 rounded-md py-1 pl-5 pr-1 text-left text-xs text-gray-800 transition-colors",
-                                                            LIQUID_GLASS_HOVER_CLASS,
-                                                            LIQUID_GLASS_PRESSED_CLASS,
-                                                        )}
-                                                        title={
-                                                            sourceDocument.filename
-                                                        }
-                                                    >
-                                                        <FileTypeIcon
-                                                            fileType={
-                                                                sourceDocument.file_type ??
-                                                                sourceDocument.filename
-                                                            }
-                                                            className="h-3 w-3 shrink-0"
-                                                        />
-                                                        <span className="min-w-0 flex-1 truncate">
-                                                            {
-                                                                sourceDocument.filename
-                                                            }
-                                                        </span>
-                                                    </button>
-                                                ),
-                                            )}
+                                        </div>
+                                    ) : (
+                                        <div className="flex min-h-6 items-center gap-1.5">
+                                            <FileTypeIcon
+                                                fileType={
+                                                    doc?.file_type ??
+                                                    doc?.filename
+                                                }
+                                                className="h-3 w-3"
+                                            />
+                                            <div
+                                                className="min-w-0 flex-1 truncate text-xs leading-6 text-gray-800"
+                                                title={row.label}
+                                            >
+                                                {row.label}
+                                            </div>
                                         </div>
                                     )}
                                 </div>
-                            ) : (
-                                <div className="flex min-h-6 items-center gap-1.5">
-                                    <FileTypeIcon
-                                        fileType={
-                                            doc?.file_type ?? doc?.filename
-                                        }
-                                        className="h-3 w-3"
-                                    />
-                                    <div
-                                        className="min-w-0 flex-1 truncate text-xs leading-6 text-gray-800"
-                                        title={row.label}
-                                    >
-                                        {row.label}
+
+                                {/* Column field */}
+                                <div className="mb-4">
+                                    <div className="mb-3 text-xs font-medium text-gray-900">
+                                        Column
+                                    </div>
+                                    <div className="min-h-6 truncate text-xs leading-6 text-gray-800">
+                                        {column.name}
                                     </div>
                                 </div>
-                            )}
-                        </div>
 
-                        {/* Column field */}
-                        <div className="mb-4">
-                            <div className="mb-3 text-xs font-medium text-gray-900">
-                                Column
-                            </div>
-                            <div className="min-h-6 truncate text-xs leading-6 text-gray-800">
-                                {column.name}
-                            </div>
-                        </div>
+                                {/* Flag section */}
+                                {cell.content?.flag && (
+                                    <div className="mb-5">
+                                        <h4 className="mb-2 text-xs font-medium text-gray-900">
+                                            Flag
+                                        </h4>
+                                        <span
+                                            className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${FLAG_BADGE[cell.content.flag] ?? FLAG_BADGE.grey}`}
+                                        >
+                                            {cell.content.flag
+                                                .charAt(0)
+                                                .toUpperCase() +
+                                                cell.content.flag.slice(1)}
+                                        </span>
+                                    </div>
+                                )}
 
-                        {/* Flag section */}
-                        {cell.content?.flag && (
-                            <div className="mb-5">
-                                <h4 className="mb-2 text-xs font-medium text-gray-900">
-                                    Flag
-                                </h4>
-                                <span
-                                    className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${FLAG_BADGE[cell.content.flag] ?? FLAG_BADGE.grey}`}
-                                >
-                                    {cell.content.flag.charAt(0).toUpperCase() +
-                                        cell.content.flag.slice(1)}
-                                </span>
-                            </div>
-                        )}
-
-                        {/* Results */}
-                        <div className="mb-6">
-                            <h4 className="mb-2 text-xs font-medium text-gray-900">
-                                Results
-                            </h4>
-                            <div className="text-xs leading-relaxed text-gray-700">
-                                <MarkdownContent
-                                    citations={summaryCitations}
-                                    onCitationClick={handleCitationOpen}
-                                    column={column}
-                                >
-                                    {summaryText || "—"}
-                                </MarkdownContent>
-                            </div>
-                        </div>
-
-                        {/* Reasoning */}
-                        {cell.content?.reasoning && (
-                            <div>
-                                <h4 className="mb-2 text-xs font-medium text-gray-900">
-                                    Reasoning
-                                </h4>
-                                <div className="text-xs leading-relaxed text-gray-700">
-                                    <MarkdownContent
-                                        citations={reasoningCitations}
-                                        onCitationClick={handleCitationOpen}
-                                        citationOffset={summaryCitations.length}
-                                        column={column}
-                                        inline
-                                    >
-                                        {reasoningText}
-                                    </MarkdownContent>
+                                {/* Results */}
+                                <div className="mb-6">
+                                    <h4 className="mb-2 text-xs font-medium text-gray-900">
+                                        Results
+                                    </h4>
+                                    <div className="text-xs leading-relaxed text-gray-700">
+                                        <MarkdownContent
+                                            citations={summaryCitations}
+                                            onCitationClick={handleCitationOpen}
+                                            column={column}
+                                        >
+                                            {summaryText || "—"}
+                                        </MarkdownContent>
+                                    </div>
                                 </div>
-                            </div>
+
+                                {/* Reasoning */}
+                                {cell.content?.reasoning && (
+                                    <div>
+                                        <h4 className="mb-2 text-xs font-medium text-gray-900">
+                                            Reasoning
+                                        </h4>
+                                        <div className="text-xs leading-relaxed text-gray-700">
+                                            <MarkdownContent
+                                                citations={reasoningCitations}
+                                                onCitationClick={
+                                                    handleCitationOpen
+                                                }
+                                                citationOffset={
+                                                    summaryCitations.length
+                                                }
+                                                column={column}
+                                                inline
+                                            >
+                                                {reasoningText}
+                                            </MarkdownContent>
+                                        </div>
+                                    </div>
+                                )}
+                            </>
                         )}
                     </div>
                 </div>
-                <div className="flex shrink-0 justify-center bg-white/25 pb-7 pt-1">
-                    <div className="grid grid-cols-3 grid-rows-3 gap-0.5">
-                        <CellNavigatorButton
-                            className="col-start-2 row-start-1"
-                            label="Previous row"
-                            title={previousRow?.label}
-                            disabled={!previousRow}
-                            onClick={() =>
-                                previousRow &&
-                                onNavigate(previousRow.id, column.index)
-                            }
-                        >
-                            <ChevronUp className="h-4 w-4" />
-                        </CellNavigatorButton>
-                        <CellNavigatorButton
-                            className="col-start-1 row-start-2"
-                            label="Previous column"
-                            title={previousColumn?.name}
-                            disabled={!previousColumn}
-                            onClick={() =>
-                                previousColumn &&
-                                onNavigate(row.id, previousColumn.index)
-                            }
-                        >
-                            <ChevronLeft className="h-4 w-4" />
-                        </CellNavigatorButton>
-                        <div className="col-start-2 row-start-2 h-7 w-7 rounded-md bg-white/35" />
-                        <CellNavigatorButton
-                            className="col-start-3 row-start-2"
-                            label="Next column"
-                            title={nextColumn?.name}
-                            disabled={!nextColumn}
-                            onClick={() =>
-                                nextColumn &&
-                                onNavigate(row.id, nextColumn.index)
-                            }
-                        >
-                            <ChevronRight className="h-4 w-4" />
-                        </CellNavigatorButton>
-                        <CellNavigatorButton
-                            className="col-start-2 row-start-3"
-                            label="Next row"
-                            title={nextRow?.label}
-                            disabled={!nextRow}
-                            onClick={() =>
-                                nextRow && onNavigate(nextRow.id, column.index)
-                            }
-                        >
-                            <ChevronDown className="h-4 w-4" />
-                        </CellNavigatorButton>
+                {!documentOnly && (
+                    <div className="flex shrink-0 justify-center bg-white/25 pb-7 pt-1">
+                        <div className="grid grid-cols-3 grid-rows-3 gap-0.5">
+                            <CellNavigatorButton
+                                className="col-start-2 row-start-1"
+                                label="Previous row"
+                                title={previousRow?.label}
+                                disabled={!previousRow}
+                                onClick={() =>
+                                    previousRow &&
+                                    onNavigate(previousRow.id, column.index)
+                                }
+                            >
+                                <ChevronUp className="h-4 w-4" />
+                            </CellNavigatorButton>
+                            <CellNavigatorButton
+                                className="col-start-1 row-start-2"
+                                label="Previous column"
+                                title={previousColumn?.name}
+                                disabled={!previousColumn}
+                                onClick={() =>
+                                    previousColumn &&
+                                    onNavigate(row.id, previousColumn.index)
+                                }
+                            >
+                                <ChevronLeft className="h-4 w-4" />
+                            </CellNavigatorButton>
+                            <div className="col-start-2 row-start-2 h-7 w-7 rounded-md bg-white/35" />
+                            <CellNavigatorButton
+                                className="col-start-3 row-start-2"
+                                label="Next column"
+                                title={nextColumn?.name}
+                                disabled={!nextColumn}
+                                onClick={() =>
+                                    nextColumn &&
+                                    onNavigate(row.id, nextColumn.index)
+                                }
+                            >
+                                <ChevronRight className="h-4 w-4" />
+                            </CellNavigatorButton>
+                            <CellNavigatorButton
+                                className="col-start-2 row-start-3"
+                                label="Next row"
+                                title={nextRow?.label}
+                                disabled={!nextRow}
+                                onClick={() =>
+                                    nextRow &&
+                                    onNavigate(nextRow.id, column.index)
+                                }
+                            >
+                                <ChevronDown className="h-4 w-4" />
+                            </CellNavigatorButton>
+                        </div>
                     </div>
-                </div>
+                )}
             </div>
         </div>
     );

--- a/frontend/src/app/components/tabular/TRTable.test.tsx
+++ b/frontend/src/app/components/tabular/TRTable.test.tsx
@@ -25,19 +25,22 @@ const documents = [
 
 function renderTable(
     documentGrouping: "document" | "folder" = "folder",
+    tableRows: TabularReviewRow[] = [row],
+    onDocumentOpen = vi.fn(),
 ) {
-    return render(
+    const renderResult = render(
         <TRTable
             loading={false}
             documentGrouping={documentGrouping}
             columns={[]}
-            rows={[row]}
+            rows={tableRows}
             documents={documents}
             cells={[]}
             savingColumn={false}
             savingColumnsConfig={false}
             selectedRowIds={[]}
             onSelectionChange={vi.fn()}
+            onDocumentOpen={onDocumentOpen}
             onExpand={vi.fn()}
             onCitationClick={vi.fn()}
             onUpdateColumn={vi.fn()}
@@ -46,6 +49,7 @@ function renderTable(
             onAddDocuments={vi.fn()}
         />,
     );
+    return { ...renderResult, onDocumentOpen };
 }
 
 describe("TRTable", () => {
@@ -68,9 +72,37 @@ describe("TRTable", () => {
     });
 
     it("expands a folder row to list its source documents", () => {
-        renderTable();
+        const { onDocumentOpen } = renderTable();
         fireEvent.click(screen.getByText("Contracts"));
         expect(screen.getByText("Agreement.pdf")).toBeInTheDocument();
         expect(screen.getByText("Schedule.docx")).toBeInTheDocument();
+
+        fireEvent.click(
+            screen.getByRole("button", { name: "Open Agreement.pdf" }),
+        );
+        expect(onDocumentOpen).toHaveBeenCalledWith(row, documents[0]);
+    });
+
+    it("opens a standalone document row from its document name", () => {
+        const documentRow = {
+            ...row,
+            label: "Agreement.pdf",
+            row_type: "document",
+            document_id: "doc-1",
+            source_document_ids: ["doc-1"],
+        } as TabularReviewRow;
+        const { onDocumentOpen } = renderTable(
+            "document",
+            [documentRow],
+        );
+
+        fireEvent.click(
+            screen.getByRole("button", { name: "Open Agreement.pdf" }),
+        );
+
+        expect(onDocumentOpen).toHaveBeenCalledWith(
+            documentRow,
+            documents[0],
+        );
     });
 });

--- a/frontend/src/app/components/tabular/TRTable.tsx
+++ b/frontend/src/app/components/tabular/TRTable.tsx
@@ -62,6 +62,7 @@ interface Props {
     dragOverFiles?: boolean;
     highlightedCell?: { colIdx: number; rowIdx: number } | null;
     onSelectionChange: (ids: string[]) => void;
+    onDocumentOpen: (row: TabularReviewRow, document: Document) => void;
     onExpand: (cell: TabularCell) => void;
     onCitationClick: (
         cell: TabularCell,
@@ -93,6 +94,7 @@ export const TRTable = forwardRef<TRTableHandle, Props>(function TRTable(
         dragOverFiles = false,
         highlightedCell,
         onSelectionChange,
+        onDocumentOpen,
         onExpand,
         onCitationClick,
         onUpdateColumn,
@@ -402,6 +404,9 @@ export const TRTable = forwardRef<TRTableHandle, Props>(function TRTable(
                                 selected={isSelected}
                                 closeSignal={scrollCloseSignal}
                                 onToggleSelection={() => toggleRow(row.id)}
+                                onDocumentOpen={(document) =>
+                                    onDocumentOpen(row, document)
+                                }
                                 className={`sticky left-0 z-[60] ${DOC_COL_W} border-b border-r border-gray-200 py-2 pl-3 pr-2 text-xs text-gray-800 flex items-center transition-colors ${stickyRowBg} ${isSelected ? "" : LIQUID_GLASS_GROUP_HOVER_CLASS}`}
                             />
                             {columns.map((col) => {

--- a/frontend/src/app/components/tabular/TabularReviewDetailsModal.tsx
+++ b/frontend/src/app/components/tabular/TabularReviewDetailsModal.tsx
@@ -115,7 +115,7 @@ export function TabularReviewDetailsModal({
             primaryAction={
                 canEdit
                     ? {
-                          label: saving ? "Saving..." : "Save changes",
+                          label: saving ? "Saving..." : "Save",
                           onClick: () => void handleSave(),
                           disabled:
                               saving ||

--- a/frontend/src/app/components/tabular/TabularReviewView.tsx
+++ b/frontend/src/app/components/tabular/TabularReviewView.tsx
@@ -116,6 +116,9 @@ export function TRView({ reviewId, projectId }: Props) {
             citationRef: number;
         } | undefined
     >(undefined);
+    const [expandedDocumentId, setExpandedDocumentId] = useState<
+        string | undefined
+    >(undefined);
     const [selectedRowIds, setSelectedRowIds] = useState<string[]>([]);
     const [actionsOpen, setActionsOpen] = useState(false);
     const [search, setSearch] = useState("");
@@ -631,6 +634,26 @@ export function TRView({ reviewId, projectId }: Props) {
             tableRef.current?.scrollToCell(colIdx, rowIdx);
         }, 50);
         setTimeout(() => setHighlightedCell(null), 3000);
+    }
+
+    function handleDocumentOpen(
+        row: TabularReviewRow,
+        document: Document,
+    ) {
+        const firstColumn = [...columns].sort(
+            (left, right) => left.index - right.index,
+        )[0];
+        if (!firstColumn) return;
+        const firstCell = cells.find(
+            (cell) =>
+                cell.row_id === row.id &&
+                cell.column_index === firstColumn.index,
+        );
+        if (!firstCell) return;
+
+        setExpandedCell(firstCell);
+        setExpandedCellCitation(undefined);
+        setExpandedDocumentId(document.id);
     }
 
     async function handleDeleteDocuments() {
@@ -1172,9 +1195,11 @@ export function TRView({ reviewId, projectId }: Props) {
                                 uploadingFilenames={uploadingDroppedFilenames}
                                 dragOverFiles={dragOverReviewFiles}
                                 onSelectionChange={setSelectedRowIds}
+                                onDocumentOpen={handleDocumentOpen}
                                 onExpand={(cell) => {
                                     setExpandedCell(cell);
                                     setExpandedCellCitation(undefined);
+                                    setExpandedDocumentId(undefined);
                                 }}
                                 onCitationClick={(
                                     cell,
@@ -1194,6 +1219,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                         documentId,
                                         citationRef,
                                     });
+                                    setExpandedDocumentId(undefined);
                                 }}
                                 onUpdateColumn={handleUpdateColumn}
                                 onDeleteColumn={handleDeleteColumn}
@@ -1232,10 +1258,12 @@ export function TRView({ reviewId, projectId }: Props) {
                         )
                             ? expandedCellCitation.documentId
                             : undefined;
+                    const requestedDocumentId =
+                        citedDocumentId ??
+                        expandedDocumentId ??
+                        expandedRow?.document_id;
                     const expandedDoc = documents.find(
-                        (document) =>
-                            document.id ===
-                            (citedDocumentId ?? expandedRow?.document_id),
+                        (document) => document.id === requestedDocumentId,
                     );
                     const expandedCol = columns.find(
                         (c) => c.index === expandedCell.column_index,
@@ -1253,6 +1281,7 @@ export function TRView({ reviewId, projectId }: Props) {
                             onClose={() => {
                                 setExpandedCell(null);
                                 setExpandedCellCitation(undefined);
+                                setExpandedDocumentId(undefined);
                             }}
                             onNavigate={(rowId, columnIndex) => {
                                 const nextCell = cells.find(
@@ -1263,6 +1292,7 @@ export function TRView({ reviewId, projectId }: Props) {
                                 if (nextCell) {
                                     setExpandedCell(nextCell);
                                     setExpandedCellCitation(undefined);
+                                    setExpandedDocumentId(undefined);
                                 }
                             }}
                             onRegenerate={
@@ -1276,8 +1306,10 @@ export function TRView({ reviewId, projectId }: Props) {
                             }
                             displayDocument={
                                 !!expandedDoc &&
-                                expandedCellCitation !== undefined
+                                (expandedCellCitation !== undefined ||
+                                    expandedDocumentId !== undefined)
                             }
+                            documentOnly={expandedDocumentId !== undefined}
                             citationQuote={expandedCellCitation?.quote}
                             citationPage={expandedCellCitation?.page}
                             citationSheet={expandedCellCitation?.sheet}

--- a/frontend/src/app/components/workflows/NewWorkflowModal.test.tsx
+++ b/frontend/src/app/components/workflows/NewWorkflowModal.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Workflow } from "../shared/types";
+import { NewWorkflowModal } from "./NewWorkflowModal";
+
+const workflow = {
+    id: "workflow-1",
+    is_owner: true,
+    metadata: {
+        title: "Contract Intake",
+        type: "assistant",
+        language: "English",
+        practice: "Litigation",
+        jurisdictions: ["Singapore"],
+    },
+} as Workflow;
+
+describe("NewWorkflowModal editing", () => {
+    it("disables Save until details change", () => {
+        render(
+            <NewWorkflowModal
+                open
+                editWorkflow={workflow}
+                onClose={vi.fn()}
+                onCreated={vi.fn()}
+                onUpdated={vi.fn()}
+            />,
+        );
+
+        const save = screen.getByRole("button", { name: "Save" });
+        expect(save).toBeDisabled();
+
+        const title = screen.getByLabelText("Title");
+        fireEvent.change(title, { target: { value: "Contract Review" } });
+        expect(save).toBeEnabled();
+
+        fireEvent.change(title, { target: { value: "Contract Intake" } });
+        expect(save).toBeDisabled();
+    });
+});

--- a/frontend/src/app/components/workflows/NewWorkflowModal.tsx
+++ b/frontend/src/app/components/workflows/NewWorkflowModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { MessageSquare, Table2, Upload } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Upload } from "lucide-react";
 import { createWorkflow, updateWorkflow } from "@/app/lib/mikeApi";
 import { userFacingApiError } from "@/app/lib/userFacingError";
 import type { Workflow } from "../shared/types";
@@ -10,10 +10,19 @@ import { Modal } from "../modals/Modal";
 import { ModalSegmentedToggle } from "../modals/ModalSegmentedToggle";
 import { ModalSelect } from "../modals/ModalSelect";
 import { FieldLabel, FormTextInput } from "../ui/form-field";
+import { WorkflowSlashCommandUI } from "@/shared/ui/WorkflowSlashCommandUI";
+import {
+    ChatSkeuoIcon,
+    TabularReviewSkeuoIcon,
+} from "../shared/AppSidebarSkeuoIcons";
+import {
+    COUNTRY_OPTIONS,
+    OTHER_JURISDICTION_OPTION,
+} from "@/app/onboarding/options";
 
 const DEFAULT_LANGUAGE = "English";
-const DEFAULT_PRACTICE = "General Transactions";
-const DEFAULT_JURISDICTION = "General";
+const DEFAULT_PRACTICE = "";
+const DEFAULT_JURISDICTION = "";
 const LANGUAGE_OPTIONS = [
     "English",
     "Chinese",
@@ -57,38 +66,8 @@ const LANGUAGE_OPTIONS = [
     "Other",
 ] as const;
 const JURISDICTION_OPTIONS = [
-    "General",
-    "United States",
-    "England and Wales",
-    "European Union",
-    "Singapore",
-    "Hong Kong",
-    "Australia",
-    "Canada",
-    "India",
-    "Malaysia",
-    "Indonesia",
-    "Philippines",
-    "Thailand",
-    "Vietnam",
-    "Japan",
-    "South Korea",
-    "China",
-    "Taiwan",
-    "Germany",
-    "France",
-    "Netherlands",
-    "Ireland",
-    "Scotland",
-    "Luxembourg",
-    "Switzerland",
-    "Cayman Islands",
-    "British Virgin Islands",
-    "United Arab Emirates",
-    "Saudi Arabia",
-    "Brazil",
-    "Mexico",
-    "Other",
+    ...COUNTRY_OPTIONS,
+    OTHER_JURISDICTION_OPTION,
 ] as const;
 const US_STATE_OPTIONS = [
     "Alabama",
@@ -231,6 +210,31 @@ export function NewWorkflowModal({
         .split(",")
         .map((item) => item.trim())
         .filter(Boolean);
+    const hasChanges = useMemo(() => {
+        if (!editWorkflow) return true;
+
+        const initialLanguage = editWorkflow.metadata.language ?? DEFAULT_LANGUAGE;
+        const initialPractice = editWorkflow.metadata.practice?.trim() || null;
+        const initialJurisdictions =
+            editWorkflow.metadata.jurisdictions
+                ?.map((item) => item.trim())
+                .filter(Boolean) ?? [];
+
+        return (
+            title.trim() !== editWorkflow.metadata.title.trim() ||
+            (effectiveLanguage.trim() || null) !==
+                (initialLanguage.trim() || null) ||
+            effectivePractice !== initialPractice ||
+            JSON.stringify(effectiveJurisdictions) !==
+                JSON.stringify(initialJurisdictions)
+        );
+    }, [
+        editWorkflow,
+        effectiveJurisdictions,
+        effectiveLanguage,
+        effectivePractice,
+        title,
+    ]);
     const formId = "workflow-modal-form";
 
     const resetForm = useCallback(() => {
@@ -436,11 +440,14 @@ export function NewWorkflowModal({
                                   ? "Saving…"
                                   : "Creating…"
                               : isEditing
-                                ? "Save changes"
+                                ? "Save"
                                 : "Create workflow",
                           type: "submit",
                           form: formId,
-                          disabled: !title.trim() || loading,
+                          disabled:
+                              !title.trim() ||
+                              loading ||
+                              (isEditing && !hasChanges),
                       }
             }
             secondaryAction={
@@ -457,7 +464,7 @@ export function NewWorkflowModal({
             <form
                 id={formId}
                 onSubmit={handleSubmit}
-                className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-5"
+                className="-mx-2 flex min-h-0 flex-1 flex-col overflow-y-auto px-2 pb-5"
             >
                 <div className="space-y-6">
                     <div>
@@ -474,6 +481,7 @@ export function NewWorkflowModal({
                             disabled={viewOnly}
                             autoFocus={!viewOnly}
                         />
+                        <WorkflowSlashCommandUI title={title} />
                     </div>
 
                     {!isEditing && (
@@ -486,12 +494,12 @@ export function NewWorkflowModal({
                                     {
                                         value: "assistant",
                                         label: "Assistant",
-                                        icon: MessageSquare,
+                                        icon: ChatSkeuoIcon,
                                     },
                                     {
                                         value: "tabular",
                                         label: "Tabular",
-                                        icon: Table2,
+                                        icon: TabularReviewSkeuoIcon,
                                     },
                                 ]}
                             />
@@ -549,6 +557,7 @@ export function NewWorkflowModal({
                                 id="workflow-practice"
                                 value={practice}
                                 options={PRACTICE_OPTIONS}
+                                placeholder="Select practice area"
                                 disabled={viewOnly}
                                 open={openDropdown === "practice"}
                                 onOpenChange={(nextOpen) =>
@@ -592,6 +601,7 @@ export function NewWorkflowModal({
                             id="workflow-jurisdiction"
                             value={jurisdiction}
                             options={jurisdictionOptions}
+                            placeholder="Select jurisdiction"
                             disabled={viewOnly}
                             open={openDropdown === "jurisdiction"}
                             onOpenChange={(nextOpen) =>

--- a/frontend/src/app/components/workflows/UseWorkflowModal.tsx
+++ b/frontend/src/app/components/workflows/UseWorkflowModal.tsx
@@ -238,7 +238,7 @@ export function UseWorkflowModal({ workflow, onClose, skipSelect = false }: Prop
             secondaryAction={
                 screen === "select"
                     ? {
-                          label: "View Page",
+                          label: "Edit",
                           onClick: selectPageAction,
                       }
                     : screen === "details"

--- a/frontend/src/app/components/workflows/WorkflowList.tsx
+++ b/frontend/src/app/components/workflows/WorkflowList.tsx
@@ -937,7 +937,7 @@ function WorkflowTable({
                 />
                 <TableCell className="ml-auto w-28">
                   <span className="inline-flex items-center gap-1.5 text-xs text-gray-600">
-                    <Icon className="h-4 w-4 shrink-0" />
+                    <Icon className="h-3 w-3 shrink-0" />
                     {workflow.metadata.type === "tabular"
                       ? "Tabular"
                       : "Assistant"}
@@ -1096,7 +1096,7 @@ function AddonTable({
         />
         <TableCell className="ml-auto w-28">
           <span className="inline-flex items-center gap-1.5 text-xs text-gray-600">
-            <Icon className="h-4 w-4" />
+            <Icon className="h-3 w-3 shrink-0" />
             {addon.type === "tabular" ? "Tabular" : "Assistant"}
           </span>
         </TableCell>

--- a/frontend/src/app/components/workflows/practices.test.ts
+++ b/frontend/src/app/components/workflows/practices.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { PRACTICE_AREA_OPTIONS } from "@/app/onboarding/options";
+import { PRACTICE_OPTIONS } from "./practices";
+
+describe("workflow practice options", () => {
+    it("adds General Transactions to the personalization practice-area list", () => {
+        expect(PRACTICE_OPTIONS).toEqual([
+            "General Transactions",
+            ...PRACTICE_AREA_OPTIONS,
+        ]);
+        expect(PRACTICE_AREA_OPTIONS).not.toContain("General Transactions");
+    });
+});

--- a/frontend/src/app/components/workflows/practices.ts
+++ b/frontend/src/app/components/workflows/practices.ts
@@ -1,23 +1,8 @@
+import { PRACTICE_AREA_OPTIONS } from "@/app/onboarding/options";
+
 export const PRACTICE_OPTIONS = [
     "General Transactions",
-    "Corporate",
-    "Finance",
-    "Litigation",
-    "Real Estate",
-    "Tax",
-    "Employment",
-    "IP",
-    "Competition",
-    "Tech Transactions",
-    "Project Finance",
-    "EC/VC",
-    "Private Equity",
-    "Private Credit",
-    "ECM",
-    "DCM",
-    "Lev Fin",
-    "Arbitration",
-    "Other",
+    ...PRACTICE_AREA_OPTIONS,
 ] as const;
 
 export type Practice = (typeof PRACTICE_OPTIONS)[number];

--- a/frontend/src/shared/ui/WorkflowSlashCommandUI.test.tsx
+++ b/frontend/src/shared/ui/WorkflowSlashCommandUI.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { WorkflowSlashCommandUI } from "./WorkflowSlashCommandUI";
+
+describe("WorkflowSlashCommandUI", () => {
+    it("shows the title-derived command and activation caption", () => {
+        render(<WorkflowSlashCommandUI title="Contract & Intake 2026!" />);
+
+        const command = screen.getByText("/contract-intake-2026");
+        expect(command).toBeInTheDocument();
+        expect(command).toHaveClass("text-gray-700");
+        expect(command).not.toHaveClass("font-mono", "font-medium");
+        expect(command.parentElement).toHaveTextContent(
+            "Type /contract-intake-2026 in chat to activate this workflow.",
+        );
+    });
+
+    it("reserves empty caption space when the title is empty", () => {
+        const { container } = render(<WorkflowSlashCommandUI title="" />);
+
+        const caption = container.querySelector("p");
+        expect(caption).toHaveClass("min-h-5", "text-xs", "text-gray-500");
+        expect(caption).toHaveTextContent("");
+        expect(screen.queryByText(/activate this workflow/)).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/shared/ui/WorkflowSlashCommandUI.tsx
+++ b/frontend/src/shared/ui/WorkflowSlashCommandUI.tsx
@@ -1,0 +1,30 @@
+export function workflowSlashCommandFromTitle(title: string): string | null {
+    const titleSlug = title
+        .trim()
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}\s-]/gu, "")
+        .trim()
+        .replace(/[\s-]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+    return titleSlug ? `/${titleSlug}` : null;
+}
+
+export function WorkflowSlashCommandUI({ title }: { title: string }) {
+    const command = workflowSlashCommandFromTitle(title);
+
+    return (
+        <p className="mt-2 min-h-5 text-xs leading-5 text-gray-500">
+            {command ? (
+                <>
+                    Type{" "}
+                    <span className="text-gray-700">
+                        {command}
+                    </span>{" "}
+                    in chat to activate this workflow.
+                </>
+            ) : (
+                <span aria-hidden="true">&nbsp;</span>
+            )}
+        </p>
+    );
+}

--- a/word-addin/e2e/workflows.spec.ts
+++ b/word-addin/e2e/workflows.spec.ts
@@ -281,7 +281,38 @@ test("opens and saves editable workflow metadata from the header", async ({
     },
   };
   await openWorkflows(addin, WORKFLOWS);
-  await addin.mockApiJson("PATCH", "**/workflows/wf-summary", updatedWorkflow);
+  const skillPatchControl = {
+    releaseResponse: (): void => undefined,
+    markSeen: (): void => undefined,
+  };
+  const allowSkillPatchResponse = new Promise<void>((resolve) => {
+    skillPatchControl.releaseResponse = resolve;
+  });
+  const skillPatchSeen = new Promise<void>((resolve) => {
+    skillPatchControl.markSeen = resolve;
+  });
+  await page.route("**/workflows/wf-summary", async (route, request) => {
+    if (request.method() !== "PATCH") return route.fallback();
+    const body = request.postDataJSON() as {
+      metadata?: unknown;
+      skill_md?: string;
+    };
+    if (!body.metadata) {
+      skillPatchControl.markSeen();
+      await allowSkillPatchResponse;
+    }
+    const response = body.metadata
+      ? updatedWorkflow
+      : {
+          ...WORKFLOWS[0],
+          skill_md: body.skill_md ?? WORKFLOWS[0]!.skill_md,
+        };
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(response),
+    });
+  });
 
   await page
     .getByRole("button", { name: /Summarize document.*Litigation/ })
@@ -300,6 +331,24 @@ test("opens and saves editable workflow metadata from the header", async ({
   await expect(modal.getByLabel("Jurisdiction")).toContainText("Singapore");
 
   await modal.getByLabel("Title").fill("Updated summary workflow");
+  await skillPatchSeen;
+  const backgroundSaveResponse = page.waitForResponse((response) => {
+    if (
+      response.request().method() !== "PATCH" ||
+      !new URL(response.url()).pathname.endsWith("/workflows/wf-summary")
+    ) {
+      return false;
+    }
+    const body = response.request().postDataJSON() as {
+      skill_md?: unknown;
+    } | null;
+    return !!body?.skill_md;
+  });
+  skillPatchControl.releaseResponse();
+  await backgroundSaveResponse;
+  await expect(modal.getByLabel("Title")).toHaveValue(
+    "Updated summary workflow",
+  );
   await modal.getByLabel("Language").click();
   await page.getByRole("menuitem", { name: "French", exact: true }).click();
   await modal.getByLabel("Practice area").click();

--- a/word-addin/e2e/workflows.spec.ts
+++ b/word-addin/e2e/workflows.spec.ts
@@ -130,17 +130,18 @@ test("shows a full-pane workflow list and opens skill details", async ({
   await expect(
     header.getByRole("button", { name: "Use", exact: true }).locator("svg"),
   ).toHaveCount(1);
-  const detailsButton = header.getByRole("button", {
-    name: "Workflow details",
+  const actionsButton = header.getByRole("button", {
+    name: "Workflow actions",
   });
-  await expect(detailsButton).toBeVisible();
-  const detailsBounds = await detailsButton.boundingBox();
+  await expect(actionsButton).toBeVisible();
+  await expect(actionsButton.locator("svg")).toHaveCount(1);
+  const actionsBounds = await actionsButton.boundingBox();
   const useBounds = await header
     .getByRole("button", { name: "Use", exact: true })
     .boundingBox();
-  expect(detailsBounds).not.toBeNull();
+  expect(actionsBounds).not.toBeNull();
   expect(useBounds).not.toBeNull();
-  expect(detailsBounds!.x).toBeLessThan(useBounds!.x);
+  expect(actionsBounds!.x).toBeLessThan(useBounds!.x);
   await expect(page.getByTestId("workflow-skill-content")).toContainText(
     "Summarize the document.",
   );
@@ -285,7 +286,8 @@ test("opens and saves editable workflow metadata from the header", async ({
   await page
     .getByRole("button", { name: /Summarize document.*Litigation/ })
     .click();
-  await page.getByRole("button", { name: "Workflow details" }).click();
+  await page.getByRole("button", { name: "Workflow actions" }).click();
+  await page.getByRole("menuitem", { name: "Edit details" }).click();
 
   const modal = page.getByRole("dialog", { name: "View and Edit details" });
   await expect(modal).toBeVisible();
@@ -315,7 +317,7 @@ test("opens and saves editable workflow metadata from the header", async ({
     const body = request.postDataJSON() as { metadata?: unknown } | null;
     return !!body?.metadata;
   });
-  await modal.getByRole("button", { name: "Save changes" }).click();
+  await modal.getByRole("button", { name: "Save", exact: true }).click();
   const body = (await requestPromise).postDataJSON();
   expect(body).toEqual({
     metadata: {

--- a/word-addin/src/shared/chat/ChatInput.tsx
+++ b/word-addin/src/shared/chat/ChatInput.tsx
@@ -20,6 +20,12 @@ interface ChatInputProps {
     /** Workflow and document pills rendered inside the glass composer. */
     attachments?: React.ReactNode;
     className?: string;
+    onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement>;
+    combobox?: {
+        controls?: string;
+        expanded: boolean;
+        activeDescendant?: string;
+    };
 }
 
 /**
@@ -42,6 +48,8 @@ export function ChatInput({
     rightSlot,
     attachments,
     className,
+    onKeyDown,
+    combobox,
 }: ChatInputProps) {
     const textareaRef = React.useRef<HTMLTextAreaElement>(null);
     const inputAreaRef = React.useRef<HTMLDivElement>(null);
@@ -91,6 +99,8 @@ export function ChatInput({
     const handleKeyDown = (
         e: React.KeyboardEvent<HTMLTextAreaElement>,
     ): void => {
+        onKeyDown?.(e);
+        if (e.defaultPrevented) return;
         if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault();
             if (value.trim() && !isLoading && !disabled) onSubmit();
@@ -119,6 +129,11 @@ export function ChatInput({
                     value={value}
                     onChange={(e) => onValueChange(e.target.value)}
                     onKeyDown={handleKeyDown}
+                    role={combobox ? "combobox" : undefined}
+                    aria-autocomplete={combobox ? "list" : undefined}
+                    aria-controls={combobox?.controls}
+                    aria-expanded={combobox?.expanded}
+                    aria-activedescendant={combobox?.activeDescendant}
                     placeholder={placeholder}
                     disabled={disabled}
                     className="w-full resize-none overflow-hidden border-0 bg-transparent p-0 text-sm leading-6 text-gray-900 outline-none placeholder:text-gray-400 disabled:opacity-60"

--- a/word-addin/src/taskpane/App.tsx
+++ b/word-addin/src/taskpane/App.tsx
@@ -56,7 +56,10 @@ export default function App(): React.ReactElement {
   const [workflowPageSelection, setWorkflowPageSelection] =
     useState<Workflow | null>(null);
   const [workflowDetailsOpen, setWorkflowDetailsOpen] = useState(false);
+  const [workflowDeleteConfirmOpen, setWorkflowDeleteConfirmOpen] =
+    useState(false);
   const [newWorkflowOpen, setNewWorkflowOpen] = useState(false);
+  const [workflowListRevision, setWorkflowListRevision] = useState(0);
   const [newQuickActionOpen, setNewQuickActionOpen] = useState(false);
   const [chatWorkflow, setChatWorkflow] = useState<{
     id: string;
@@ -114,6 +117,7 @@ export default function App(): React.ReactElement {
       case "workflows":
         return (
           <WorkflowPicker
+            key={workflowListRevision}
             selectedWorkflow={workflowPageSelection}
             onSelectedWorkflowChange={setWorkflowPageSelection}
           />
@@ -148,6 +152,7 @@ export default function App(): React.ReactElement {
     setSelectedSection("chat");
     setWorkflowPageSelection(null);
     setWorkflowDetailsOpen(false);
+    setWorkflowDeleteConfirmOpen(false);
     setChatWorkflow(null);
     setChatId(selectedChatId);
     setChatInSession(true);
@@ -161,6 +166,7 @@ export default function App(): React.ReactElement {
     if (section !== "workflows") {
       setWorkflowPageSelection(null);
       setWorkflowDetailsOpen(false);
+      setWorkflowDeleteConfirmOpen(false);
     }
   };
 
@@ -168,6 +174,7 @@ export default function App(): React.ReactElement {
     setSelectedSection("chat");
     setWorkflowPageSelection(null);
     setWorkflowDetailsOpen(false);
+    setWorkflowDeleteConfirmOpen(false);
     setChatWorkflow(null);
     setChatId(null);
     setChatInSession(false);
@@ -182,6 +189,7 @@ export default function App(): React.ReactElement {
       title: workflowPageSelection.metadata.title,
     });
     setWorkflowDetailsOpen(false);
+    setWorkflowDeleteConfirmOpen(false);
     setWorkflowPageSelection(null);
     setSelectedSection("chat");
   };
@@ -199,9 +207,16 @@ export default function App(): React.ReactElement {
         }
         onWorkflowBack={() => {
           setWorkflowDetailsOpen(false);
+          setWorkflowDeleteConfirmOpen(false);
           setWorkflowPageSelection(null);
         }}
         onOpenWorkflowDetails={() => setWorkflowDetailsOpen(true)}
+        onDeleteWorkflow={() => setWorkflowDeleteConfirmOpen(true)}
+        canDeleteWorkflow={
+          !!workflowPageSelection &&
+          !workflowPageSelection.is_system &&
+          workflowPageSelection.allow_edit !== false
+        }
         onUseWorkflow={useSelectedWorkflow}
         onNewWorkflow={() => setNewWorkflowOpen(true)}
         onNewQuickAction={() => setNewQuickActionOpen(true)}
@@ -251,6 +266,17 @@ export default function App(): React.ReactElement {
         workflow={workflowPageSelection}
         onClose={() => setWorkflowDetailsOpen(false)}
         onUpdated={setWorkflowPageSelection}
+        deleteConfirmOpen={workflowDeleteConfirmOpen}
+        onDeleteConfirmOpenChange={setWorkflowDeleteConfirmOpen}
+        onDeleted={(workflowId) => {
+          setWorkflowDetailsOpen(false);
+          setWorkflowDeleteConfirmOpen(false);
+          setWorkflowPageSelection(null);
+          setWorkflowListRevision((current) => current + 1);
+          setChatWorkflow((current) =>
+            current?.id === workflowId ? null : current
+          );
+        }}
       />
       <NewWorkflowModal
         open={newWorkflowOpen}

--- a/word-addin/src/taskpane/api/client.ts
+++ b/word-addin/src/taskpane/api/client.ts
@@ -521,3 +521,9 @@ export async function updateWorkflow(
     body: JSON.stringify(payload),
   });
 }
+
+export async function deleteWorkflow(workflowId: string): Promise<void> {
+  await apiRequest(`/workflows/${workflowId}`, {
+    method: "DELETE",
+  });
+}

--- a/word-addin/src/taskpane/api/mikeApi.ts
+++ b/word-addin/src/taskpane/api/mikeApi.ts
@@ -52,6 +52,7 @@ configureMikeApiClient({
 export {
   createQuickAction,
   createWorkflow,
+  deleteWorkflow,
   deleteWorkflowReferenceFile,
   getApiKeyStatus,
   getLibrary,

--- a/word-addin/src/taskpane/components/assistant/ChatInput.tsx
+++ b/word-addin/src/taskpane/components/assistant/ChatInput.tsx
@@ -11,11 +11,12 @@ import { ChatInput as ChatInputShell } from "../../../shared/chat/ChatInput";
 import {
   getApiKeyStatus,
   getUserProfile,
+  listWorkflows,
   uploadStandaloneDocument,
   type ApiKeyStatus,
 } from "../../api/mikeApi";
 import { useSelectedModel } from "../../hooks/useSelectedModel";
-import type { Document } from "../../types";
+import type { Document, Workflow } from "../../types";
 import {
   partitionSupportedDocumentFiles,
   SUPPORTED_DOCUMENT_ACCEPT,
@@ -33,6 +34,11 @@ import type {
 } from "../../lib/wordChatTypes";
 import { isModelAvailable, missingModelProvider } from "../../lib/modelCatalog";
 import { loadWithRetry } from "../../lib/composerPreflight";
+import { workflowSlashCommandFromTitle } from "@mike/workflow-slash-command-ui";
+import {
+  WORD_WORKFLOW_SLASH_MENU_ID,
+  WorkflowSlashMenu,
+} from "./WorkflowSlashMenu";
 
 export interface ChatInputHandle {
   setDraft: (prompt: string) => void;
@@ -90,11 +96,36 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     const [vercelModels, setVercelModels] = useState<string[]>([]);
     const [openCodeGoModels, setOpenCodeGoModels] = useState<string[]>([]);
     const [modelError, setModelError] = useState<string | null>(null);
+    const [slashWorkflows, setSlashWorkflows] = useState<Workflow[] | null>(
+      null,
+    );
+    const [activeSlashIndex, setActiveSlashIndex] = useState(0);
+    const [slashMenuDismissed, setSlashMenuDismissed] = useState(false);
     const localFileInputRef = useRef<HTMLInputElement>(null);
     const composerRef = useRef<HTMLDivElement>(null);
     const [compactControls, setCompactControls] = useState(false);
     const mountedRef = useRef(true);
     const uploadGenerationRef = useRef(0);
+
+    const slashQuery = (() => {
+      const trimmed = input.trim();
+      return /^\/\S*$/.test(trimmed) ? trimmed.toLowerCase() : null;
+    })();
+    const matchingSlashWorkflows = (slashWorkflows ?? []).filter((workflow) =>
+      workflowSlashCommandFromTitle(workflow.metadata.title)?.startsWith(
+        slashQuery ?? "",
+      ),
+    );
+    const slashCommandsLoading = slashQuery !== null && slashWorkflows === null;
+    const slashMenuOpen =
+      !slashMenuDismissed &&
+      !selectedWorkflow &&
+      slashQuery !== null &&
+      matchingSlashWorkflows.length > 0;
+    const resolvedSlashIndex = Math.min(
+      activeSlashIndex,
+      Math.max(0, matchingSlashWorkflows.length - 1),
+    );
 
     useImperativeHandle(
       ref,
@@ -112,6 +143,21 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
         uploadGenerationRef.current += 1;
       };
     }, []);
+
+    useEffect(() => {
+      if (!slashCommandsLoading) return;
+      let cancelled = false;
+      void listWorkflows("assistant")
+        .then((workflows) => {
+          if (!cancelled) setSlashWorkflows(workflows);
+        })
+        .catch(() => {
+          if (!cancelled) setSlashWorkflows([]);
+        });
+      return () => {
+        cancelled = true;
+      };
+    }, [slashCommandsLoading]);
 
     useEffect(() => {
       const composer = composerRef.current;
@@ -219,8 +265,28 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       setUploadingLocalFiles(false);
     };
 
+    const selectSlashWorkflow = (workflow: Workflow): void => {
+      if (!workflowSlashCommandFromTitle(workflow.metadata.title)) return;
+      onSelectedWorkflowChange({
+        id: workflow.id,
+        title: workflow.metadata.title,
+      });
+      setInput("");
+      setSlashMenuDismissed(true);
+    };
+
     const submit = (): void => {
       const content = input.trim();
+      if (slashCommandsLoading) return;
+      const exactSlashWorkflow = (slashWorkflows ?? []).find(
+        (workflow) =>
+          workflowSlashCommandFromTitle(workflow.metadata.title) ===
+          content.toLowerCase(),
+      );
+      if (exactSlashWorkflow) {
+        selectSlashWorkflow(exactSlashWorkflow);
+        return;
+      }
       if (!content || isResponseLoading) return;
       if (!isModelAvailable(model, keyStatus)) {
         setModelError(
@@ -289,11 +355,65 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
               </button>
             </div>
           )}
-          <div ref={composerRef}>
+          <div ref={composerRef} className="relative">
+            {slashMenuOpen && (
+              <WorkflowSlashMenu
+                workflows={matchingSlashWorkflows}
+                activeIndex={resolvedSlashIndex}
+                onSelect={selectSlashWorkflow}
+              />
+            )}
             <ChatInputShell
               value={input}
-              onValueChange={setInput}
+              onValueChange={(value) => {
+                setInput(value);
+                setActiveSlashIndex(0);
+                setSlashMenuDismissed(false);
+              }}
               onSubmit={submit}
+              onKeyDown={(event) => {
+                if (slashMenuOpen && matchingSlashWorkflows.length > 0) {
+                  if (event.key === "ArrowDown") {
+                    event.preventDefault();
+                    setActiveSlashIndex(
+                      (resolvedSlashIndex + 1) %
+                        matchingSlashWorkflows.length,
+                    );
+                    return;
+                  }
+                  if (event.key === "ArrowUp") {
+                    event.preventDefault();
+                    setActiveSlashIndex(
+                      (resolvedSlashIndex -
+                        1 +
+                        matchingSlashWorkflows.length) %
+                        matchingSlashWorkflows.length,
+                    );
+                    return;
+                  }
+                  if (event.key === "Enter" && !event.shiftKey) {
+                    event.preventDefault();
+                    const workflow =
+                      matchingSlashWorkflows[resolvedSlashIndex];
+                    if (workflow) selectSlashWorkflow(workflow);
+                    return;
+                  }
+                }
+                if (slashMenuOpen && event.key === "Escape") {
+                  event.preventDefault();
+                  setSlashMenuDismissed(true);
+                }
+              }}
+              combobox={{
+                controls: slashMenuOpen
+                  ? WORD_WORKFLOW_SLASH_MENU_ID
+                  : undefined,
+                expanded: slashMenuOpen,
+                activeDescendant:
+                  slashMenuOpen && matchingSlashWorkflows.length > 0
+                    ? `${WORD_WORKFLOW_SLASH_MENU_ID}-${resolvedSlashIndex}`
+                    : undefined,
+              }}
               isLoading={isResponseLoading}
               onCancel={onCancel}
               disabled={false}

--- a/word-addin/src/taskpane/components/assistant/WorkflowSlashMenu.tsx
+++ b/word-addin/src/taskpane/components/assistant/WorkflowSlashMenu.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useRef } from "react";
+import type { Workflow } from "../../types";
+import { workflowSlashCommandFromTitle } from "@mike/workflow-slash-command-ui";
+
+export const WORD_WORKFLOW_SLASH_MENU_ID = "word-workflow-slash-menu";
+
+export function WorkflowSlashMenu({
+  workflows,
+  activeIndex,
+  onSelect,
+}: {
+  workflows: Workflow[];
+  activeIndex: number;
+  onSelect: (workflow: Workflow) => void;
+}): React.ReactElement | null {
+  const activeOptionRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    activeOptionRef.current?.scrollIntoView?.({ block: "nearest" });
+  }, [activeIndex]);
+
+  if (workflows.length === 0) return null;
+
+  return (
+    <div
+      id={WORD_WORKFLOW_SLASH_MENU_ID}
+      role="listbox"
+      aria-label="Workflow commands"
+      className="liquid-glass-translucent absolute bottom-full left-0 z-10 mb-1.5 grid max-h-56 w-full gap-1 overflow-y-auto rounded-[18px] p-1 overscroll-contain"
+    >
+      {workflows.map((workflow, index) => {
+        const command = workflowSlashCommandFromTitle(workflow.metadata.title);
+        if (!command) return null;
+        const active = index === activeIndex;
+        return (
+          <button
+            ref={active ? activeOptionRef : undefined}
+            key={workflow.id}
+            id={`${WORD_WORKFLOW_SLASH_MENU_ID}-${index}`}
+            type="button"
+            role="option"
+            aria-label={`${command} ${workflow.metadata.title}`}
+            aria-selected={active}
+            onClick={() => onSelect(workflow)}
+            className={`theme-dropdown-item flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm transition-colors ${
+              active
+                ? "theme-dropdown-selected text-gray-900"
+                : "text-gray-700"
+            }`}
+          >
+            <span className="font-medium text-gray-900">{command}</span>
+            <span className="truncate text-gray-500">
+              {workflow.metadata.title}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/word-addin/src/taskpane/components/primitives/ModalForm.tsx
+++ b/word-addin/src/taskpane/components/primitives/ModalForm.tsx
@@ -118,9 +118,10 @@ export function ModalSelect({
         {normalizedOptions.map((option) => (
           <DropdownItem
             key={option.value}
+            textValue={option.label}
             selected={option.value === value}
             onSelect={() => onChange(option.value)}
-            className="text-sm"
+            className="text-xs"
           >
             <span className="truncate">{option.label}</span>
           </DropdownItem>

--- a/word-addin/src/taskpane/components/shell/FloatingHeader.tsx
+++ b/word-addin/src/taskpane/components/shell/FloatingHeader.tsx
@@ -1,6 +1,15 @@
 import React, { useState } from "react";
 import type { Message } from "../../types";
-import { Check, ChevronLeft, Ellipsis, Menu, Plus, X } from "lucide-react";
+import {
+  Check,
+  ChevronLeft,
+  Ellipsis,
+  Menu,
+  Pencil,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react";
 import {
   LiquidActionRow,
   LiquidIconButton,
@@ -42,6 +51,8 @@ interface FloatingHeaderProps {
   workflowDetailOpen?: boolean;
   onWorkflowBack?: () => void;
   onOpenWorkflowDetails?: () => void;
+  onDeleteWorkflow?: () => void;
+  canDeleteWorkflow?: boolean;
   onUseWorkflow?: () => void;
   onNewWorkflow?: () => void;
   onNewQuickAction?: () => void;
@@ -76,6 +87,8 @@ export function FloatingHeader({
   workflowDetailOpen = false,
   onWorkflowBack,
   onOpenWorkflowDetails,
+  onDeleteWorkflow,
+  canDeleteWorkflow = false,
   onUseWorkflow,
   onNewWorkflow,
   onNewQuickAction,
@@ -85,6 +98,7 @@ export function FloatingHeader({
   wordChatOwnerId,
 }: FloatingHeaderProps): React.ReactElement {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [workflowActionsOpen, setWorkflowActionsOpen] = useState(false);
 
   return (
     <header
@@ -197,14 +211,34 @@ export function FloatingHeader({
         </HeaderButtonsUI>
       ) : workflowDetailOpen ? (
         <HeaderButtonsUI className="pointer-events-auto relative z-10">
-          <HeaderButtonUI
-            iconOnly
-            onClick={onOpenWorkflowDetails}
-            aria-label="Workflow details"
-            title="Workflow details"
+          <Dropdown
+            open={workflowActionsOpen}
+            onOpenChange={setWorkflowActionsOpen}
           >
-            <Ellipsis className="h-4 w-4" />
-          </HeaderButtonUI>
+            <DropdownTrigger asChild>
+              <HeaderButtonUI
+                iconOnly
+                aria-label="Workflow actions"
+                title="Workflow actions"
+              >
+                <Ellipsis className="h-4 w-4" />
+              </HeaderButtonUI>
+            </DropdownTrigger>
+            <DropdownContent align="end" sideOffset={8} className="min-w-40">
+              <DropdownItem onSelect={() => onOpenWorkflowDetails?.()}>
+                <Pencil className="h-3.5 w-3.5" />
+                <span>Edit details</span>
+              </DropdownItem>
+              <DropdownItem
+                disabled={!canDeleteWorkflow}
+                onSelect={() => onDeleteWorkflow?.()}
+                className="text-red-600"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                <span>Delete</span>
+              </DropdownItem>
+            </DropdownContent>
+          </Dropdown>
           <LiquidTextButton onClick={onUseWorkflow}>
             <Check className="h-3.5 w-3.5" />
             Use

--- a/word-addin/src/taskpane/components/workflows/NewWorkflowModal.tsx
+++ b/word-addin/src/taskpane/components/workflows/NewWorkflowModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Upload } from "lucide-react";
+import { WorkflowSlashCommandUI } from "@mike/workflow-slash-command-ui";
 import type { Workflow } from "../../types";
 import { createWorkflow } from "../../api/mikeApi";
 import { Modal } from "../primitives/Modal";
@@ -236,6 +237,7 @@ export function NewWorkflowModal({
               variant="minimal"
               autoFocus
             />
+            <WorkflowSlashCommandUI title={title} />
           </div>
 
           <div>

--- a/word-addin/src/taskpane/components/workflows/WorkflowDetailsModal.tsx
+++ b/word-addin/src/taskpane/components/workflows/WorkflowDetailsModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
+import { WorkflowSlashCommandUI } from "@mike/workflow-slash-command-ui";
 import type { Workflow } from "../../types";
-import { updateWorkflow } from "../../api/mikeApi";
+import { deleteWorkflow, updateWorkflow } from "../../api/mikeApi";
 import { Modal } from "../primitives/Modal";
 import {
   ModalFieldLabel,
@@ -18,7 +19,7 @@ import {
 
 function valueOrOther(
   value: string,
-  options: readonly string[]
+  options: readonly string[],
 ): { selected: string; custom: string } {
   return options.includes(value)
     ? { selected: value, custom: "" }
@@ -30,6 +31,9 @@ interface WorkflowDetailsModalProps {
   workflow: Workflow | null;
   onClose: () => void;
   onUpdated: (workflow: Workflow) => void;
+  onDeleted: (workflowId: string) => void;
+  deleteConfirmOpen: boolean;
+  onDeleteConfirmOpenChange: (open: boolean) => void;
 }
 
 export function WorkflowDetailsModal({
@@ -37,6 +41,9 @@ export function WorkflowDetailsModal({
   workflow,
   onClose,
   onUpdated,
+  onDeleted,
+  deleteConfirmOpen,
+  onDeleteConfirmOpenChange,
 }: WorkflowDetailsModalProps): React.ReactElement | null {
   const [title, setTitle] = useState("");
   const [language, setLanguage] = useState(DEFAULT_WORKFLOW_LANGUAGE);
@@ -44,11 +51,13 @@ export function WorkflowDetailsModal({
   const [practice, setPractice] = useState(DEFAULT_WORKFLOW_PRACTICE);
   const [customPractice, setCustomPractice] = useState("");
   const [jurisdiction, setJurisdiction] = useState(
-    DEFAULT_WORKFLOW_JURISDICTION
+    DEFAULT_WORKFLOW_JURISDICTION,
   );
   const [customJurisdiction, setCustomJurisdiction] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open || !workflow) return;
@@ -56,14 +65,14 @@ export function WorkflowDetailsModal({
 
     const nextLanguage = valueOrOther(
       workflow.metadata.language || DEFAULT_WORKFLOW_LANGUAGE,
-      WORKFLOW_LANGUAGE_OPTIONS
+      WORKFLOW_LANGUAGE_OPTIONS,
     );
     setLanguage(nextLanguage.selected);
     setCustomLanguage(nextLanguage.custom);
 
     const nextPractice = valueOrOther(
       workflow.metadata.practice || DEFAULT_WORKFLOW_PRACTICE,
-      WORKFLOW_PRACTICE_OPTIONS
+      WORKFLOW_PRACTICE_OPTIONS,
     );
     setPractice(nextPractice.selected);
     setCustomPractice(nextPractice.custom);
@@ -73,31 +82,48 @@ export function WorkflowDetailsModal({
       : DEFAULT_WORKFLOW_JURISDICTION;
     const nextJurisdiction = valueOrOther(
       savedJurisdiction,
-      WORKFLOW_JURISDICTION_OPTIONS
+      WORKFLOW_JURISDICTION_OPTIONS,
     );
     setJurisdiction(nextJurisdiction.selected);
     setCustomJurisdiction(nextJurisdiction.custom);
     setError(null);
+    setDeleting(false);
+    setDeleteError(null);
   }, [open, workflow]);
+
+  useEffect(() => {
+    if (deleteConfirmOpen) setDeleteError(null);
+  }, [deleteConfirmOpen]);
 
   if (!workflow) return null;
 
   const readOnly = workflow.is_system || workflow.allow_edit === false;
+  const effectiveLanguage =
+    language === "Other" ? customLanguage.trim() : language;
+  const effectivePractice =
+    practice === "Other" ? customPractice.trim() : practice;
+  const effectiveJurisdiction =
+    jurisdiction === "Other" ? customJurisdiction : jurisdiction;
+  const jurisdictions = effectiveJurisdiction
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const initialLanguage =
+    workflow.metadata.language || DEFAULT_WORKFLOW_LANGUAGE;
+  const initialPractice =
+    workflow.metadata.practice || DEFAULT_WORKFLOW_PRACTICE;
+  const initialJurisdictions = workflow.metadata.jurisdictions ?? [];
+  const hasChanges =
+    title.trim() !== workflow.metadata.title.trim() ||
+    effectiveLanguage !== initialLanguage ||
+    effectivePractice !== initialPractice ||
+    JSON.stringify(jurisdictions) !== JSON.stringify(initialJurisdictions);
+
   const handleSave = async (): Promise<void> => {
-    if (readOnly || !title.trim() || saving) return;
+    if (readOnly || !title.trim() || saving || !hasChanges) return;
     setSaving(true);
     setError(null);
     try {
-      const effectiveLanguage =
-        language === "Other" ? customLanguage.trim() : language;
-      const effectivePractice =
-        practice === "Other" ? customPractice.trim() : practice;
-      const effectiveJurisdiction =
-        jurisdiction === "Other" ? customJurisdiction : jurisdiction;
-      const jurisdictions = effectiveJurisdiction
-        .split(",")
-        .map((value) => value.trim())
-        .filter(Boolean);
       const updated = await updateWorkflow(workflow.id, {
         metadata: {
           title: title.trim(),
@@ -114,127 +140,181 @@ export function WorkflowDetailsModal({
       onClose();
     } catch (reason) {
       setError(
-        reason instanceof Error ? reason.message : "Failed to update workflow"
+        reason instanceof Error ? reason.message : "Failed to update workflow",
       );
     } finally {
       setSaving(false);
     }
   };
 
+  const handleDelete = async (): Promise<void> => {
+    if (readOnly || deleting) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await deleteWorkflow(workflow.id);
+      onDeleted(workflow.id);
+      onDeleteConfirmOpenChange(false);
+      onClose();
+    } catch (reason) {
+      setDeleteError(
+        reason instanceof Error ? reason.message : "Failed to delete workflow",
+      );
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   return (
-    <Modal
-      open={open}
-      onClose={onClose}
-      parentLabel="Workflows"
-      title="View and Edit details"
-      primaryAction={
-        readOnly
-          ? undefined
-          : {
-              label: saving ? "Saving…" : "Save changes",
-              onClick: () => void handleSave(),
-              disabled: !title.trim() || saving,
-            }
-      }
-    >
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-5">
-        <div className="space-y-6">
-          <div>
-            <ModalFieldLabel htmlFor="workflow-details-title">
-              Title
-            </ModalFieldLabel>
-            <ModalTextInput
-              id="workflow-details-title"
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              placeholder="Add workflow name"
-              variant="minimal"
-              disabled={readOnly}
-            />
-          </div>
-
-          <div>
-            <ModalFieldLabel htmlFor="workflow-details-language">
-              Language
-            </ModalFieldLabel>
-            <ModalSelect
-              id="workflow-details-language"
-              value={language}
-              options={WORKFLOW_LANGUAGE_OPTIONS}
-              disabled={readOnly}
-              onChange={(value) => {
-                setLanguage(value);
-                if (value !== "Other") setCustomLanguage("");
-              }}
-            />
-            {language === "Other" && (
+    <>
+      <Modal
+        open={open}
+        onClose={onClose}
+        parentLabel="Workflows"
+        title="View and Edit details"
+        primaryAction={
+          readOnly
+            ? undefined
+            : {
+                label: saving ? "Saving…" : "Save",
+                onClick: () => void handleSave(),
+                disabled: !title.trim() || saving || !hasChanges,
+              }
+        }
+      >
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-5">
+          <div className="space-y-6">
+            <div>
+              <ModalFieldLabel htmlFor="workflow-details-title">
+                Title
+              </ModalFieldLabel>
               <ModalTextInput
-                value={customLanguage}
-                onChange={(event) => setCustomLanguage(event.target.value)}
-                placeholder="Enter language…"
+                id="workflow-details-title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="Add workflow name"
+                variant="minimal"
                 disabled={readOnly}
-                className="mt-2"
               />
+              <WorkflowSlashCommandUI title={title} />
+            </div>
+
+            <div>
+              <ModalFieldLabel htmlFor="workflow-details-language">
+                Language
+              </ModalFieldLabel>
+              <ModalSelect
+                id="workflow-details-language"
+                value={language}
+                options={WORKFLOW_LANGUAGE_OPTIONS}
+                disabled={readOnly}
+                onChange={(value) => {
+                  setLanguage(value);
+                  if (value !== "Other") setCustomLanguage("");
+                }}
+              />
+              {language === "Other" && (
+                <ModalTextInput
+                  value={customLanguage}
+                  onChange={(event) => setCustomLanguage(event.target.value)}
+                  placeholder="Enter language…"
+                  disabled={readOnly}
+                  className="mt-2"
+                />
+              )}
+            </div>
+
+            <div>
+              <ModalFieldLabel htmlFor="workflow-details-practice">
+                Practice area
+              </ModalFieldLabel>
+              <ModalSelect
+                id="workflow-details-practice"
+                value={practice}
+                options={WORKFLOW_PRACTICE_OPTIONS}
+                disabled={readOnly}
+                onChange={(value) => {
+                  setPractice(value);
+                  if (value !== "Other") setCustomPractice("");
+                }}
+              />
+              {practice === "Other" && (
+                <ModalTextInput
+                  value={customPractice}
+                  onChange={(event) => setCustomPractice(event.target.value)}
+                  placeholder="Enter practice area…"
+                  disabled={readOnly}
+                  className="mt-2"
+                />
+              )}
+            </div>
+
+            <div>
+              <ModalFieldLabel htmlFor="workflow-details-jurisdiction">
+                Jurisdiction
+              </ModalFieldLabel>
+              <ModalSelect
+                id="workflow-details-jurisdiction"
+                value={jurisdiction}
+                options={WORKFLOW_JURISDICTION_OPTIONS}
+                disabled={readOnly}
+                onChange={(value) => {
+                  setJurisdiction(value);
+                  if (value !== "Other") setCustomJurisdiction("");
+                }}
+              />
+              {jurisdiction === "Other" && (
+                <ModalTextInput
+                  value={customJurisdiction}
+                  onChange={(event) =>
+                    setCustomJurisdiction(event.target.value)
+                  }
+                  placeholder="Enter jurisdiction…"
+                  disabled={readOnly}
+                  className="mt-2"
+                />
+              )}
+            </div>
+
+            {error && (
+              <p role="alert" className="text-sm text-red-500">
+                {error}
+              </p>
             )}
           </div>
+        </div>
+      </Modal>
 
-          <div>
-            <ModalFieldLabel htmlFor="workflow-details-practice">
-              Practice area
-            </ModalFieldLabel>
-            <ModalSelect
-              id="workflow-details-practice"
-              value={practice}
-              options={WORKFLOW_PRACTICE_OPTIONS}
-              disabled={readOnly}
-              onChange={(value) => {
-                setPractice(value);
-                if (value !== "Other") setCustomPractice("");
-              }}
-            />
-            {practice === "Other" && (
-              <ModalTextInput
-                value={customPractice}
-                onChange={(event) => setCustomPractice(event.target.value)}
-                placeholder="Enter practice area…"
-                disabled={readOnly}
-                className="mt-2"
-              />
-            )}
-          </div>
-
-          <div>
-            <ModalFieldLabel htmlFor="workflow-details-jurisdiction">
-              Jurisdiction
-            </ModalFieldLabel>
-            <ModalSelect
-              id="workflow-details-jurisdiction"
-              value={jurisdiction}
-              options={WORKFLOW_JURISDICTION_OPTIONS}
-              disabled={readOnly}
-              onChange={(value) => {
-                setJurisdiction(value);
-                if (value !== "Other") setCustomJurisdiction("");
-              }}
-            />
-            {jurisdiction === "Other" && (
-              <ModalTextInput
-                value={customJurisdiction}
-                onChange={(event) => setCustomJurisdiction(event.target.value)}
-                placeholder="Enter jurisdiction…"
-                disabled={readOnly}
-                className="mt-2"
-              />
-            )}
-          </div>
-
-          {error && (
-            <p role="alert" className="text-sm text-red-500">
-              {error}
+      <Modal
+        open={deleteConfirmOpen}
+        onClose={() => !deleting && onDeleteConfirmOpenChange(false)}
+        parentLabel="Workflows"
+        title="Delete workflow?"
+        primaryAction={{
+          label: deleting ? "Deleting…" : "Delete",
+          tone: "danger",
+          disabled: deleting,
+          onClick: () => void handleDelete(),
+        }}
+        secondaryAction={{
+          label: "Cancel",
+          disabled: deleting,
+          onClick: () => onDeleteConfirmOpenChange(false),
+        }}
+      >
+        <div className="pb-5 text-sm leading-6 text-gray-600">
+          <p>
+            {workflow.is_default
+              ? "Deleting this default workflow also permanently deletes its corresponding Quick Action. It will not be recreated automatically."
+              : "This workflow will be permanently deleted."}
+          </p>
+          {deleteError && (
+            <p role="alert" className="mt-3 text-red-500">
+              {deleteError}
             </p>
           )}
         </div>
-      </div>
-    </Modal>
+      </Modal>
+    </>
   );
 }

--- a/word-addin/src/taskpane/components/workflows/WorkflowDetailsModal.tsx
+++ b/word-addin/src/taskpane/components/workflows/WorkflowDetailsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { WorkflowSlashCommandUI } from "@mike/workflow-slash-command-ui";
 import type { Workflow } from "../../types";
 import { deleteWorkflow, updateWorkflow } from "../../api/mikeApi";
@@ -58,9 +58,15 @@ export function WorkflowDetailsModal({
   const [error, setError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const initializedWorkflowIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!open || !workflow) return;
+    if (!open || !workflow) {
+      initializedWorkflowIdRef.current = null;
+      return;
+    }
+    if (initializedWorkflowIdRef.current === workflow.id) return;
+    initializedWorkflowIdRef.current = workflow.id;
     setTitle(workflow.metadata.title);
 
     const nextLanguage = valueOrOther(

--- a/word-addin/src/taskpane/styles.css
+++ b/word-addin/src/taskpane/styles.css
@@ -22,6 +22,7 @@
 @source "../../../frontend/src/shared/ui/MikeIconUI.tsx";
 @source "../../../frontend/src/shared/ui/AuthStylesUI.ts";
 @source "../../../frontend/src/shared/ui/AuthDividerUI.tsx";
+@source "../../../frontend/src/shared/ui/WorkflowSlashCommandUI.tsx";
 @source "../../../frontend/src/shared/ui/LiquidGlassUI.ts";
 
 /* The web supplies these font variables via next/font; the add-in supplies

--- a/word-addin/tsconfig.json
+++ b/word-addin/tsconfig.json
@@ -71,6 +71,9 @@
       ],
       "@mike/auth-divider-ui": [
         "../frontend/src/shared/ui/AuthDividerUI.tsx"
+      ],
+      "@mike/workflow-slash-command-ui": [
+        "../frontend/src/shared/ui/WorkflowSlashCommandUI.tsx"
       ]
     },
     "jsx": "react-jsx",

--- a/word-addin/webpack.config.js
+++ b/word-addin/webpack.config.js
@@ -165,6 +165,9 @@ module.exports = async (_env, options) => {
         "@mike/google-icon-ui": frontendSharedUi("GoogleIconUI.tsx"),
         "@mike/auth-styles-ui": frontendSharedUi("AuthStylesUI.ts"),
         "@mike/auth-divider-ui": frontendSharedUi("AuthDividerUI.tsx"),
+        "@mike/workflow-slash-command-ui": frontendSharedUi(
+          "WorkflowSlashCommandUI.tsx",
+        ),
       },
     },
     module: {


### PR DESCRIPTION
## Summary
Separates the workflow and document-viewer UX improvements from the direct-upload session work.

## What changed
- Derive and surface workflow slash commands across the web app and Word add-in.
- Align workflow and project modal selectors, actions, save states, icons, loading states, and focus behavior.
- Stabilize PowerPoint and PDF preview rendering.
- Open tabular-review documents in a document-only side panel showing the filename and version.

## Why
Keeps the direct-upload branch focused and makes the UX changes independently reviewable.

## Testing
- 40 focused frontend tests across 11 files
- Frontend TypeScript check
- Word add-in typecheck
- Word add-in E2E production build
- Frontend ESLint (no errors; eight existing unused `node` warnings in `TRSidePanel.tsx`)
- `git diff --check`