### PR TITLE
fix(build): build frontend image from repo root so backend type imports resolve

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Keeps the repo-root build context small now that the frontend image builds
+# from the repo root (see frontend/Dockerfile) instead of ./frontend.
+**/node_modules
+word-addin
+.git
+**/.next
+**/dist
+**/*.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,7 +275,13 @@ services:
 
   frontend:
     build:
-      context: ./frontend
+      # LOCAL PATCH (not upstream): the frontend imports backend types via
+      # ../../../../../backend/src/lib/... (frontend/src/app/components/shared/types.ts).
+      # A ./frontend context cannot see backend/, so next build's tsc fails with
+      # "implicitly has an 'any' type". Build from the repo root instead and
+      # mirror the layout in the image. See frontend/Dockerfile.
+      context: .
+      dockerfile: frontend/Dockerfile
     environment:
       - API_BASE_URL=${API_BASE_URL:-http://backend:3001}
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,15 @@
 FROM node:22-slim
 
-WORKDIR /app
-COPY package*.json ./
+# LOCAL PATCH (not upstream): built from the REPO ROOT context, not ./frontend.
+# frontend/src/app/components/shared/types.ts imports backend types through
+# ../../../../../backend/src/lib/..., which only resolves when both packages sit
+# side by side. Keeping /app/frontend + /app/backend makes those paths real, so
+# next build type-checks instead of degrading the imports to `any`.
+WORKDIR /app/frontend
+COPY frontend/package*.json ./
 RUN npm ci
-COPY . .
+COPY frontend/ ./
+COPY backend/ /app/backend/
 
 RUN npm run build
 


### PR DESCRIPTION
## Summary

`docker-compose.yml` built the frontend image with `context: ./frontend`, but `frontend/src/app/components/shared/types.ts` imports backend types through a relative path reaching outside the frontend package (`../../../../../backend/src/lib/chat/types`). With a `./frontend` build context, `backend/` doesn't exist in the image, so the import silently degrades to `any` and `next build` fails on the first place that surfaces as an implicit `any`:

```
./src/app/components/assistant/AskInputPopup.tsx:93:31
Type error: Parameter 'item' implicitly has an 'any' type.
```

## Changes

- `docker-compose.yml` — frontend service now builds with `context: .` and `dockerfile: frontend/Dockerfile`, so both packages sit side by side in the build.
- `frontend/Dockerfile` — works from `/app/frontend`, copies `frontend/` and `backend/` into the image separately so the relative import resolves.
- `.dockerignore` (new, tracked) — building from the repo root would otherwise ship `node_modules`, `word-addin`, and `.git` into the build context (537 MB in practice); this keeps it to just what's needed.

An alternative — annotating the one call site with an explicit type — only silences that one symptom; every other backend-imported type in the frontend would stay `any`, which is a bad trade in a tool handling privileged documents.

## Testing

```
docker compose config -q          valid
docker compose up -d --build      frontend and backend build and start healthy
```
Verified end-to-end on a real local Docker Compose stack, not just config validation.

The investigation and code in this PR were done by Claude (Sonnet 5) via Claude Code; I reviewed and am submitting it.